### PR TITLE
Use UUID as resource identifiers

### DIFF
--- a/app/mikane/src/app/pages/category/category.component.ts
+++ b/app/mikane/src/app/pages/category/category.component.ts
@@ -47,7 +47,7 @@ import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.servic
 	],
 })
 export class CategoryComponent implements OnInit, AfterViewChecked {
-	private eventId!: number;
+	private eventId!: string;
 
 	loading: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
@@ -109,7 +109,7 @@ export class CategoryComponent implements OnInit, AfterViewChecked {
 		});
 	}
 
-	filterUsers(categoryId: number) {
+	filterUsers(categoryId: string) {
 		const category = this.categories.find((category) => {
 			return category.id === categoryId;
 		});
@@ -149,7 +149,7 @@ export class CategoryComponent implements OnInit, AfterViewChecked {
 		});
 	}
 
-	addUser(categoryId: number) {
+	addUser(categoryId: string) {
 		if (this.addUserForm.value.participantName) {
 			this.categoryService.addUser(categoryId, this.addUserForm.value.participantName, this.addUserForm.value.weight ?? 1).subscribe({
 				next: (res) => {
@@ -172,7 +172,7 @@ export class CategoryComponent implements OnInit, AfterViewChecked {
 		}
 	}
 
-	removeUser(categoryId: number, userId: number) {
+	removeUser(categoryId: string, userId: string) {
 		this.categoryService.deleteUser(categoryId, userId).subscribe({
 			next: (res) => {
 				const index = this.categories.findIndex((category) => category.id === res.id);
@@ -189,7 +189,7 @@ export class CategoryComponent implements OnInit, AfterViewChecked {
 		});
 	}
 
-	openEditDialog(categoryId: number, userId: number) {
+	openEditDialog(categoryId: string, userId: string) {
 		const dialogRef = this.dialog.open(CategoryEditDialogComponent, {
 			width: '300px',
 			data: { categoryId, userId },
@@ -202,7 +202,7 @@ export class CategoryComponent implements OnInit, AfterViewChecked {
 		});
 	}
 
-	editCategory(categoryId: number, userId: number, weight: number) {
+	editCategory(categoryId: string, userId: string, weight: number) {
 		this.categoryService.editUser(categoryId, userId, weight).subscribe({
 			next: (res) => {
 				const catIndex = this.categories.findIndex((category) => {
@@ -225,7 +225,7 @@ export class CategoryComponent implements OnInit, AfterViewChecked {
 		});
 	}
 
-	toggleWeighted(categoryId: number, weighted: boolean) {
+	toggleWeighted(categoryId: string, weighted: boolean) {
 		this.categoryService.setWeighted(categoryId, !weighted).subscribe({
 			next: () => {
 				const category = this.categories.find((category) => {
@@ -242,7 +242,7 @@ export class CategoryComponent implements OnInit, AfterViewChecked {
 		});
 	}
 
-	deleteCategoryDialog(categoryId: number) {
+	deleteCategoryDialog(categoryId: string) {
 		const dialogRef = this.dialog.open(ConfirmDialogComponent, {
 			width: '350px',
 			data: {
@@ -259,7 +259,7 @@ export class CategoryComponent implements OnInit, AfterViewChecked {
 		});
 	}
 
-	deleteCategory(categoryId: number) {
+	deleteCategory(categoryId: string) {
 		this.categoryService.deleteCategory(categoryId).subscribe({
 			next: () => {
 				const index = this.categories.findIndex((category) => category.id === categoryId);

--- a/app/mikane/src/app/pages/events/event-dialog/event-dialog.component.ts
+++ b/app/mikane/src/app/pages/events/event-dialog/event-dialog.component.ts
@@ -14,7 +14,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 	imports: [MatDialogModule, MatFormFieldModule, MatInputModule, FormsModule, MatButtonModule],
 })
 export class EventDialogComponent {
-	event: { id?: number; name: string; description: string } = { name: '', description: '' };
+	event: { id?: string; name: string; description: string } = { name: '', description: '' };
 	edit: boolean;
 	currentName: string;
 	currentDescription: string;

--- a/app/mikane/src/app/pages/events/event/event.component.ts
+++ b/app/mikane/src/app/pages/events/event/event.component.ts
@@ -68,7 +68,7 @@ export class EventComponent implements OnInit {
 			.pipe(
 				map(([events, params]) => {
 					return events.find((event) => {
-						return event.id === +params['eventId'];
+						return event.id === params['eventId'];
 					});
 				})
 			)

--- a/app/mikane/src/app/pages/expenditures/expenditure-dialog/expenditure-dialog.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expenditure-dialog/expenditure-dialog.component.ts
@@ -44,8 +44,8 @@ export class ExpenditureDialogComponent implements OnInit {
 		public dialogRef: MatDialogRef<ExpenditureDialogComponent>,
 		@Inject(MAT_DIALOG_DATA)
 		public data: {
-			eventId: number;
-			userId: number;
+			eventId: string;
+			userId: string;
 		},
 		private categoryService: CategoryService,
 		private userService: UserService

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.ts
@@ -39,14 +39,14 @@ import { MatListModule } from '@angular/material/list';
 	],
 })
 export class ExpendituresComponent implements OnInit {
-	private eventId!: number;
+	private eventId!: string;
 
 	loading: BehaviorSubject<boolean> = new BehaviorSubject(false);
 	cancel$: Subject<void> = new Subject();
 
 	expenses: Expense[] = [];
 	displayedColumns: string[] = ['name', 'payer', 'amount', 'categoryName', 'description', 'delete'];
-	currentUserId: number;
+	currentUserId: string;
 
 	constructor(
 		private expenseService: ExpenseService,
@@ -134,7 +134,7 @@ export class ExpendituresComponent implements OnInit {
 			});
 	}
 
-	removeExpense(expenseId: number) {
+	removeExpense(expenseId: string) {
 		this.expenseService.deleteExpense(expenseId).subscribe({
 			next: () => {
 				this.expenses = [

--- a/app/mikane/src/app/pages/payment-structure/payment-structure.component.ts
+++ b/app/mikane/src/app/pages/payment-structure/payment-structure.component.ts
@@ -35,7 +35,7 @@ import { NgIf, NgFor, AsyncPipe, CurrencyPipe } from '@angular/common';
 export class PaymentStructureComponent implements OnInit {
 	@ViewChild(MatAccordion) accordion!: MatAccordion;
 
-	private eventId!: number;
+	private eventId!: string;
 
 	loading: BehaviorSubject<boolean> = new BehaviorSubject(false);
 

--- a/app/mikane/src/app/pages/reset-password/reset-password.component.html
+++ b/app/mikane/src/app/pages/reset-password/reset-password.component.html
@@ -2,7 +2,7 @@
 	<span class="logo-container">
 		<img src="assets/mikane.svg" class="logo" />
 	</span>
-	<span>PUDDING DEBT</span>
+	<span>MIKANE</span>
 	<span class="toolbar-spacer"></span>
 	<menu></menu>
 </mat-toolbar>

--- a/app/mikane/src/app/pages/user/expense.datasource.ts
+++ b/app/mikane/src/app/pages/user/expense.datasource.ts
@@ -21,7 +21,7 @@ export class ExpenseDataSource implements DataSource<Expense> {
 		this.loadingSubject.complete();
 	}
 
-	loadExpenses(userId: number, eventId: number) {
+	loadExpenses(userId: string, eventId: string) {
 		this.loadingSubject.next(true);
 
 		this.userService
@@ -36,7 +36,7 @@ export class ExpenseDataSource implements DataSource<Expense> {
 			});
 	}
 
-	removeExpense(expenseId: number) {
+	removeExpense(expenseId: string) {
 		const expenses = this.expenseSubject.value;
 		const index = expenses.findIndex((expense) => {
 			return expense.id === expenseId;

--- a/app/mikane/src/app/pages/user/user.component.ts
+++ b/app/mikane/src/app/pages/user/user.component.ts
@@ -43,7 +43,7 @@ import { NgIf, NgFor, AsyncPipe, CurrencyPipe } from '@angular/common';
 	],
 })
 export class UserComponent implements OnInit, OnDestroy {
-	private eventId!: number;
+	private eventId!: string;
 	private userSubscription: Subscription;
 	private addUserSubscription: Subscription;
 
@@ -202,7 +202,7 @@ export class UserComponent implements OnInit, OnDestroy {
 		});
 	}
 
-	deleteUserDialog(userId: number) {
+	deleteUserDialog(userId: string) {
 		const dialogRef = this.dialog.open(ConfirmDialogComponent, {
 			width: '380px',
 			data: {
@@ -219,7 +219,7 @@ export class UserComponent implements OnInit, OnDestroy {
 		});
 	}
 
-	removeUser(userId: number) {
+	removeUser(userId: string) {
 		this.eventService.removeUser(this.eventId, userId).subscribe({
 			next: () => {
 				// Reload users and balances
@@ -237,7 +237,7 @@ export class UserComponent implements OnInit, OnDestroy {
 		this.dataSources[index].loadExpenses(user.id, this.eventId);
 	}
 
-	createExpenseDialog(userId: number, dataSource: ExpenseDataSource) {
+	createExpenseDialog(userId: string, dataSource: ExpenseDataSource) {
 		const dialogRef = this.dialog.open(ExpenditureDialogComponent, {
 			width: '400px',
 			data: {
@@ -281,7 +281,7 @@ export class UserComponent implements OnInit, OnDestroy {
 			});
 	}
 
-	deleteExpense(id: number, dataSource: ExpenseDataSource): void {
+	deleteExpense(id: string, dataSource: ExpenseDataSource): void {
 		this.expenseService.deleteExpense(id).subscribe({
 			next: () => {
 				dataSource.removeExpense(id);

--- a/app/mikane/src/app/services/category/category.service.ts
+++ b/app/mikane/src/app/services/category/category.service.ts
@@ -4,12 +4,12 @@ import { map, Observable, of, switchMap } from 'rxjs';
 import { environment } from 'src/environments/environment';
 
 export interface Category {
-	id: number;
+	id: string;
 	name: string;
 	icon: string;
 	weighted: boolean;
 	users: {
-		id: number;
+		id: string;
 		name: string;
 		weight?: number;
 	}[];
@@ -23,11 +23,11 @@ export class CategoryService {
 
 	constructor(private httpClient: HttpClient) {}
 
-	loadCategories(eventId: number): Observable<Category[]> {
+	loadCategories(eventId: string): Observable<Category[]> {
 		return this.httpClient.get<Category[]>(this.apiUrl + `?eventId=${eventId}`);
 	}
 
-	createCategory(name: string, eventId: number, weighted: boolean): Observable<Category> {
+	createCategory(name: string, eventId: string, weighted: boolean): Observable<Category> {
 		return this.httpClient.post<Category>(this.apiUrl, {
 			name,
 			eventId,
@@ -35,27 +35,27 @@ export class CategoryService {
 		});
 	}
 
-	addUser(categoryId: number, userId: string, weight: number): Observable<Category> {
+	addUser(categoryId: string, userId: string, weight: number): Observable<Category> {
 		return this.httpClient.post<Category>(this.apiUrl + `/${categoryId}/user/${userId}`, { weight });
 	}
 
-	deleteUser(categoryId: number, userId: number): Observable<Category> {
+	deleteUser(categoryId: string, userId: string): Observable<Category> {
 		return this.httpClient.delete<Category>(this.apiUrl + `/${categoryId}/user/${userId}`);
 	}
 
-	editUser(categoryId: number, userId: number, weight: number): Observable<Category> {
+	editUser(categoryId: string, userId: string, weight: number): Observable<Category> {
 		return this.httpClient.put<Category>(this.apiUrl + `/${categoryId}/user/${userId}`, { weight });
 	}
 
-	setWeighted(categoryId: number, weighted: boolean): Observable<Category> {
+	setWeighted(categoryId: string, weighted: boolean): Observable<Category> {
 		return this.httpClient.put<Category>(this.apiUrl + `/${categoryId}/weighted`, { weighted });
 	}
 
-	deleteCategory(categoryId: number): Observable<Category[]> {
+	deleteCategory(categoryId: string): Observable<Category[]> {
 		return this.httpClient.delete<Category[]>(this.apiUrl + `/${categoryId}`);
 	}
 
-	findOrCreate(eventId: number, categoryName: string): Observable<Category> {
+	findOrCreate(eventId: string, categoryName: string): Observable<Category> {
 		return this.loadCategories(eventId).pipe(
 			map((categories): Category | undefined => {
 				return categories.find((c) => c.name === categoryName);

--- a/app/mikane/src/app/services/event/event.service.ts
+++ b/app/mikane/src/app/services/event/event.service.ts
@@ -5,15 +5,14 @@ import { environment } from 'src/environments/environment';
 import { User, UserBalance } from '../user/user.service';
 
 export interface PuddingEvent {
-	id: number;
-	uuid: string;
+	id: string;
 	name: string;
 	description: string;
 	created: Date;
-	adminIds: number[];
+	adminIds: string[];
 	private: boolean;
 	user?: {
-		id: number;
+		id: string;
 		inEvent: boolean;
 		isAdmin: boolean;
 	};
@@ -37,11 +36,11 @@ export class EventService {
 		return this.httpClient.get<PuddingEvent[]>(this.apiUrl);
 	}
 
-	loadBalances(eventId: number): Observable<UserBalance[]> {
+	loadBalances(eventId: string): Observable<UserBalance[]> {
 		return this.httpClient.get<UserBalance[]>(this.apiUrl + `/${eventId}/balances`);
 	}
 
-	loadPayments(eventId: number): Observable<Payment[]> {
+	loadPayments(eventId: string): Observable<Payment[]> {
 		return this.httpClient.get<Payment[]>(this.apiUrl + `/${eventId}/payments`);
 	}
 
@@ -49,19 +48,19 @@ export class EventService {
 		return this.httpClient.post<PuddingEvent>(this.apiUrl, { name, description, private: false });
 	}
 
-	editEvent({ id, name, description }: { id: number; name: string; description: string }): Observable<PuddingEvent> {
+	editEvent({ id, name, description }: { id: string; name: string; description: string }): Observable<PuddingEvent> {
 		return this.httpClient.put<PuddingEvent>(this.apiUrl + `/${id}`, { name, description, private: false });
 	}
 
-	deleteEvent(eventId: number): Observable<void> {
+	deleteEvent(eventId: string): Observable<void> {
 		return this.httpClient.delete<void>(this.apiUrl + `/${eventId}`);
 	}
 
-	addUser(eventId: number, userId: number): Observable<PuddingEvent> {
+	addUser(eventId: string, userId: string): Observable<PuddingEvent> {
 		return this.httpClient.post<PuddingEvent>(this.apiUrl + `/${eventId}/user/${userId}`, {});
 	}
 
-	removeUser(eventId: number, userId: number): Observable<PuddingEvent> {
+	removeUser(eventId: string, userId: string): Observable<PuddingEvent> {
 		return this.httpClient.delete<PuddingEvent>(this.apiUrl + `/${eventId}/user/${userId}`);
 	}
 }

--- a/app/mikane/src/app/services/expense/expense.service.ts
+++ b/app/mikane/src/app/services/expense/expense.service.ts
@@ -5,13 +5,13 @@ import { environment } from 'src/environments/environment';
 import { User } from '../user/user.service';
 
 export interface Expense {
-	id: number;
+	id: string;
 	name: string;
 	description: string;
 	amount: number;
 	dateAdded: Date;
 	category: {
-		id: number;
+		id: string;
 		name: string;
 		icon: string;
 	}
@@ -26,7 +26,7 @@ export class ExpenseService {
 
 	constructor(private httpClient: HttpClient) {}
 
-	loadExpenses(eventId: number): Observable<Expense[]> {
+	loadExpenses(eventId: string): Observable<Expense[]> {
 		return this.httpClient.get<Expense[]>(this.apiUrl + `?eventId=${eventId}`);
 	}
 
@@ -34,8 +34,8 @@ export class ExpenseService {
 		expenseName: string,
 		expenseDescription: string,
 		amount: number,
-		categoryId: number,
-		payerId: number
+		categoryId: string,
+		payerId: string
 	): Observable<Expense> {
 		return this.httpClient.post<Expense>(this.apiUrl, {
 			name: expenseName,
@@ -46,7 +46,7 @@ export class ExpenseService {
 		});
 	}
 
-	deleteExpense(expenseId: number): Observable<void> {
+	deleteExpense(expenseId: string): Observable<void> {
 		return this.httpClient.delete<void>(this.apiUrl + `/${expenseId}`);
 	}
 }

--- a/app/mikane/src/app/services/user/user.service.ts
+++ b/app/mikane/src/app/services/user/user.service.ts
@@ -6,8 +6,7 @@ import { Expense } from '../expense/expense.service';
 import { Phonenumber } from 'src/app/types/phonenumber.type';
 
 export interface User {
-	id: number;
-	uuid: string;
+	id: string;
 	name: string;
 	username: string;
 	firstName?: string;
@@ -16,7 +15,7 @@ export interface User {
 	phone?: string;
 	created?: Date;
 	event?: {
-		id: number;
+		id: string;
 		isAdmin: boolean;
 		joinedDate: Date;
 	}
@@ -41,27 +40,27 @@ export class UserService {
 		return this.httpClient.get<User[]>(this.apiUrl + (excludeSelf ? '?exclude=self' : ''));
 	}
 
-	loadUsersByEvent(eventId: number) {
+	loadUsersByEvent(eventId: string) {
 		return this.httpClient.get<User[]>(this.apiUrl + `?eventId=${eventId}`);
 	}
 
-	loadUserById(userId: number) {
+	loadUserById(userId: string) {
 		return this.httpClient.get<User>(this.apiUrl + `/${userId}`);
 	}
 
-	createUser(eventId: number, name: string): Observable<User> {
+	createUser(eventId: string, name: string): Observable<User> {
 		return this.httpClient.post<User>(this.apiUrl, { name: name, eventId: eventId, email: 'email', password: 'password' });
 	}
 
-	loadUserExpenses(userId: number, eventId: number): Observable<Expense[]> {
+	loadUserExpenses(userId: string, eventId: string): Observable<Expense[]> {
 		return this.httpClient.get<Expense[]>(this.apiUrl + `/${userId}/expenses/${eventId}`);
 	}
 
-	loadUserBalance(eventId: number): Observable<UserBalance[]> {
+	loadUserBalance(eventId: string): Observable<UserBalance[]> {
 		return this.httpClient.get<UserBalance[]>(this.apiUrl + `/balances?eventId=${eventId}`);
 	}
 
-	editUser(userId: number, username: string, firstName: string, lastName: string, email: string, phone: Phonenumber): Observable<User> {
+	editUser(userId: string, username: string, firstName: string, lastName: string, email: string, phone: Phonenumber): Observable<User> {
 		return this.httpClient.put<User>(this.apiUrl + `/${userId}`, {
 			username,
 			firstName,
@@ -71,7 +70,7 @@ export class UserService {
 		});
 	}
 
-	deleteUser(userId: number): Observable<User[]> {
+	deleteUser(userId: string): Observable<User[]> {
 		return this.httpClient.delete<User[]>(this.apiUrl + `/${userId}`);
 	}
 

--- a/server/db_scripts/add_user_as_event_admin.sql
+++ b/server/db_scripts/add_user_as_event_admin.sql
@@ -2,11 +2,18 @@ if object_id ('add_user_as_event_admin') is not null
   drop procedure add_user_as_event_admin
 go
 create procedure add_user_as_event_admin
-  @event_id int,
-  @user_id int,
-  @by_user_id int
+  @event_uuid uniqueidentifier,
+  @user_uuid uniqueidentifier,
+  @by_user_uuid uniqueidentifier
 as
 begin
+
+  declare @event_id int
+  declare @user_id int
+  declare @by_user_id int
+  select @event_id = id from [event] where uuid = @event_uuid
+  select @user_id = id from [user] where uuid = @user_uuid
+  select @by_user_id = id from [user] where uuid = @by_user_uuid
 
   if not exists (select 1 from [event] where id = @event_id)
   begin
@@ -37,7 +44,7 @@ begin
 
   update user_event set [admin] = 1 where event_id = @event_id and user_id = @user_id
 
-  exec get_events @event_id, null
+  exec get_events @event_uuid, null
 
 end
 go

--- a/server/db_scripts/add_user_to_category.sql
+++ b/server/db_scripts/add_user_to_category.sql
@@ -2,11 +2,16 @@ if object_id ('add_user_to_category') is not null
   drop procedure add_user_to_category
 go
 create procedure add_user_to_category
-  @category_id int,
-  @user_id int,
+  @category_uuid uniqueidentifier,
+  @user_uuid uniqueidentifier,
   @weight numeric(14)
 as
 begin
+
+  declare @category_id int
+  declare @user_id int
+  select @category_id = id from category where uuid = @category_uuid
+  select @user_id = id from [user] where uuid = @user_uuid
 
   if not exists (select id from category where id = @category_id)
   begin
@@ -46,7 +51,10 @@ begin
       insert into user_category (user_id, category_id) values (@user_id, @category_id)
     end
 
-  exec get_categories @event_id, @category_id
+  declare @event_uuid uniqueidentifier
+  select @event_uuid = uuid from [event] where id = @event_id
+  
+  exec get_categories @event_uuid, @category_uuid
 
 end
 go

--- a/server/db_scripts/add_user_to_event.sql
+++ b/server/db_scripts/add_user_to_event.sql
@@ -2,11 +2,16 @@ if object_id ('add_user_to_event') is not null
   drop procedure add_user_to_event
 go
 create procedure add_user_to_event
-  @event_id int,
-  @user_id int,
+  @event_uuid uniqueidentifier,
+  @user_uuid uniqueidentifier,
   @admin bit
 as
 begin
+
+  declare @event_id int
+  declare @user_id int
+  select @event_id = id from [event] where uuid = @event_uuid
+  select @user_id = id from [user] where uuid = @user_uuid
 
   if not exists (select id from [event] where id = @event_id)
   begin
@@ -25,7 +30,7 @@ begin
 
   insert into user_event (user_id, event_id, joined_date, [admin]) values (@user_id, @event_id, GETDATE(), @admin)
 
-  exec get_events @event_id, null
+  exec get_events @event_uuid, null
 
 end
 go

--- a/server/db_scripts/change_password.sql
+++ b/server/db_scripts/change_password.sql
@@ -2,14 +2,14 @@ if object_id ('change_password') is not null
   drop procedure change_password
 go
 create procedure change_password
-  @user_id int,
+  @user_uuid uniqueidentifier,
   @password nvarchar(255)
 as
 begin
 
-  update [user] set [password] = @password where id = @user_id
+  update [user] set [password] = @password where uuid = @user_uuid
   
-  select id, username, email, created from [user] where id = @user_id
+  select uuid, username, email, created from [user] where uuid = @user_uuid
 
 end
 go

--- a/server/db_scripts/delete_category.sql
+++ b/server/db_scripts/delete_category.sql
@@ -2,16 +2,16 @@ if object_id ('delete_category') is not null
   drop procedure delete_category
 go
 create procedure delete_category
-  @category_id int
+  @category_uuid uniqueidentifier
 as
 begin
 
-  if not exists (select 1 from category where id = @category_id)
+  if not exists (select 1 from category where uuid = @category_uuid)
   begin
     throw 50007, 'Category not found', 1
   end
 
-  delete from category where id = @category_id
+  delete from category where uuid = @category_uuid
 
 end
 go

--- a/server/db_scripts/delete_event.sql
+++ b/server/db_scripts/delete_event.sql
@@ -2,10 +2,15 @@ if object_id ('delete_event') is not null
   drop procedure delete_event
 go
 create procedure delete_event
-  @event_id int,
-  @user_id int
+  @event_uuid uniqueidentifier,
+  @user_uuid uniqueidentifier
 as
 begin
+
+  declare @event_id int
+  declare @user_id int
+  select @event_id = id from [event] where uuid = @event_uuid
+  select @user_id = id from [user] where uuid = @user_uuid
 
   if not exists (select 1 from [event] where id = @event_id)
   begin

--- a/server/db_scripts/delete_expense.sql
+++ b/server/db_scripts/delete_expense.sql
@@ -2,10 +2,15 @@ if object_id ('delete_expense') is not null
   drop procedure delete_expense
 go
 create procedure delete_expense
-  @expense_id int,
-  @user_id int
+  @expense_uuid uniqueidentifier,
+  @user_uuid uniqueidentifier
 as
 begin
+
+  declare @expense_id int
+  declare @user_id int
+  select @expense_id = id from expense where uuid = @expense_uuid
+  select @user_id = id from [user] where uuid = @user_uuid
 
   if not exists (select 1 from expense where id = @expense_id)
   begin

--- a/server/db_scripts/delete_user.sql
+++ b/server/db_scripts/delete_user.sql
@@ -2,16 +2,16 @@ if object_id ('delete_user') is not null
   drop procedure delete_user
 go
 create procedure delete_user
-  @user_id int
+  @user_uuid uniqueidentifier
 as
 begin
 
-  if not exists (select 1 from [user] where id = @user_id)
+  if not exists (select 1 from [user] where uuid = @user_uuid)
   begin
     throw 50008, 'User not found', 1
   end
 
-  delete from [user] where id = @user_id
+  delete from [user] where uuid = @user_uuid
 
 end
 go

--- a/server/db_scripts/edit_category_weighted_status.sql
+++ b/server/db_scripts/edit_category_weighted_status.sql
@@ -2,10 +2,13 @@ if object_id ('edit_category_weighted_status') is not null
   drop procedure edit_category_weighted_status
 go
 create procedure edit_category_weighted_status
-  @category_id int,
+  @category_uuid uniqueidentifier,
   @weighted bit
 as
 begin
+
+  declare @category_id int
+  select @category_id = id from category where uuid = @category_uuid
 
   if not exists (select 1 from category where id = @category_id)
   begin
@@ -25,7 +28,9 @@ begin
     end
   end
 
-  exec get_categories @event_id, @category_id
+  declare @event_uuid uniqueidentifier
+  select @event_uuid = uuid from [event] where id = @event_id
+  exec get_categories @event_uuid, @category_uuid
 
 end
 go

--- a/server/db_scripts/edit_event.sql
+++ b/server/db_scripts/edit_event.sql
@@ -2,13 +2,18 @@ if object_id ('edit_event') is not null
   drop procedure edit_event
 go
 create procedure edit_event
-  @event_id int,
-  @user_id int,
+  @event_uuid uniqueidentifier,
+  @user_uuid uniqueidentifier,
   @name nvarchar(255),
   @description nvarchar(400),
   @private bit
 as
 begin
+
+  declare @event_id int
+  declare @user_id int
+  select @event_id = id from [event] where uuid = @event_uuid
+  select @user_id = id from [user] where uuid = @user_uuid
 
   if not exists (select 1 from [event] where id = @event_id)
   begin
@@ -41,7 +46,7 @@ begin
     update [event] set [description] = null where id = @event_id
   end
   
-  exec get_events @event_id, null
+  exec get_events @event_uuid, null
 
 end
 go

--- a/server/db_scripts/edit_user.sql
+++ b/server/db_scripts/edit_user.sql
@@ -2,7 +2,7 @@ if object_id ('edit_user') is not null
   drop procedure edit_user
 go
 create procedure edit_user
-  @user_id int,
+  @user_uuid uniqueidentifier,
   @username nvarchar(255),
   @first_name nvarchar(255),
   @last_name nvarchar(255),
@@ -11,17 +11,17 @@ create procedure edit_user
 as
 begin
 
-  if @username is not null and exists (select id from [user] where [username] = @username and id != @user_id) 
+  if @username is not null and exists (select id from [user] where [username] = @username and uuid != @user_uuid) 
   begin
     throw 50017, 'Username already taken', 1
   end
 
-  if @email is not null and exists (select id from [user] where email = @email and id != @user_id) 
+  if @email is not null and exists (select id from [user] where email = @email and uuid != @user_uuid) 
   begin
     throw 50018, 'Email address already taken', 1
   end
 
-  if @phone_number is not null and exists (select id from [user] where phone_number = @phone_number and id != @user_id)
+  if @phone_number is not null and exists (select id from [user] where phone_number = @phone_number and uuid != @user_uuid)
   begin
     throw 50019, 'Phone number already taken', 1
   end
@@ -35,9 +35,9 @@ begin
     email = isnull(@email, email),
     phone_number = isnull(@phone_number, phone_number)
   where
-    id = @user_id
+    uuid = @user_uuid
   
-  exec get_user @user_id, null
+  exec get_user @user_uuid, null
 
 end
 go

--- a/server/db_scripts/edit_user_weight.sql
+++ b/server/db_scripts/edit_user_weight.sql
@@ -2,11 +2,16 @@ if object_id ('edit_user_weight') is not null
   drop procedure edit_user_weight
 go
 create procedure edit_user_weight
-  @category_id int,
-  @user_id int,
+  @category_uuid uniqueidentifier,
+  @user_uuid uniqueidentifier,
   @weight numeric(14)
 as
 begin
+
+  declare @category_id int
+  declare @user_id int
+  select @category_id = id from category where uuid = @category_uuid
+  select @user_id = id from [user] where uuid = @user_uuid
 
   if not exists (select 1 from category where id = @category_id)
   begin
@@ -18,10 +23,14 @@ begin
   where user_id = @user_id
     and category_id = @category_id
 
-  declare @event_id int
-  select @event_id = event_id from category where id = @category_id
+  declare @event_uuid uniqueidentifier
+  select
+    @event_uuid = e.uuid
+  from category c
+    inner join [event] e on c.event_id = e.id
+  where c.id = @category_id
 
-  exec get_categories @event_id, @category_id
+  exec get_categories @event_uuid, @category_uuid
 
 end
 go

--- a/server/db_scripts/get_categories.sql
+++ b/server/db_scripts/get_categories.sql
@@ -2,14 +2,24 @@ if object_id ('get_categories') is not null
   drop procedure get_categories
 go
 create procedure get_categories
-  @event_id int,
-  @category_id int
+  @event_uuid uniqueidentifier,
+  @category_uuid uniqueidentifier
 as
 begin
 
-  if @event_id is not null and not exists (select 1 from [event] where id = @event_id)
+  declare @event_id int
+  declare @category_id int
+  select @event_id = id from [event] where uuid = @event_uuid
+  select @category_id = id from category where uuid = @category_uuid
+
+  if @event_uuid is not null and not exists (select 1 from [event] where id = @event_id)
   begin
     throw 50006, 'Event not found', 1
+  end
+
+  if @category_uuid is not null and not exists (select 1 from category where id = @category_id)
+  begin
+    throw 50007, 'Category not found', 1
   end
 
   select
@@ -28,14 +38,15 @@ begin
     c.event_id = isnull(@event_id, c.event_id)
 
   select
-    c.id,
+    c.uuid,
     c.name,
     c.icon,
     c.weighted,
-    c.event_id,
+    e.uuid as event_uuid,
     (
       select
         uc.user_id,
+        u.uuid as user_uuid,
         u.username,
         u.first_name,
         u.last_name,

--- a/server/db_scripts/get_event_payment_data.sql
+++ b/server/db_scripts/get_event_payment_data.sql
@@ -2,18 +2,18 @@ if object_id ('get_event_payment_data') is not null
   drop procedure get_event_payment_data
 go
 create procedure get_event_payment_data
-  @event_id int
+  @event_uuid uniqueidentifier
 as
 begin
 
-  if (@event_id is null)
+  if (@event_uuid is null)
   begin
     return
   end
 
-  execute get_users @event_id, null
-  execute get_categories @event_id, null
-  execute get_expenses @event_id, null, null
+  execute get_users @event_uuid, null
+  execute get_categories @event_uuid, null
+  execute get_expenses @event_uuid, null, null
 
 end
 go

--- a/server/db_scripts/get_expenses.sql
+++ b/server/db_scripts/get_expenses.sql
@@ -2,13 +2,20 @@ if object_id ('get_expenses') is not null
   drop procedure get_expenses
 go
 create procedure get_expenses
-  @event_id int,
-  @user_id int,
-  @expense_id int
+  @event_uuid uniqueidentifier,
+  @user_uuid uniqueidentifier,
+  @expense_uuid uniqueidentifier
 as
 begin
 
-  if (@event_id is not null and @user_id is null)
+  declare @event_id int
+  declare @user_id int
+  declare @expense_id int
+  select @event_id = id from [event] where uuid = @event_uuid
+  select @user_id = id from [user] where uuid = @user_uuid
+  select @expense_id = id from expense where uuid = @expense_uuid
+
+  if (@event_uuid is not null and @user_uuid is null)
   begin
     if not exists (select 1 from [event] where id = @event_id)
     begin
@@ -16,9 +23,9 @@ begin
     end
 
     select
-      ex.*,
-      c.name as category_name, c.icon as category_icon,
-      u.first_name as payer_first_name, u.last_name as payer_last_name, u.username as payer_username, u.uuid as payer_uuid
+      ex.uuid, ex.name, ex.description, ex.amount, ex.payer_id, ex.date_added,
+      c.uuid as 'category_uuid', c.name as 'category_name', c.icon as 'category_icon',
+      u.uuid as 'payer_uuid', u.first_name as 'payer_first_name', u.last_name as 'payer_last_name', u.username as 'payer_username'
     from
       expense ex
       inner join category c on c.id = ex.category_id
@@ -30,7 +37,7 @@ begin
       ex.date_added desc
   end
 
-  else if (@event_id is not null and @user_id is not null)
+  else if (@event_uuid is not null and @user_uuid is not null)
   begin
     if not exists (select 1 from [event] where id = @event_id)
     begin
@@ -43,9 +50,9 @@ begin
     end
     
     select
-      ex.*,
-      c.name as category_name, c.icon as category_icon,
-      u.first_name as payer_first_name, u.last_name as payer_last_name, u.username as payer_username, u.uuid as payer_uuid
+      ex.uuid, ex.name, ex.description, ex.amount, ex.payer_id, ex.date_added,
+      c.uuid as 'category_uuid', c.name as 'category_name', c.icon as 'category_icon',
+      u.uuid as 'payer_uuid', u.first_name as 'payer_first_name', u.last_name as 'payer_last_name', u.username as 'payer_username'
     from
       expense ex
       inner join category c on c.id = ex.category_id
@@ -58,7 +65,7 @@ begin
       ex.date_added desc
   end
 
-  else if (@expense_id is not null)
+  else if (@expense_uuid is not null)
   begin
     if not exists (select 1 from expense where id = @expense_id)
     begin
@@ -66,9 +73,9 @@ begin
     end
 
     select
-      ex.*,
-      c.name as category_name, c.icon as category_icon,
-      u.first_name as payer_first_name, u.last_name as payer_last_name, u.username as payer_username, u.uuid as payer_uuid
+      ex.uuid, ex.name, ex.description, ex.amount, ex.payer_id, ex.date_added,
+      c.uuid as 'category_uuid', c.name as 'category_name', c.icon as 'category_icon',
+      u.uuid as 'payer_uuid', u.first_name as 'payer_first_name', u.last_name as 'payer_last_name', u.username as 'payer_username'
     from
       expense ex
       inner join category c on c.id = ex.category_id

--- a/server/db_scripts/get_user.sql
+++ b/server/db_scripts/get_user.sql
@@ -2,25 +2,25 @@ if object_id ('get_user') is not null
   drop procedure get_user
 go
 create procedure get_user
-  @user_id int,
+  @user_uuid uniqueidentifier,
   @username nvarchar(255)
 as
 begin
 
-  if (@user_id is not null)
+  if (@user_uuid is not null)
   begin
     select
-      id, username, first_name, last_name, email, phone_number, [password], created, uuid
+      uuid, username, first_name, last_name, email, phone_number, [password], created
     from
       [user]
     where
-      id = @user_id
+      uuid = @user_uuid
   end
 
   else if (@username is not null)
   begin
     select
-      id, username, first_name, last_name, email, phone_number, [password], created, uuid
+      uuid, username, first_name, last_name, email, phone_number, [password], created
     from
       [user]
     where

--- a/server/db_scripts/get_user_hash.sql
+++ b/server/db_scripts/get_user_hash.sql
@@ -3,23 +3,23 @@ if object_id ('get_user_hash') is not null
 go
 create procedure get_user_hash
   @usernameEmail nvarchar(255),
-  @user_id int
+  @user_uuid uniqueidentifier
 as
 begin
 
-  if (@user_id is not null)
+  if (@user_uuid is not null)
     begin
       select
-        id, [password]
+        uuid, [password]
       from
         [user]
       where
-        id = @user_id
+        uuid = @user_uuid
     end
   else
     begin
       select
-        id, [password]
+        uuid, [password]
       from
         [user]
       where

--- a/server/db_scripts/get_user_id.sql
+++ b/server/db_scripts/get_user_id.sql
@@ -7,7 +7,7 @@ as
 begin
 
   select
-    id
+    uuid
   from
     [user]
   where

--- a/server/db_scripts/get_users.sql
+++ b/server/db_scripts/get_users.sql
@@ -2,16 +2,21 @@ if object_id ('get_users') is not null
   drop procedure get_users
 go
 create procedure get_users
-  @event_id int,
-  @exclude_user_id int
+  @event_uuid uniqueidentifier,
+  @exclude_user_uuid uniqueidentifier
 as
 begin
 
-  if (@event_id is null)
+  declare @event_id int
+  declare @exclude_user_id int
+  select @event_id = id from [event] where uuid = @event_uuid
+  select @exclude_user_id = id from [user] where uuid = @exclude_user_uuid
+
+  if (@event_uuid is null)
     begin
         
       select
-        id, username, first_name, last_name, email, phone_number, created, uuid
+        uuid, username, first_name, last_name, email, phone_number, created
       from
         [user]
       where
@@ -25,11 +30,12 @@ begin
     begin
         
       select
-        u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.created, u.uuid,
-        ue.event_id, ue.admin as 'event_admin', ue.joined_date as 'event_joined_date'
+        u.uuid, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.created,
+        e.uuid as 'event_uuid', ue.admin as 'event_admin', ue.joined_date as 'event_joined_date'
       from
         [user] u
         inner join user_event ue on ue.user_id = u.id
+        inner join [event] e on e.id = ue.event_id
       where
         ue.event_id = @event_id and
         ((IsNumeric(@exclude_user_id) = 1 and u.id != @exclude_user_id) or

--- a/server/db_scripts/new_category.sql
+++ b/server/db_scripts/new_category.sql
@@ -5,9 +5,12 @@ create procedure new_category
   @name nvarchar(255),
   @icon nvarchar(255),
   @weighted bit,
-  @event_id int
+  @event_uuid uniqueidentifier
 as
 begin
+
+  declare @event_id int
+  select @event_id = id from [event] where uuid = @event_uuid
 
   if not exists (select 1 from [event] where id = @event_id)
   begin
@@ -21,7 +24,10 @@ begin
 
   insert into category(event_id, [name], icon, weighted) values (@event_id, @name, @icon, @weighted)
 
-  select * from category where id = @@IDENTITY
+  declare @category_uuid uniqueidentifier
+  select @category_uuid = uuid from category where id = @@IDENTITY
+
+  exec get_categories null, @category_uuid
 
 end
 go

--- a/server/db_scripts/new_event.sql
+++ b/server/db_scripts/new_event.sql
@@ -4,27 +4,28 @@ go
 create procedure new_event
   @name nvarchar(255),
   @description nvarchar(400),
-  @user_id int,
+  @user_uuid uniqueidentifier,
   @private bit,
   @active bit,
   @usernames_only bit
 as
 begin
 
-  if exists (select id from [event] where [name] = @name)
+  if exists (select 1 from [event] where [name] = @name)
   begin
     throw 50005, 'Another event already has this name', 1
   end
 
-  if not exists (select id from [user] where id = @user_id)
+  if not exists (select 1 from [user] where uuid = @user_uuid)
   begin
     throw 50008, 'User not found', 1
   end
 
   insert into [event]([name], [description], created, [private], active, usernames_only) values (@name, @description, GETDATE(), @private, @active, @usernames_only)
 
-  declare @event_id int = @@IDENTITY
-  exec add_user_to_event @event_id, @user_id, 1
+  declare @event_uuid uniqueidentifier
+  select @event_uuid = uuid from [event] where id = @@IDENTITY
+  exec add_user_to_event @event_uuid, @user_uuid, 1
 
 end
 go

--- a/server/db_scripts/new_expense.sql
+++ b/server/db_scripts/new_expense.sql
@@ -5,10 +5,15 @@ create procedure new_expense
   @name nvarchar(255),
   @description nvarchar(255),
   @amount numeric(16, 2),
-  @category_id int,
-  @payer_id int
+  @category_uuid uniqueidentifier,
+  @payer_uuid uniqueidentifier
 as
 begin
+
+  declare @category_id int
+  declare @payer_id int
+  select @category_id = id from category where uuid = @category_uuid
+  select @payer_id = id from [user] where uuid = @payer_uuid
 
   if not exists (select 1 from category where id = @category_id)
   begin
@@ -28,7 +33,9 @@ begin
   insert into expense([name], [description], amount, category_id, payer_id, date_added)
     values (@name, nullif(@description, ''), @amount, @category_id, @payer_id, GETDATE())
 
-  exec get_expenses null, null, @@IDENTITY
+  declare @expense_uuid uniqueidentifier
+  select @expense_uuid = uuid from expense where id = @@IDENTITY
+  exec get_expenses null, null, @expense_uuid
 
 end
 go

--- a/server/db_scripts/new_password_reset_key.sql
+++ b/server/db_scripts/new_password_reset_key.sql
@@ -2,10 +2,13 @@ if object_id ('new_password_reset_key') is not null
   drop procedure new_password_reset_key
 go
 create procedure new_password_reset_key
-  @user_id int,
+  @user_uuid uniqueidentifier,
   @key nvarchar(255)
 as
 begin
+
+  declare @user_id int
+  select @user_id = id from [user] where uuid = @user_uuid
 
   insert into password_reset_key([key], user_id, used, expires)
     values (@key, @user_id, 0, DATEADD(hour, 1, GETDATE()))

--- a/server/db_scripts/new_user.sql
+++ b/server/db_scripts/new_user.sql
@@ -29,8 +29,9 @@ begin
   insert into [user](username, first_name, last_name, email, phone_number, [password], created)
     values (@username, @first_name, nullif(@last_name, ''), @email, @phone_number, @password, GETDATE())
 
-  declare @user_id int = @@IDENTITY
-  exec get_user @user_id, null
+  declare @user_uuid uniqueidentifier
+  select @user_uuid = uuid from [user] where id = @@IDENTITY
+  exec get_user @user_uuid, null
 
 end
 go

--- a/server/db_scripts/remove_user_as_event_admin.sql
+++ b/server/db_scripts/remove_user_as_event_admin.sql
@@ -2,11 +2,18 @@ if object_id ('remove_user_as_event_admin') is not null
   drop procedure remove_user_as_event_admin
 go
 create procedure remove_user_as_event_admin
-  @event_id int,
-  @user_id int,
-  @by_user_id int
+  @event_uuid uniqueidentifier,
+  @user_uuid uniqueidentifier,
+  @by_user_uuid uniqueidentifier
 as
 begin
+
+  declare @event_id int
+  declare @user_id int
+  declare @by_user_id int
+  select @event_id = id from [event] where uuid = @event_uuid
+  select @user_id = id from [user] where uuid = @user_uuid
+  select @by_user_id = id from [user] where uuid = @by_user_uuid
 
   if not exists (select 1 from [event] where id = @event_id)
   begin
@@ -39,7 +46,7 @@ begin
 
   update user_event set [admin] = 0 where event_id = @event_id and user_id = @user_id
 
-  exec get_events @event_id, null
+  exec get_events @event_uuid, null
 
 end
 go

--- a/server/db_scripts/remove_user_from_category.sql
+++ b/server/db_scripts/remove_user_from_category.sql
@@ -2,10 +2,15 @@ if object_id ('remove_user_from_category') is not null
   drop procedure remove_user_from_category
 go
 create procedure remove_user_from_category
-  @category_id int,
-  @user_id int
+  @category_uuid uniqueidentifier,
+  @user_uuid uniqueidentifier
 as
 begin
+
+  declare @category_id int
+  declare @user_id int
+  select @category_id = id from category where uuid = @category_uuid
+  select @user_id = id from [user] where uuid = @user_uuid
 
   if not exists (select id from category where id = @category_id)
   begin
@@ -19,11 +24,14 @@ begin
 
   delete from user_category where category_id = @category_id and user_id = @user_id
 
-  declare @event_id int
+  declare @event_uuid uniqueidentifier
+  select
+    @event_uuid = e.uuid
+  from category c
+    inner join [event] e on c.event_id = e.id
+  where c.id = @category_id
 
-  select @event_id = event_id from category where id = @category_id
-
-  exec get_categories @event_id, @category_id
+  exec get_categories @event_uuid, @category_uuid
 
 end
 go

--- a/server/db_scripts/remove_user_from_event.sql
+++ b/server/db_scripts/remove_user_from_event.sql
@@ -2,10 +2,15 @@ if object_id ('remove_user_from_event') is not null
   drop procedure remove_user_from_event
 go
 create procedure remove_user_from_event
-  @event_id int,
-  @user_id int
+  @event_uuid uniqueidentifier,
+  @user_uuid uniqueidentifier
 as
 begin
+
+  declare @event_id int
+  declare @user_id int
+  select @event_id = id from [event] where uuid = @event_uuid
+  select @user_id = id from [user] where uuid = @user_uuid
 
   if not exists (select id from [event] where id = @event_id)
   begin
@@ -26,7 +31,7 @@ begin
     c.event_id = @event_id and
     e.payer_id = @user_id
 
-  exec get_events @event_id, null
+  exec get_events @event_uuid, null
 
 end
 go

--- a/server/db_scripts/rename_category.sql
+++ b/server/db_scripts/rename_category.sql
@@ -2,21 +2,19 @@ if object_id ('rename_category') is not null
   drop procedure rename_category
 go
 create procedure rename_category
-  @category_id int,
+  @category_uuid uniqueidentifier,
   @name nvarchar(255)
 as
 begin
 
-  if not exists (select 1 from category where id = @category_id)
+  if not exists (select 1 from category where uuid = @category_uuid)
   begin
     throw 50007, 'Category not found', 1
   end
 
-  update category set [name] = @name where id = @category_id
+  update category set [name] = @name where uuid = @category_uuid
   
-  select * from category where event_id = (
-    select event_id from category where id = @category_id
-  )
+  exec get_categories null, @category_uuid
 
 end
 go

--- a/server/db_scripts/reset_password.sql
+++ b/server/db_scripts/reset_password.sql
@@ -13,7 +13,7 @@ begin
   update [user] set [password] = @password where id = @user_id
   update password_reset_key set used = 1 where [key] = @key
 
-  select id, username, email, created from [user] where id = @user_id
+  select uuid, username, email, created from [user] where id = @user_id
 
 end
 go

--- a/server/db_scripts/schema/db_schema.sql
+++ b/server/db_scripts/schema/db_schema.sql
@@ -7,7 +7,7 @@ create table [user] (
   phone_number nvarchar(20) not null unique,
   [password] nvarchar(255) not null,
   created datetime not null,
-  uuid uniqueidentifier not null default newid()
+  uuid uniqueidentifier not null unique default newid()
 );
 
 create table [event] (
@@ -18,7 +18,7 @@ create table [event] (
   [private] bit not null,
   active bit not null default 1,
   usernames_only bit not null,
-  uuid uniqueidentifier not null default newid()
+  uuid uniqueidentifier not null unique default newid()
 );
 
 create table user_event (
@@ -34,7 +34,8 @@ create table category (
   [name] nvarchar(255) not null,
   icon nvarchar(255),
   weighted bit not null,
-  event_id int foreign key references [event](id) on delete cascade
+  event_id int foreign key references [event](id) on delete cascade,
+  uuid uniqueidentifier not null unique default newid()
 );
 
 create table expense (
@@ -44,7 +45,8 @@ create table expense (
   amount numeric(16, 2) not null,
   category_id int foreign key references category(id) on delete cascade,
   payer_id int foreign key references [user](id) on delete cascade,
-  date_added datetime not null
+  date_added datetime not null,
+  uuid uniqueidentifier not null unique default newid()
 );
 
 create table user_category (
@@ -58,7 +60,8 @@ create table [session] (
   [sid] nvarchar(255) not null primary key,
   [session] nvarchar(max) not null,
   expires datetime not null,
-  user_id int not null
+  user_id int foreign key references [user](id) on delete cascade,
+  user_uuid uniqueidentifier not null
 );
 
 create table api_key (

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -33,16 +33,12 @@
                       "example": "true"
                     },
                     "id": {
-                      "type": "integer",
-                      "example": 1
+                      "type": "string",
+                      "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
                     },
                     "username": {
                       "type": "string",
                       "example": "testuser"
-                    },
-                    "uuid": {
-                      "type": "string",
-                      "example": "e1c594bc-93b7-4a33-9181-5de0b094ed9b"
                     }
                   }
                 }
@@ -1853,8 +1849,8 @@
                     "example": true
                   },
                   "eventId": {
-                    "type": "integer",
-                    "example": 1
+                    "type": "string",
+                    "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
                   }                 
                 }
               }
@@ -2571,12 +2567,12 @@
                     "example": 100
                   },
                   "categoryId": {
-                    "type": "number",
-                    "example": 1
+                    "type": "string",
+                    "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
                   },
                   "payerId": {
-                    "type": "number",
-                    "example": 1
+                    "type": "string",
+                    "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
                   }
                 }
               }
@@ -2776,8 +2772,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "example": 1
+            "type": "string",
+            "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
           },
           "username": {
             "type": "string",
@@ -2794,10 +2790,6 @@
           "created": {
             "type": "date-time",
             "example": "2023-01-20T18:00:00"
-          },
-          "uuid": {
-            "type": "string",
-            "example": "e1c594bc-93b7-4a33-9181-5de0b094ed9b"
           }
         }
       },
@@ -2805,8 +2797,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "example": 1
+            "type": "string",
+            "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
           },
           "username": {
             "type": "string",
@@ -2824,16 +2816,12 @@
             "type": "date-time",
             "example": "2023-01-20T18:00:00"
           },
-          "uuid": {
-            "type": "string",
-            "example": "e1c594bc-93b7-4a33-9181-5de0b094ed9b"
-          },
           "event": {
             "type": "object",
             "properties": {
               "id": {
-                "type": "integer",
-                "example": 1
+                "type": "string",
+                "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
               },
               "isAdmin": {
                 "type": "boolean",
@@ -2851,16 +2839,15 @@
           "username",
           "name",
           "email",
-          "created",
-          "uuid"
+          "created"
         ]
       },
       "UserDetailed": {
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "example": 1
+            "type": "string",
+            "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
           },
           "username": {
             "type": "string",
@@ -2889,10 +2876,6 @@
           "created": {
             "type": "date-time",
             "example": "2023-01-20T18:00:00"
-          },
-          "uuid": {
-            "type": "string",
-            "example": "e1c594bc-93b7-4a33-9181-5de0b094ed9b"
           }
         }
       },
@@ -2904,8 +2887,8 @@
             "example": "true"
           },
           "id": {
-            "type": "integer",
-            "example": 1
+            "type": "string",
+            "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
           },
           "username": {
             "type": "string",
@@ -2930,10 +2913,6 @@
           "created": {
             "type": "date-time",
             "example": "2023-01-20T18:00:00"
-          },
-          "uuid": {
-            "type": "string",
-            "example": "e1c594bc-93b7-4a33-9181-5de0b094ed9b"
           }
         }
       },
@@ -2941,8 +2920,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "example": 1
+            "type": "string",
+            "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
           },
           "name": {
             "type": "string",
@@ -2959,17 +2938,13 @@
           "adminIds": {
             "type": "array",
             "items": {
-              "type": "number",
-              "example": 1
+              "type": "string",
+              "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
             }
           },
           "private": {
             "type": "boolean",
             "example": false
-          },
-          "uuid": {
-            "type": "string",
-            "example": "e1c594bc-93b7-4a33-9181-5de0b094ed9b"
           }
         }
       },
@@ -2977,8 +2952,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "example": 1
+            "type": "string",
+            "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
           },
           "name": {
             "type": "string",
@@ -2995,24 +2970,20 @@
           "adminIds": {
             "type": "array",
             "items": {
-              "type": "number",
-              "example": 1
+              "type": "string",
+              "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
             }
           },
           "private": {
             "type": "boolean",
             "example": false
           },
-          "uuid": {
-            "type": "string",
-            "example": "e1c594bc-93b7-4a33-9181-5de0b094ed9b"
-          },
           "user": {
             "type": "object",
             "properties": {
               "id": {
-                "type": "integer",
-                "example": 2
+                "type": "string",
+                "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
               },
               "inEvent": {
                 "type": "boolean",
@@ -3031,16 +3002,15 @@
           "description",
           "created",
           "adminIds",
-          "private",
-          "uuid"
+          "private"
         ]
       },
       "Expense": {
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "example": 1
+            "type": "string",
+            "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
           },
           "name": {
             "type": "string",
@@ -3062,8 +3032,8 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "integer",
-                "example": 1
+                "type": "string",
+                "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
               },
               "name": {
                 "type": "string",
@@ -3079,8 +3049,8 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "integer",
-                "example": 1
+                "type": "string",
+                "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
               },
               "username": {
                 "type": "string",
@@ -3089,10 +3059,6 @@
               "name": {
                 "type": "string",
                 "example": "Test"
-              },
-              "uuid": {
-                "type": "string",
-                "example": "e1c594bc-93b7-4a33-9181-5de0b094ed9b"
               }
             }
           }
@@ -3102,8 +3068,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "example": 1
+            "type": "string",
+            "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
           },
           "name": {
             "type": "string",
@@ -3123,8 +3089,8 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "integer",
-                  "example": 1
+                  "type": "string",
+                  "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
                 },
                 "name": {
                   "type": "string",

--- a/server/src/api/authentication.ts
+++ b/server/src/api/authentication.ts
@@ -26,8 +26,7 @@ router.get("/login", (req, res, next) => {
     return res.status(200).json({
       authenticated: req.session.authenticated,
       username: req.session.username,
-      id: req.session.userId,
-      uuid: req.session.uuid
+      id: req.session.userId
     });
   }
   catch (err) {
@@ -92,7 +91,6 @@ router.post("/login", async (req, res, next) => {
       }
       req.session.authenticated = true;
       req.session.userId = user.id;
-      req.session.uuid = user.uuid;
       req.session.username = user.username;
       console.log(`User ${user.username} signing in...`, req.sessionID);
       res.status(200).json({

--- a/server/src/api/categories.ts
+++ b/server/src/api/categories.ts
@@ -1,10 +1,11 @@
 import express from "express";
 import * as db from "../db/dbCategories";
 import { authCheck } from "../middlewares/authCheck";
+import { isUUID } from "../utils/uuidValidator";
 import { Category } from "../types/types";
+import { CategoryIcon } from "../types/enums";
 import { ErrorExt } from "../types/errorExt";
 import * as ec from "../types/errorCodes";
-import { CategoryIcon } from "../types/enums";
 const router = express.Router();
 
 /* --- */
@@ -16,8 +17,8 @@ const router = express.Router();
 */
 router.get("/categories", authCheck, async (req, res, next) => {
   try {
-    const eventId = Number(req.query.eventId);
-    if (isNaN(eventId)) {
+    const eventId = req.query.eventId as string;
+    if (!isUUID(eventId)) {
       throw new ErrorExt(ec.PUD013);
     }
 
@@ -34,8 +35,8 @@ router.get("/categories", authCheck, async (req, res, next) => {
 */
 router.get("/categories/:id", authCheck, async (req, res, next) => {
   try {
-    const id = Number(req.params.id);
-    if (isNaN(id)) {
+    const id = req.params.id;
+    if (!isUUID(id)) {
       throw new ErrorExt(ec.PUD045);
     }
 
@@ -62,8 +63,8 @@ router.post("/categories", authCheck, async (req, res, next) => {
     if (!req.body.name || !req.body.eventId || req.body.weighted === undefined) {
       throw new ErrorExt(ec.PUD046);
     }
-    const eventId = Number(req.body.eventId);
-    if (isNaN(eventId)) {
+    const eventId = req.body.eventId as string;
+    if (!isUUID(eventId)) {
       throw new ErrorExt(ec.PUD013);
     }
 
@@ -85,11 +86,11 @@ router.post("/categories", authCheck, async (req, res, next) => {
 */
 router.post("/categories/:id/user/:userId", authCheck, async (req, res, next) => {
   try {
-    const catId = Number(req.params.id);
-    const userId = Number(req.params.userId);
+    const catId = req.params.id;
+    const userId = req.params.userId;
     const weight = req.body.weight ? Number(req.body.weight) : undefined;
 
-    if (isNaN(catId) || isNaN(userId)) {
+    if (!isUUID(catId) || !isUUID(userId)) {
       throw new ErrorExt(ec.PUD047);
     }
     if (weight && isNaN(weight)) {
@@ -116,8 +117,8 @@ router.post("/categories/:id/user/:userId", authCheck, async (req, res, next) =>
 */
 router.put("/categories/:id", authCheck, async (req, res, next) => {
   try {
-    const catId = Number(req.params.id);
-    if (isNaN(catId)) {
+    const catId = req.params.id;
+    if (!isUUID(catId)) {
       throw new ErrorExt(ec.PUD045);
     }
     if (!req.body.name) {
@@ -140,8 +141,8 @@ router.put("/categories/:id", authCheck, async (req, res, next) => {
 */
 router.put("/categories/:id/weighted", authCheck, async (req, res, next) => {
   try {
-    const catId = Number(req.params.id);
-    if (isNaN(catId)) {
+    const catId = req.params.id;
+    if (!isUUID(catId)) {
       throw new ErrorExt(ec.PUD045);
     }
     if (typeof(req.body.weighted) !== "boolean") {
@@ -161,11 +162,11 @@ router.put("/categories/:id/weighted", authCheck, async (req, res, next) => {
 */
 router.put("/categories/:id/user/:userId", authCheck, async (req, res, next) => {
   try {
-    const catId = Number(req.params.id);
-    const userId = Number(req.params.userId);
+    const catId = req.params.id;
+    const userId = req.params.userId;
     const weight = req.body.weight ? Number(req.body.weight) : undefined;
 
-    if (isNaN(catId) || isNaN(userId)) {
+    if (!isUUID(catId) || !isUUID(userId)) {
       throw new ErrorExt(ec.PUD047);
     }
     if (!weight || isNaN(weight)) {
@@ -192,8 +193,8 @@ router.put("/categories/:id/user/:userId", authCheck, async (req, res, next) => 
 */
 router.delete("/categories/:id", authCheck, async (req, res, next) => {
   try {
-    const catId = Number(req.params.id);
-    if (isNaN(catId)) {
+    const catId = req.params.id;
+    if (!isUUID(catId)) {
       throw new ErrorExt(ec.PUD045);
     }
 
@@ -210,9 +211,9 @@ router.delete("/categories/:id", authCheck, async (req, res, next) => {
 */
 router.delete("/categories/:id/user/:userId", authCheck, async (req, res, next) => {
   try {
-    const catId = Number(req.params.id);
-    const userId = Number(req.params.userId);
-    if (isNaN(catId) || isNaN(userId)) {
+    const catId = req.params.id;
+    const userId = req.params.userId;
+    if (!isUUID(catId) || !isUUID(userId)) {
       throw new ErrorExt(ec.PUD047);
     }
 

--- a/server/src/api/events.ts
+++ b/server/src/api/events.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import * as db from "../db/dbEvents";
 import { authCheck, authKeyCheck } from "../middlewares/authCheck";
+import { isUUID } from "../utils/uuidValidator";
 import { Event, Payment, UserBalance } from "../types/types";
 import { ErrorExt } from "../types/errorExt";
 import * as ec from "../types/errorCodes";
@@ -29,9 +30,9 @@ router.get("/events", authCheck, async (req, res, next) => {
 */
 router.get("/events/:id", authCheck, async (req, res, next) => {
   try {
-    const eventId = Number(req.params.id);
+    const eventId = req.params.id;
     const userId = req.session.userId;
-    if (isNaN(eventId)) {
+    if (!isUUID(eventId)) {
       throw new ErrorExt(ec.PUD013);
     }
 
@@ -70,8 +71,8 @@ router.get("/event-by-name", authKeyCheck, async (req, res, next) => {
 */
 router.get("/events/:id/balances", authCheck, async (req, res, next) => {
   try {
-    const eventId = Number(req.params.id);
-    if (isNaN(eventId)) {
+    const eventId = req.params.id;
+    if (!isUUID(eventId)) {
       throw new ErrorExt(ec.PUD013);
     }
 
@@ -88,8 +89,8 @@ router.get("/events/:id/balances", authCheck, async (req, res, next) => {
 */
 router.get("/events/:id/payments", authKeyCheck, async (req, res, next) => {
   try {
-    const eventId = Number(req.params.id);
-    if (isNaN(eventId)) {
+    const eventId = req.params.id;
+    if (!isUUID(eventId)) {
       throw new ErrorExt(ec.PUD013);
     }
 
@@ -134,9 +135,9 @@ router.post("/events", authCheck, async (req, res, next) => {
 */
 router.post("/events/:id/user/:userId", authCheck, async (req, res, next) => {
   try {
-    const eventId = Number(req.params.id);
-    const userId = Number(req.params.userId);
-    if (isNaN(eventId) || isNaN(userId)) {
+    const eventId = req.params.id;
+    const userId = req.params.userId;
+    if (!isUUID(eventId) || !isUUID(userId)) {
       throw new ErrorExt(ec.PUD015);
     }
 
@@ -153,9 +154,9 @@ router.post("/events/:id/user/:userId", authCheck, async (req, res, next) => {
 */
 router.post("/events/:id/admin/:userId", authCheck, async (req, res, next) => {
   try {
-    const eventId = Number(req.params.id);
-    const userId = Number(req.params.userId);
-    if (isNaN(eventId) || isNaN(userId)) {
+    const eventId = req.params.id;
+    const userId = req.params.userId;
+    if (!isUUID(eventId) || !isUUID(userId)) {
       throw new ErrorExt(ec.PUD015);
     }
     const byUserId = req.session.userId;
@@ -180,8 +181,8 @@ router.post("/events/:id/admin/:userId", authCheck, async (req, res, next) => {
 */
 router.put("/events/:id", authCheck, async (req, res, next) => {
   try {
-    const eventId = Number(req.params.id);
-    if (isNaN(eventId)) {
+    const eventId = req.params.id;
+    if (!isUUID(eventId)) {
       throw new ErrorExt(ec.PUD013);
     }
     if (![undefined, null].includes(req.body.name) && req.body.name.trim() === "") {
@@ -212,8 +213,8 @@ router.put("/events/:id", authCheck, async (req, res, next) => {
 */
 router.delete("/events/:id", authCheck, async (req, res, next) => {
   try {
-    const eventId = Number(req.params.id);
-    if (isNaN(eventId)) {
+    const eventId = req.params.id;
+    if (!isUUID(eventId)) {
       throw new ErrorExt(ec.PUD013);
     }
     const userId = req.session.userId;
@@ -234,9 +235,9 @@ router.delete("/events/:id", authCheck, async (req, res, next) => {
 */
 router.delete("/events/:id/user/:userId", authCheck, async (req, res, next) => {
   try {
-    const eventId = Number(req.params.id);
-    const userId = Number(req.params.userId);
-    if (isNaN(eventId) || isNaN(userId)) {
+    const eventId = req.params.id;
+    const userId = req.params.userId;
+    if (!isUUID(eventId) || !isUUID(userId)) {
       throw new ErrorExt(ec.PUD015);
     }
 
@@ -253,9 +254,9 @@ router.delete("/events/:id/user/:userId", authCheck, async (req, res, next) => {
 */
 router.delete("/events/:id/admin/:userId", authCheck, async (req, res, next) => {
   try {
-    const eventId = Number(req.params.id);
-    const userId = Number(req.params.userId);
-    if (isNaN(eventId) || isNaN(userId)) {
+    const eventId = req.params.id;
+    const userId = req.params.userId;
+    if (!isUUID(eventId) || !isUUID(userId)) {
       throw new ErrorExt(ec.PUD015);
     }
     const byUserId = req.session.userId;

--- a/server/src/api/expenses.ts
+++ b/server/src/api/expenses.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import * as db from "../db/dbExpenses";
 import { authCheck } from "../middlewares/authCheck";
+import { isUUID } from "../utils/uuidValidator";
 import { Expense } from "../types/types";
 import { ErrorExt } from "../types/errorExt";
 import * as ec from "../types/errorCodes";
@@ -15,8 +16,8 @@ const router = express.Router();
 */
 router.get("/expenses", authCheck, async (req, res, next) => {
   try {
-    const eventId = Number(req.query.eventId);
-    if (!req.query.eventId || isNaN(eventId)) {
+    const eventId = req.query.eventId as string;
+    if (!isUUID(eventId)) {
       throw new ErrorExt(ec.PUD013);
     }
 
@@ -33,8 +34,8 @@ router.get("/expenses", authCheck, async (req, res, next) => {
 */
 router.get("/expenses/:id", authCheck, async (req, res, next) => {
   try {
-    const expenseId = Number(req.params.id);
-    if (isNaN(expenseId)) {
+    const expenseId = req.params.id;
+    if (!isUUID(expenseId)) {
       throw new ErrorExt(ec.PUD056);
     }
 
@@ -61,13 +62,13 @@ router.post("/expenses", authCheck, async (req, res, next) => {
     if (!req.body.name || !req.body.amount || !req.body.categoryId || !req.body.payerId) {
       throw new ErrorExt(ec.PUD057);
     }
-    const categoryId = Number(req.body.categoryId);
-    const payerId = Number(req.body.payerId);
+    const categoryId = req.body.categoryId as string;
+    const payerId = req.body.payerId as string;
     const amount = Number(req.body.amount);
-    if (isNaN(categoryId)) {
+    if (!isUUID(categoryId)) {
       throw new ErrorExt(ec.PUD045);
     }
-    if (isNaN(payerId)) {
+    if (!isUUID(payerId)) {
       throw new ErrorExt(ec.PUD089);
     }
     if (isNaN(amount)) {
@@ -91,8 +92,8 @@ router.post("/expenses", authCheck, async (req, res, next) => {
 */
 router.delete("/expenses/:id", authCheck, async (req, res, next) => {
   try {
-    const expenseId = Number(req.params.id);
-    if (isNaN(expenseId)) {
+    const expenseId = req.params.id;
+    if (!isUUID(expenseId)) {
       throw new ErrorExt(ec.PUD056);
     }
     const userId = req.session.userId;

--- a/server/src/calculations.ts
+++ b/server/src/calculations.ts
@@ -22,8 +22,8 @@ export const calculateBalance = (
   const balance: Record[] = [];
   const spending: Record[] = [];
   const expensesOutput: Record[] = [];
-  const categoryWeights = new Map<number, Map<number, number>>();
-  const userNetExpense = new Map<number, number>();
+  const categoryWeights = new Map<string, Map<string, number>>();
+  const userNetExpense = new Map<string, number>();
 
   categories.forEach((category) => {
     if (!category.userWeights) {
@@ -33,15 +33,15 @@ export const calculateBalance = (
     category.userWeights.forEach((weight) => {
       sumCategoryWeights += weight;
     });
-    const adjustedUserWeights = new Map<number, number>();
+    const adjustedUserWeights = new Map<string, number>();
     category.userWeights.forEach((weight, user) => {
       adjustedUserWeights.set(user, weight / sumCategoryWeights);
     });
     categoryWeights.set(category.id, adjustedUserWeights);
   });
 
-  const spendingMap = new Map<number, number>();
-  const expensesOutputMap = new Map<number, number>();
+  const spendingMap = new Map<string, number>();
+  const expensesOutputMap = new Map<string, number>();
   expenses.forEach((expense) => {
     expensesOutputMap.set(
       expense.payer.id,
@@ -53,7 +53,7 @@ export const calculateBalance = (
     );
     const expenseCategory = categoryWeights.get(expense.category.id);
     if (expenseCategory) {
-      expenseCategory.forEach((userWeight: number, userId: number) => {
+      expenseCategory.forEach((userWeight: number, userId: string) => {
         spendingMap.set(
           userId,
           (spendingMap.get(userId) ?? 0) - expense.amount * userWeight
@@ -66,7 +66,7 @@ export const calculateBalance = (
     }
   });
 
-  userNetExpense.forEach((netExpense: number, userId: number) => {
+  userNetExpense.forEach((netExpense: number, userId: string) => {
     const user = users.find((user) => {
       return user.id == userId;
     });

--- a/server/src/db/dbAuthentication.ts
+++ b/server/src/db/dbAuthentication.ts
@@ -10,18 +10,18 @@ import { randomUUID } from "crypto";
  * @param userId
  * @returns User's hashed password
  */
-export const getUserHash = async (usernameEmail?: string, userId?: number) => {
+export const getUserHash = async (usernameEmail?: string, userId?: string) => {
   const request = new sql.Request();
   const userHash = await request
     .input("usernameEmail", sql.NVarChar, usernameEmail)
-    .input("user_id", sql.Int, userId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .execute("get_user_hash")
     .then(data => {
       if (data.recordset.length < 1) {
         return null;
       }
       return {
-        id: data.recordset[0].id as number,
+        id: data.recordset[0].uuid as string,
         hash: data.recordset[0].password as string
       };
     })
@@ -95,10 +95,10 @@ export const newApiKey = async (name: string, hash: string, validFrom?: Date, va
  * @param userId 
  * @param key 
  */
-export const newPasswordResetKey = async (userId: number, key: string) => {
+export const newPasswordResetKey = async (userId: string, key: string) => {
   const request = new sql.Request();
   await request
-    .input("user_id", sql.Int, userId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .input("key", sql.NVarChar, key)
     .execute("new_password_reset_key")
     .catch(err => {

--- a/server/src/db/dbEvents.ts
+++ b/server/src/db/dbEvents.ts
@@ -14,11 +14,11 @@ import * as ec from "../types/errorCodes";
  * @param userId Get user specific information about events (optional)
  * @returns List of events
  */
-export const getEvents = async (userId?: number) => {
+export const getEvents = async (userId?: string) => {
   const request = new sql.Request();
   const events: Event[] = await request
-    .input("event_id", sql.Int, null)
-    .input("user_id", sql.Int, userId)
+    .input("event_uuid", sql.UniqueIdentifier, null)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .execute("get_events")
     .then(data => {
       return parseEvents(data.recordset);
@@ -38,11 +38,11 @@ export const getEvents = async (userId?: number) => {
  * @param userId Get user specific information about event (optional)
  * @returns Event
  */
-export const getEvent = async (eventId: number, userId?: number) => {
+export const getEvent = async (eventId: string, userId?: string) => {
   const request = new sql.Request();
   const events: Event[] = await request
-    .input("event_id", sql.Int, eventId)
-    .input("user_id", sql.Int, userId)
+    .input("event_uuid", sql.UniqueIdentifier, eventId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .execute("get_events")
     .then(data => {
       return parseEvents(data.recordset);
@@ -65,11 +65,11 @@ export const getEvent = async (eventId: number, userId?: number) => {
  * @param userId Get user specific information about event (optional)
  * @returns Event
  */
-export const getEventByName = async (eventName: string, userId?: number) => {
+export const getEventByName = async (eventName: string, userId?: string) => {
   const request = new sql.Request();
   const events: Event[] = await request
     .input("event_name", sql.NVarChar, eventName)
-    .input("user_id", sql.Int, userId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .execute("get_event_by_name")
     .then(data => {
       return parseEvents(data.recordset);
@@ -91,10 +91,10 @@ export const getEventByName = async (eventName: string, userId?: number) => {
  * @param eventId Event ID
  * @returns List of user balances for an event
  */
-export const getEventBalances = async (eventId: number) => {
+export const getEventBalances = async (eventId: string) => {
   const request = new sql.Request();
   const data = await request
-    .input("event_id", sql.Int, eventId)
+    .input("event_uuid", sql.UniqueIdentifier, eventId)
     .execute("get_event_payment_data")
     .then(res => {
       return res.recordsets as sql.IRecordSet<any>[];
@@ -128,10 +128,10 @@ export const getEventBalances = async (eventId: number) => {
  * @param eventId Event ID
  * @returns List of payments for an event
  */
-export const getEventPayments = async (eventId: number) => {
+export const getEventPayments = async (eventId: string) => {
   const request = new sql.Request();
   const data = await request
-    .input("event_id", sql.Int, eventId)
+    .input("event_uuid", sql.UniqueIdentifier, eventId)
     .execute("get_event_payment_data")
     .then(res => {
       return res.recordsets as sql.IRecordSet<any>[];
@@ -167,12 +167,12 @@ export const getEventPayments = async (eventId: number) => {
  * @param description Description of event (optional)
  * @returns Newly created event
  */
-export const createEvent = async (name: string, userId: number, privateEvent: boolean, description?: string) => {
+export const createEvent = async (name: string, userId: string, privateEvent: boolean, description?: string) => {
   const request = new sql.Request();
   const events: Event[] = await request
     .input("name", sql.NVarChar, name)
     .input("description", sql.NVarChar, description)
-    .input("user_id", sql.Int, userId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .input("private", sql.Bit, privateEvent)
     .input("active", sql.Bit, 1)
     .input("usernames_only", sql.Bit, 0)
@@ -196,11 +196,11 @@ export const createEvent = async (name: string, userId: number, privateEvent: bo
  * @param id Event ID
  * @returns True if successful
  */
-export const deleteEvent = async (id: number, userId: number) => {
+export const deleteEvent = async (id: string, userId: string) => {
   const request = new sql.Request();
   const success = await request
-    .input("event_id", sql.Int, id)
-    .input("user_id", sql.Int, userId)
+    .input("event_uuid", sql.UniqueIdentifier, id)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .execute("delete_event")
     .then(() => {
       return true;
@@ -222,11 +222,11 @@ export const deleteEvent = async (id: number, userId: number) => {
  * @param userId 
  * @returns Affected event
  */
-export const addUserToEvent = async (eventId: number, userId: number) => {
+export const addUserToEvent = async (eventId: string, userId: string) => {
   const request = new sql.Request();
   const events: Event[] = await request
-    .input("event_id", sql.Int, eventId)
-    .input("user_id", sql.Int, userId)
+    .input("event_uuid", sql.UniqueIdentifier, eventId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .input("admin", sql.Bit, 0)
     .execute("add_user_to_event")
     .then(data => {
@@ -251,11 +251,11 @@ export const addUserToEvent = async (eventId: number, userId: number) => {
  * @param userId 
  * @returns Affected event
  */
-export const removeUserFromEvent = async (eventId: number, userId: number) => {
+export const removeUserFromEvent = async (eventId: string, userId: string) => {
   const request = new sql.Request();
   const events: Event[] = await request
-    .input("event_id", sql.Int, eventId)  
-    .input("user_id", sql.Int, userId)  
+    .input("event_uuid", sql.UniqueIdentifier, eventId)  
+    .input("user_uuid", sql.UniqueIdentifier, userId)  
     .execute("remove_user_from_event")
     .then(data => {
       return parseEvents(data.recordset);
@@ -278,12 +278,12 @@ export const removeUserFromEvent = async (eventId: number, userId: number) => {
  * @param byUserId UserId of user performing the action
  * @returns Affected event
  */
-export const addUserAsEventAdmin = async (eventId: number, userId: number, byUserId: number) => {
+export const addUserAsEventAdmin = async (eventId: string, userId: string, byUserId: string) => {
   const request = new sql.Request();
   const events: Event[] = await request
-    .input("event_id", sql.Int, eventId)
-    .input("user_id", sql.Int, userId)
-    .input("by_user_id", sql.Int, byUserId)
+    .input("event_uuid", sql.UniqueIdentifier, eventId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
+    .input("by_user_uuid", sql.UniqueIdentifier, byUserId)
     .execute("add_user_as_event_admin")
     .then(data => {
       return parseEvents(data.recordset);
@@ -310,12 +310,12 @@ export const addUserAsEventAdmin = async (eventId: number, userId: number, byUse
  * @param byUserId UserId of user performing the action
  * @returns Affected event
  */
-export const removeUserAsEventAdmin = async (eventId: number, userId: number, byUserId: number) => {
+export const removeUserAsEventAdmin = async (eventId: string, userId: string, byUserId: string) => {
   const request = new sql.Request();
   const events: Event[] = await request
-    .input("event_id", sql.Int, eventId)
-    .input("user_id", sql.Int, userId)
-    .input("by_user_id", sql.Int, byUserId)
+    .input("event_uuid", sql.UniqueIdentifier, eventId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
+    .input("by_user_uuid", sql.UniqueIdentifier, byUserId)
     .execute("remove_user_as_event_admin")
     .then(data => {
       return parseEvents(data.recordset);
@@ -344,11 +344,11 @@ export const removeUserAsEventAdmin = async (eventId: number, userId: number, by
  * @param privateEvent Whether event should be open for all or invite only
  * @returns Edited event
  */
-export const editEvent = async (eventId: number, userId: number, name?: string, description?: string, privateEvent?: boolean) => {
+export const editEvent = async (eventId: string, userId: string, name?: string, description?: string, privateEvent?: boolean) => {
   const request = new sql.Request();
   const events: Event[] = await request
-    .input("event_id", sql.Int, eventId)
-    .input("user_id", sql.Int, userId)
+    .input("event_uuid", sql.UniqueIdentifier, eventId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .input("name", sql.NVarChar, name)
     .input("description", sql.NVarChar, description)
     .input("private", sql.Bit, privateEvent)

--- a/server/src/db/dbExpenses.ts
+++ b/server/src/db/dbExpenses.ts
@@ -9,12 +9,12 @@ import * as ec from "../types/errorCodes";
  * @param eventId 
  * @returns List of expenses
  */
-export const getExpenses = async (eventId: number) => {
+export const getExpenses = async (eventId: string) => {
   const request = new sql.Request();
   const expenses: Expense[] = await request
-    .input("event_id", sql.Int, eventId)
-    .input("user_id", sql.Int, null)
-    .input("expense_id", sql.Int, null)
+    .input("event_uuid", sql.UniqueIdentifier, eventId)
+    .input("user_uuid", sql.UniqueIdentifier, null)
+    .input("expense_uuid", sql.UniqueIdentifier, null)
     .execute("get_expenses")
     .then(data => {
       return parseExpenses(data.recordset);
@@ -37,12 +37,12 @@ export const getExpenses = async (eventId: number) => {
  * @param expenseId 
  * @returns Expense object
  */
-export const getExpense = async (expenseId: number) => {
+export const getExpense = async (expenseId: string) => {
   const request = new sql.Request();
   const expenses: Expense[] = await request
-    .input("event_id", sql.Int, null)
-    .input("user_id", sql.Int, null)
-    .input("expense_id", sql.Int, expenseId)
+    .input("event_uuid", sql.UniqueIdentifier, null)
+    .input("user_uuid", sql.UniqueIdentifier, null)
+    .input("expense_uuid", sql.UniqueIdentifier, expenseId)
     .execute("get_expenses")
     .then(data => {
       return parseExpenses(data.recordset);
@@ -72,14 +72,14 @@ export const getExpense = async (expenseId: number) => {
  * @param payerId 
  * @returns Newly created expense
  */
-export const createExpense = async (name: string, description: string, amount: number, categoryId: number, payerId: number) => {
+export const createExpense = async (name: string, description: string, amount: number, categoryId: string, payerId: string) => {
   const request = new sql.Request();
   const expenses: Expense[] = await request
     .input("name", sql.NVarChar, name)
     .input("description", sql.NVarChar, description)
     .input("amount", sql.Numeric(16, 2), amount)
-    .input("category_id", sql.Int, categoryId)
-    .input("payer_id", sql.Int, payerId)
+    .input("category_uuid", sql.UniqueIdentifier, categoryId)
+    .input("payer_uuid", sql.UniqueIdentifier, payerId)
     .execute("new_expense")
     .then(data => {
       return parseExpenses(data.recordset);
@@ -102,11 +102,11 @@ export const createExpense = async (name: string, description: string, amount: n
  * @param expenseId 
  * @returns True if successful
  */
-export const deleteExpense = async (expenseId: number, userId: number) => {
+export const deleteExpense = async (expenseId: string, userId: string) => {
   const request = new sql.Request();
   const success = await request
-    .input("expense_id", sql.Int, expenseId)
-    .input("user_id", sql.Int, userId)
+    .input("expense_uuid", sql.UniqueIdentifier, expenseId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .execute("delete_expense")
     .then(() => {
       return true;

--- a/server/src/db/dbUsers.ts
+++ b/server/src/db/dbUsers.ts
@@ -40,7 +40,7 @@ export const getUserID = async (email: string) => {
     .input("email", sql.NVarChar, email)
     .execute("get_user_id")
     .then(data => {
-      return data.recordset[0]?.id || null;
+      return data.recordset[0]?.uuid || null;
     })
     .catch(err => {
       throw new ErrorExt(ec.PUD071, err);

--- a/server/src/db/dbUsers.ts
+++ b/server/src/db/dbUsers.ts
@@ -11,10 +11,10 @@ import * as ec from "../types/errorCodes";
  * @param username
  * @returns User data
  */
-export const getUser = async (userId: number | null, username?: string | null) => {
+export const getUser = async (userId: string | null, username?: string | null) => {
   const request = new sql.Request();
   const user: User | null = await request
-    .input("user_id", sql.Int, userId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .input("username", sql.NVarChar, username)
     .execute("get_user")
     .then(data => {
@@ -36,7 +36,7 @@ export const getUser = async (userId: number | null, username?: string | null) =
  */
 export const getUserID = async (email: string) => {
   const request = new sql.Request();
-  const userId: number | null = await request
+  const userId: string | null = await request
     .input("email", sql.NVarChar, email)
     .execute("get_user_id")
     .then(data => {
@@ -53,11 +53,11 @@ export const getUserID = async (email: string) => {
  * @param filter Object containing filters (event ID, user ID to exclude)
  * @returns List of users
  */
-export const getUsers = async (filter?: { eventId?: number, excludeUserId?: number }) => {
+export const getUsers = async (filter?: { eventId?: string, excludeUserId?: string }) => {
   const request = new sql.Request();
   return request
-    .input("event_id", sql.Int, filter?.eventId)
-    .input("exclude_user_id", sql.Int, filter?.excludeUserId)
+    .input("event_uuid", sql.UniqueIdentifier, filter?.eventId)
+    .input("exclude_user_uuid", sql.UniqueIdentifier, filter?.excludeUserId)
     .execute("get_users")
     .then(data => {
       const users: User[] = parseUsers(data.recordset, true);
@@ -74,12 +74,12 @@ export const getUsers = async (filter?: { eventId?: number, excludeUserId?: numb
  * @param eventId 
  * @returns List of expenses
  */
-export const getUserExpenses = async (userId: number, eventId: number) => {
+export const getUserExpenses = async (userId: string, eventId: string) => {
   const request = new sql.Request();
   const expenses: Expense[] = await request
-    .input("event_id", sql.Int, eventId)
-    .input("user_id", sql.Int, userId)
-    .input("expense_id", sql.Int, null)
+    .input("event_uuid", sql.UniqueIdentifier, eventId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
+    .input("expense_uuid", sql.UniqueIdentifier, null)
     .execute("get_expenses")
     .then(data => {
       return parseExpenses(data.recordset);
@@ -138,10 +138,10 @@ export const createUser = async (username: string, firstName: string, lastName: 
  * @param data Data object
  * @returns Edited user
  */
-export const editUser = async (userId: number, data: { username?: string, firstName?: string, lastName?: string, email?: string, phone?: string }) => {
+export const editUser = async (userId: string, data: { username?: string, firstName?: string, lastName?: string, email?: string, phone?: string }) => {
   const request = new sql.Request();
   const user: User | null = await request
-    .input("user_id", sql.Int, userId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .input("username", sql.NVarChar, data.username)
     .input("first_name", sql.NVarChar, data.firstName)
     .input("last_name", sql.NVarChar, data.lastName)
@@ -172,10 +172,10 @@ export const editUser = async (userId: number, data: { username?: string, firstN
  * @param userId 
  * @returns True if successful
  */
-export const deleteUser = async (userId: number) => {
+export const deleteUser = async (userId: string) => {
   const request = new sql.Request();
   const success = request
-    .input("user_id", sql.Int, userId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .execute("delete_user")
     .then(() => {
       return true;
@@ -195,10 +195,10 @@ export const deleteUser = async (userId: number) => {
  * @param hash 
  * @returs True if successful
  */
-export const changePassword = async (userId: number, hash: string) => {
+export const changePassword = async (userId: string, hash: string) => {
   const request = new sql.Request();
   const success = await request
-    .input("user_id", sql.Int, userId)
+    .input("user_uuid", sql.UniqueIdentifier, userId)
     .input("password", sql.NVarChar, hash)
     .execute("change_password")
     .then(() => {

--- a/server/src/parsers/parseCategories.ts
+++ b/server/src/parsers/parseCategories.ts
@@ -20,7 +20,7 @@ export const parseCategories = (catInput: CategoryDB[], target: Target) : Catego
     }
 
     const category: Category = {
-      id: catObj.id,
+      id: catObj.uuid,
       name: catObj.name,
       icon: icon,
       weighted: catObj.weighted
@@ -30,7 +30,7 @@ export const parseCategories = (catInput: CategoryDB[], target: Target) : Catego
       category.users = [];
     }
     else if (target === Target.CALC) {
-      category.userWeights = new Map<number, number>();
+      category.userWeights = new Map<string, number>();
     }
 
     try {
@@ -41,7 +41,7 @@ export const parseCategories = (catInput: CategoryDB[], target: Target) : Catego
           if (target === Target.CLIENT && category.users) {
             category.users.push(
               {
-                id: weight.user_id,
+                id: weight.user_uuid,
                 name: weight.first_name,
                 firstName: weight.first_name,
                 lastName: weight.last_name,
@@ -50,7 +50,7 @@ export const parseCategories = (catInput: CategoryDB[], target: Target) : Catego
             );
           }
           else if (target === Target.CALC && category.userWeights) {
-            category.userWeights.set(weight.user_id, weight.weight);
+            category.userWeights.set(weight.user_uuid, weight.weight);
           }
         });
       }

--- a/server/src/parsers/parseEvents.ts
+++ b/server/src/parsers/parseEvents.ts
@@ -12,17 +12,16 @@ export const parseEvents = (eventsInput: EventDB[]) => {
     const adminIds: AdminIdDB[] = JSON.parse(eventObj.admin_ids) ?? [];
 
     const event: Event = {
-      id: eventObj.id,
+      id: eventObj.uuid,
       name: eventObj.name,
       description: eventObj.description,
       created: eventObj.created,
-      adminIds: adminIds.map(admin => admin.user_id),
+      adminIds: adminIds.map(admin => admin.user_uuid),
       private: eventObj.private,
-      uuid: eventObj.uuid,
-      user: eventObj.user_id && eventObj.in_event !== undefined && eventObj.is_admin !== undefined ? {
-          id: eventObj.user_id,
-          inEvent: eventObj.in_event,
-          isAdmin: eventObj.is_admin
+      user: eventObj.user_uuid && eventObj.user_in_event !== undefined && eventObj.user_is_admin !== undefined ? {
+          id: eventObj.user_uuid,
+          inEvent: eventObj.user_in_event,
+          isAdmin: eventObj.user_is_admin
         } : undefined
     };
     events.push(event);

--- a/server/src/parsers/parseExpenses.ts
+++ b/server/src/parsers/parseExpenses.ts
@@ -19,23 +19,22 @@ export const parseExpenses = (expInput: ExpenseDB[]): Expense[] => {
     }
 
     const expense: Expense = {
-      id: expObj.id,
+      id: expObj.uuid,
       name: expObj.name,
       description: expObj.description,
       amount: expObj.amount,
       dateAdded: expObj.date_added,
       category: {
-        id: expObj.category_id,
+        id: expObj.category_uuid,
         name: expObj.category_name,
         icon: icon
       },
       payer: {
-        id: expObj.payer_id,
+        id: expObj.payer_uuid,
         username: expObj.payer_username,
         name: expObj.payer_first_name,
         firstName: expObj.payer_first_name,
-        lastName: expObj.payer_last_name,
-        uuid: expObj.payer_uuid
+        lastName: expObj.payer_last_name
       }
 		};
 		expenses.push(expense);

--- a/server/src/parsers/parseUsers.ts
+++ b/server/src/parsers/parseUsers.ts
@@ -12,16 +12,15 @@ export const parseUsers = (usersInput: UserDB[], withEventData: boolean): User[]
   const users: User[] = [];
   usersInput.forEach(userObj => {
     const user: User = {
-      id: userObj.id,
+      id: userObj.uuid,
       username: userObj.username,
       name: userObj.first_name,
       firstName: userObj.first_name,
       lastName: userObj.last_name,
       email: userObj.email,
       created: userObj.created,
-      uuid: userObj.uuid,
-      event: withEventData && userObj.event_id && userObj.event_joined_date ? {
-        id: userObj.event_id,
+      event: withEventData && userObj.event_uuid && userObj.event_joined_date ? {
+        id: userObj.event_uuid,
         isAdmin: userObj.event_admin ?? false,
         joinedDate: userObj.event_joined_date
       } : undefined
@@ -54,7 +53,7 @@ export const parseUsers = (usersInput: UserDB[], withEventData: boolean): User[]
  */
 export const parseUser = (userObj: UserDB): User => {
   return {
-    id: userObj.id,
+    id: userObj.uuid,
     username: userObj.username,
     name: userObj.first_name,
     firstName: userObj.first_name,
@@ -62,6 +61,5 @@ export const parseUser = (userObj: UserDB): User => {
     email: userObj.email,
     phone: userObj.phone_number,
     created: userObj.created,
-    uuid: userObj.uuid
   };
 };

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -114,11 +114,11 @@ export const PUD012: ErrorCode = {
 };
 
 /**
- * PUD-013: Event ID must be a number (400)
+ * PUD-013: Event ID must be a valid UUID (400)
  */
 export const PUD013: ErrorCode = {
   code: "PUD-013",
-  message: "Event ID must be a number",
+  message: "Event ID must be a valid UUID",
   status: 400
 };
 
@@ -132,20 +132,20 @@ export const PUD014: ErrorCode = {
 };
 
 /**
- * PUD-015: Event ID and user ID must be numbers (400)
+ * PUD-015: Event ID and user ID must be valid UUIDs (400)
  */
 export const PUD015: ErrorCode = {
   code: "PUD-015",
-  message: "Event ID and user ID must be numbers",
+  message: "Event ID and user ID must be valid UUIDs",
   status: 400
 };
 
 /**
- * PUD-016: User ID must be a number (400)
+ * PUD-016: User ID must be a valid UUID (400)
  */
 export const PUD016: ErrorCode = {
   code: "PUD-016",
-  message: "User ID must be a number",
+  message: "User ID must be a valid UUID",
   status: 400
 };
 
@@ -427,11 +427,11 @@ export const PUD044: ErrorCode = {
 };
 
 /**
- * PUD-045: Category ID must be a number (400)
+ * PUD-045: Category ID must be a valid UUID (400)
  */
 export const PUD045: ErrorCode = {
   code: "PUD-045",
-  message: "Category ID must be a number",
+  message: "Category ID must be a valid UUID",
   status: 400
 };
 
@@ -445,11 +445,11 @@ export const PUD046: ErrorCode = {
 };
 
 /**
- * PUD-047: Category ID and user ID must be numbers (400)
+ * PUD-047: Category ID and user ID must be valid UUIDs (400)
  */
 export const PUD047: ErrorCode = {
   code: "PUD-047",
-  message: "Category ID and user ID must be numbers",
+  message: "Category ID and user ID must be valid UUIDs",
   status: 400
 };
 
@@ -526,11 +526,11 @@ export const PUD055: ErrorCode = {
 };
 
 /**
- * PUD-056: Expense ID must be a number (400)
+ * PUD-056: Expense ID must be a valid UUID (400)
  */
 export const PUD056: ErrorCode = {
   code: "PUD-056",
-  message: "Expense ID must be a number",
+  message: "Expense ID must be a valid UUID",
   status: 400
 };
 
@@ -835,11 +835,11 @@ export const PUD088: ErrorCode = {
 };
 
 /**
- * PUD-089: Payer ID must be a number (400)
+ * PUD-089: Payer ID must be a valid UUID (400)
  */
 export const PUD089: ErrorCode = {
   code: "PUD-089",
-  message: "Payer ID must be a number",
+  message: "Payer ID must be a valid UUID",
   status: 400
 };
 

--- a/server/src/types/express-session.d.ts
+++ b/server/src/types/express-session.d.ts
@@ -3,12 +3,11 @@ import "express-session";
 declare module "express-session" {
   export interface SessionData {
     authenticated: boolean;
-    userId: number;
-    uuid: string;
+    userId: string;
     username: string;
   }
   export interface Store {
     destroyExpired(): void;
-    destroyAll(userId: number, callback?: ((err?: any) => void)): void;
+    destroyAll(userId: string, callback?: ((err?: any) => void)): void;
   }
 }

--- a/server/src/types/types.ts
+++ b/server/src/types/types.ts
@@ -1,8 +1,7 @@
 import { CategoryIcon } from "./enums";
 
 export type User = {
-  id: number,
-  uuid: string,
+  id: string,
   name: string,
   username: string,
   firstName?: string,
@@ -11,35 +10,34 @@ export type User = {
   phone?: string,
   created?: Date,
   event?: {
-    id: number,
+    id: string,
     isAdmin: boolean,
     joinedDate: Date
   }
 }
 
 export type Event = {
-  id: number,
-  uuid: string,
+  id: string,
   name: string,
   description: string,
   created: Date,
-  adminIds: number[],
+  adminIds: string[],
   private: boolean,
   user?: {
-    id: number,
+    id: string,
     inEvent: boolean,
     isAdmin: boolean
   }
 };
 
 export type Category = {
-  id: number,
+  id: string,
   name: string,
   icon: CategoryIcon,
   weighted: boolean,
-  userWeights?: Map<number, number>,
+  userWeights?: Map<string, number>,
   users?: {
-    id: number,
+    id: string,
     name: string,
     firstName?: string,
     lastName?: string,
@@ -48,13 +46,13 @@ export type Category = {
 }
 
 export type Expense = {
-  id: number,
+  id: string,
   name: string,
   description: string,
   amount: number,
   dateAdded: Date,
   category: {
-    id: number,
+    id: string,
     name: string,
     icon: CategoryIcon
   },

--- a/server/src/types/typesDB.ts
+++ b/server/src/types/typesDB.ts
@@ -1,5 +1,30 @@
+export type UserDB = {
+  uuid: string,
+  username: string,
+  first_name: string,
+  last_name: string,
+  email: string,
+  phone_number: string,
+  created: Date,
+  event_uuid?: string,
+  event_admin?: boolean,
+  event_joined_date?: Date
+}
+
+export type EventDB = {
+  uuid: string,
+  name: string,
+  description: string,
+  created: Date,
+  admin_ids: string,
+  private: boolean,
+  user_uuid?: string,
+  user_in_event?: boolean,
+  user_is_admin?: boolean
+}
+
 export type CategoryDB = {
-  id: number,
+  uuid: string,
   name: string,
   icon: string,
   weighted: boolean,
@@ -7,57 +32,30 @@ export type CategoryDB = {
 }
 
 export type UserWeightDB = {
-  user_id: number,
+  user_uuid: string,
   first_name: string,
   last_name: string,
   weight: number
 }
 
 export type ExpenseDB = {
-  id: number,
+  uuid: string,
   name: string,
   description: string,
   amount: number,
   category_id: number,
+  category_uuid: string,
   category_name: string,
   category_icon: string;
   date_added: Date,
-  payer_id: number,
+  payer_uuid: string,
   payer_username: string,
   payer_first_name: string,
-  payer_last_name: string,
-  payer_uuid: string
-}
-
-export type UserDB = {
-  id: number,
-  username: string,
-  first_name: string,
-  last_name: string,
-  email: string,
-  phone_number: string,
-  created: Date,
-  uuid: string,
-  event_id?: number,
-  event_admin?: boolean,
-  event_joined_date?: Date
-}
-
-export type EventDB = {
-  id: number,
-  name: string,
-  description: string,
-  created: Date,
-  admin_ids: string,
-  private: boolean,
-  uuid: string,
-  user_id?: number,
-  in_event?: boolean,
-  is_admin?: boolean
+  payer_last_name: string
 }
 
 export type AdminIdDB = {
-  user_id: number
+  user_uuid: string
 }
 
 export type APIKeyDB = {

--- a/server/src/utils/setUserDisplayNames.ts
+++ b/server/src/utils/setUserDisplayNames.ts
@@ -4,7 +4,7 @@ import { User } from "../types/types";
  * Set a user's display name as the first and last names combined in cases where first name is shared with another user
  * @param users List of users
  */
-export const setUserUniqueNames = (users: User[] | { id: number, name: string, [key: string]: any }[]) => {
+export const setUserUniqueNames = (users: User[] | { id: string, name: string, [key: string]: any }[]) => {
   for (const user of users) {
     const sameFirstName = users.some(otherUser => {
       return otherUser.firstName === user.firstName && otherUser.id !== user.id;

--- a/server/src/utils/uuidValidator.ts
+++ b/server/src/utils/uuidValidator.ts
@@ -1,0 +1,5 @@
+const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const isUUID = (uuid: string) => {
+  return uuidRegex.test(uuid);
+};

--- a/server/tests/authentication.test.ts
+++ b/server/tests/authentication.test.ts
@@ -93,6 +93,22 @@ describe("authentication", async () => {
     });
   });
 
+  /* -------------------------- */
+  /* POST /requestpasswordreset */
+  /* -------------------------- */
+  describe("POST /requestpasswordreset", async () => {
+    test("fail when requesting password reset", async () => {
+      const res = await request(app)
+        .post("/api/requestpasswordreset")
+        .send({
+          email: "a@mikane.no"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD073.code);
+    });
+  });
+
   /* ----------------- */
   /* POST /generatekey */
   /* ----------------- */

--- a/server/tests/categories.test.ts
+++ b/server/tests/categories.test.ts
@@ -106,7 +106,7 @@ describe("categories", async () => {
           name: "Test category 2",
           icon: "shopping_cart",
           weighted: false,
-          eventId: 15
+          eventId: "56e901ad-374f-4e1d-92f1-d02dd22d11d3"
         });
 
       expect(res.status).toEqual(404);
@@ -146,7 +146,7 @@ describe("categories", async () => {
     test("fail find categories with invalid event ID", async () => {
       const res = await request(app)
         .get("/api/categories")
-        .query("eventId=" + 15)
+        .query("eventId=56e901ad-374f-4e1d-92f1-d02dd22d11d3")
         .set("Cookie", authToken);
 
       expect(res.status).toEqual(404);
@@ -157,7 +157,7 @@ describe("categories", async () => {
   /* ------------------- */
   /* GET /categories/:id */
   /* ------------------- */
-  describe("GET /categories", async () => {
+  describe("GET /categories/:id", async () => {
     test("should get category", async () => {
       const res = await request(app)
         .get("/api/categories/" + category.id)
@@ -169,7 +169,7 @@ describe("categories", async () => {
 
     test("fail find category", async () => {
       const res = await request(app)
-        .get("/api/categories/" + 30)
+        .get("/api/categories/56e901ad-374f-4e1d-92f1-d02dd22d11d3")
         .set("Cookie", authToken);
 
       expect(res.status).toEqual(404);
@@ -180,7 +180,7 @@ describe("categories", async () => {
   /* ------------------- */
   /* PUT /categories/:id */
   /* ------------------- */
-  describe("PUT /categories", async () => {
+  describe("PUT /categories/:id", async () => {
     test("should edit category", async () => {
       const res = await request(app)
         .put("/api/categories/" + category.id)
@@ -196,7 +196,7 @@ describe("categories", async () => {
 
     test("fail edit category with invalid ID", async () => {
       const res = await request(app)
-        .put("/api/categories/" + 30)
+        .put("/api/categories/56e901ad-374f-4e1d-92f1-d02dd22d11d3")
         .set("Cookie", authToken)
         .send({
           name: "New test category name"
@@ -311,6 +311,29 @@ describe("categories", async () => {
 
       expect(res.status).toEqual(200);
       expect(res.body.users.length).toEqual(0);
+    });
+  });
+
+  /* ---------------------- */
+  /* DELETE /categories/:id */
+  /* ---------------------- */
+  describe("DELETE /categories/:id", async () => {
+    test("should delete category", async () => {
+      const res = await request(app)
+        .delete("/api/categories/" + category.id)
+        .set("Cookie", authToken);
+
+      expect(res.status).toEqual(200);
+      expect(res.body.success).toEqual(true);
+    });
+
+    test("confirm deleted category does not exist", async () => {
+      const res = await request(app)
+        .get("/api/categories/" + category.id)
+        .set("Cookie", authToken);
+
+      expect(res.status).toEqual(404);
+      expect(res.body.code).toEqual(ec.PUD007.code);
     });
   });
 });

--- a/server/tests/events.test.ts
+++ b/server/tests/events.test.ts
@@ -168,7 +168,7 @@ describe("events", async () => {
 
     test("should not find event", async () => {
       const res = await request(app)
-        .get("/api/events/" + 3)
+        .get("/api/events/56e901ad-374f-4e1d-92f1-d02dd22d11d3")
         .set("Cookie", authToken);
 
       expect(res.status).toEqual(404);

--- a/server/tests/expenses.test.ts
+++ b/server/tests/expenses.test.ts
@@ -144,7 +144,7 @@ describe("expenses", async () => {
     test("fail finding expenses for non-existing event", async () => {
       const res = await request(app)
         .get("/api/expenses")
-        .query("eventId=" + 15)
+        .query("eventId=56e901ad-374f-4e1d-92f1-d02dd22d11d3")
         .set("Cookie", authToken);
 
       expect(res.status).toEqual(404);
@@ -167,7 +167,7 @@ describe("expenses", async () => {
 
     test("fail finding expense", async () => {
       const res = await request(app)
-        .get("/api/expenses/" + 35)
+        .get("/api/expenses/56e901ad-374f-4e1d-92f1-d02dd22d11d3")
         .set("Cookie", authToken);
 
       expect(res.status).toEqual(404);

--- a/server/tests/users.test.ts
+++ b/server/tests/users.test.ts
@@ -150,7 +150,7 @@ describe("users", async () => {
 
     test("should not find user", async () => {
       const res = await request(app)
-        .get("/api/users/" + 3)
+        .get("/api/users/56e901ad-374f-4e1d-92f1-d02dd22d11d3")
         .set("Cookie", authToken);
 
       expect(res.status).toEqual(404);


### PR DESCRIPTION
Change from using sequential IDs as resource identifiers to using UUIDs. This encompasses both API endpoint parameters, and frontend URLs. Database will still use sequential IDs as primary identifiers internally.

Changelog:
  - [x] Update database to use UUID for input parameters
  - [x] Update backend to use UUID as ID
  - [x] Update frontend to use UUID as ID
  - [x] Update documentation

Closes #149 