### PR TITLE
Align amount column on payment structure page

### DIFF
--- a/app/pudding-debt/src/app/pages/payment-structure/payment-structure.component.html
+++ b/app/pudding-debt/src/app/pages/payment-structure/payment-structure.component.html
@@ -23,7 +23,7 @@
 					<!-- Amount Column -->
 					<ng-container matColumnDef="amount">
 						<th mat-header-cell *matHeaderCellDef>Amount</th>
-						<td mat-cell *matCellDef="let receiver">
+						<td mat-cell *matCellDef="let receiver" class="amount-cell">
 							{{ receiver.amount | currency : "" : "" : "1.2-2" : "no" }}
 							kr
 						</td></ng-container

--- a/app/pudding-debt/src/app/pages/payment-structure/payment-structure.component.scss
+++ b/app/pudding-debt/src/app/pages/payment-structure/payment-structure.component.scss
@@ -4,3 +4,7 @@
 	justify-content: center;
 	margin-top: 2em;
 }
+
+.amount-cell {
+	width: 50%;
+}


### PR DESCRIPTION
Fixes the payment structure page so that the amount column for all rows are aligned with each other.

Closes #98 