### PR TITLE
User avatar support via Gravatar

### DIFF
--- a/app/mikane/src/app/features/menu/menu.component.html
+++ b/app/mikane/src/app/features/menu/menu.component.html
@@ -4,7 +4,15 @@
 	</span>
 	<split-button #splitButton [onClick]="onAccountClick">
 		<div button>
-			<mat-icon class="account">account_circle</mat-icon>
+			<img *ngIf="avatarURL" [src]="avatarURL" class="avatar" />
+		</div>
+		<div dropdown-button>
+			<div *ngIf="breakpointService.isMobile() | async; else dropdownArrow">
+				<img *ngIf="avatarURL" [src]="avatarURL" class="avatar" />
+			</div>
+			<ng-template #dropdownArrow>
+				<mat-icon dropdown-button class="dropdown-button">arrow_drop_down</mat-icon>
+			</ng-template>
 		</div>
 		<split-button-item *splitButtonItem [onClick]="onAccountClick" icon="person" text="Account"></split-button-item>
 		<split-button-item *splitButtonItem [onClick]="logout" icon="logout" text="Log out"></split-button-item>

--- a/app/mikane/src/app/features/menu/menu.component.scss
+++ b/app/mikane/src/app/features/menu/menu.component.scss
@@ -4,10 +4,15 @@
 	margin-right: 12px;
 }
 
-.account {
+.avatar {
+	height: 36px;
+	width: 36px;
 	vertical-align: middle;
-	font-size: 30px;
-	margin-bottom: 4px;
-	height: auto;
-	width: auto;
+	margin-bottom: 3px;
+	border-radius: 50%;
+  object-fit: cover;
+}
+
+.dropdown-button {
+	vertical-align: middle;
 }

--- a/app/mikane/src/app/features/menu/menu.component.ts
+++ b/app/mikane/src/app/features/menu/menu.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule, NgIf } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import { Component, ViewChild } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { Router } from '@angular/router';
@@ -15,11 +15,12 @@ import { SplitButtonItemDirective } from '../split-button/split-button-item/spli
 	templateUrl: './menu.component.html',
 	styleUrls: ['./menu.component.scss'],
 	standalone: true,
-	imports: [CommonModule, NgIf, MatIconModule, SplitButtonComponent, SplitButtonItemComponent, SplitButtonItemDirective],
+	imports: [CommonModule, MatIconModule, SplitButtonComponent, SplitButtonItemComponent, SplitButtonItemDirective],
 })
 export class MenuComponent {
 	@ViewChild('splitButton') private splitButton: SplitButtonComponent;
 	username: string;
+	avatarURL: string;
 
 	constructor(
 		private router: Router,
@@ -32,6 +33,7 @@ export class MenuComponent {
 		this.authService.getCurrentUser().subscribe({
 			next: (user) => {
 				this.username = user.username;
+				this.avatarURL = user.avatarURL;
 			},
 			error: (err: ApiError) => {
 				this.messageService.showError('Failed to get user');

--- a/app/mikane/src/app/features/split-button/split-button-item/split-button-item.component.scss
+++ b/app/mikane/src/app/features/split-button/split-button-item/split-button-item.component.scss
@@ -17,7 +17,6 @@ a {
 	font-size: 1rem;
 	width: 1rem;
 	height: 1rem;
-	top: 2px;
 	margin-right: 10px;
 }
 

--- a/app/mikane/src/app/features/split-button/split-button.component.html
+++ b/app/mikane/src/app/features/split-button/split-button.component.html
@@ -3,7 +3,12 @@
 		<ng-content select="[button]"></ng-content>
 	</mat-button-toggle>
 	<mat-button-toggle (click)="toggleDropdown()" class="split-button" [ngClass]="{ 'mobile': breakpointService.isMobile() | async }">
-		<mat-icon>arrow_drop_down</mat-icon>
+		<div #ref>
+			<ng-content select="[dropdown-button]"></ng-content>
+		</div>
+		<mat-icon *ngIf="!ref.children.length">
+			arrow_drop_down
+		</mat-icon>
 	</mat-button-toggle>
 </mat-button-toggle-group>
 

--- a/app/mikane/src/app/pages/account/account.component.html
+++ b/app/mikane/src/app/pages/account/account.component.html
@@ -9,4 +9,5 @@
 <div class="account-settings">
 	<user-settings [ngClass]="(breakpointService.isMobile() | async) ? 'section-mobile' : 'section-pc'"></user-settings>
 	<change-password [ngClass]="(breakpointService.isMobile() | async) ? 'section-mobile' : 'section-pc'"></change-password>
+	<danger-zone [ngClass]="(breakpointService.isMobile() | async) ? 'section-mobile' : 'section-pc'"></danger-zone>
 </div>

--- a/app/mikane/src/app/pages/account/account.component.html
+++ b/app/mikane/src/app/pages/account/account.component.html
@@ -7,7 +7,7 @@
 	<menu></menu>
 </mat-toolbar>
 <div class="account-settings">
-	<user-settings [ngClass]="(breakpointService.isMobile() | async) ? 'section-mobile' : 'section-pc'"></user-settings>
+	<user-settings [ngClass]="(breakpointService.isMobile() | async) ? 'section-mobile' : 'section-pc first'"></user-settings>
 	<change-password [ngClass]="(breakpointService.isMobile() | async) ? 'section-mobile' : 'section-pc'"></change-password>
-	<danger-zone [ngClass]="(breakpointService.isMobile() | async) ? 'section-mobile' : 'section-pc'"></danger-zone>
+	<danger-zone [ngClass]="(breakpointService.isMobile() | async) ? 'section-mobile' : 'section-pc last'"></danger-zone>
 </div>

--- a/app/mikane/src/app/pages/account/account.component.scss
+++ b/app/mikane/src/app/pages/account/account.component.scss
@@ -8,9 +8,17 @@
 	align-items: center;
 
 	.section-pc {
-		margin: 2em;
+		margin: 1em 2em;
 		width: 40em;
 		min-width: 30em;
+
+		&.first {
+			margin-top: 2em;
+		}
+
+		&.last {
+			margin-bottom: 2em;
+		}
 	}
 
 	.section-mobile {

--- a/app/mikane/src/app/pages/account/account.component.scss
+++ b/app/mikane/src/app/pages/account/account.component.scss
@@ -9,7 +9,7 @@
 
 	.section-pc {
 		margin: 2em;
-		width: 36em;
+		width: 40em;
 		min-width: 30em;
 	}
 

--- a/app/mikane/src/app/pages/account/account.component.ts
+++ b/app/mikane/src/app/pages/account/account.component.ts
@@ -9,6 +9,7 @@ import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.servic
 import { MenuComponent } from 'src/app/features/menu/menu.component';
 import { ChangePasswordComponent } from './change-password/change-password.component';
 import { UserSettingsComponent } from './user/user-settings.component';
+import { DangerZoneComponent } from './danger-zone/danger-zone.component';
 
 @Component({
 	selector: 'account',
@@ -24,6 +25,7 @@ import { UserSettingsComponent } from './user/user-settings.component';
 		MatIconModule,
 		UserSettingsComponent,
 		ChangePasswordComponent,
+		DangerZoneComponent,
 		MenuComponent,
 	],
 })

--- a/app/mikane/src/app/pages/account/change-password/change-password.component.html
+++ b/app/mikane/src/app/pages/account/change-password/change-password.component.html
@@ -98,7 +98,7 @@
 			</mat-form-field>
 		</div>
 		<br />
-		<mat-card-actions class="reset-actions">
+		<mat-card-actions>
 			<button type="submit" mat-raised-button color="primary">Change password</button>
 		</mat-card-actions>
 	</form>

--- a/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.html
+++ b/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.html
@@ -1,0 +1,36 @@
+
+<mat-card *ngIf="(breakpointService.isMobile() | async) === false; else mobileView">
+	<mat-card-header>
+		<div mat-card-avatar>
+			<mat-icon aria-hidden="false">key</mat-icon>
+		</div>
+		<mat-card-title>Danger zone</mat-card-title>
+	</mat-card-header>
+	<mat-card-content>
+		<ng-container *ngTemplateOutlet="dangerZoneContent"></ng-container>
+	</mat-card-content>
+</mat-card>
+
+<ng-template #mobileView>
+	<div class="title-mobile">Danger zone</div>
+	<div class="danger-zone-mobile">
+		<ng-container *ngTemplateOutlet="dangerZoneContent"></ng-container>
+	</div>
+</ng-template>
+
+<ng-template #dangerZoneContent>
+  <div>
+    <h2>Delete your account</h2>
+  </div>
+  <div class="delete-account-text">
+    When the deletion process is initiated by clicking the button below you'll get a confirmation email with the deletion link. Think hard before you press this link!
+    <br><br>
+    If you decide to proceed, you should know: once an account has been deleted you cannot go back. There is no undo button. The data is gone permanently and no one can get it back for you.
+  </div>
+  <mat-card-actions>
+    <button type="button" mat-stroked-button color="warn" (click)="deleteUser()">
+      <mat-icon>delete</mat-icon>
+      Send deletion confirmation email
+    </button>
+  </mat-card-actions>
+</ng-template>

--- a/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.html
+++ b/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.html
@@ -23,7 +23,7 @@
     <h2>Delete your account</h2>
   </div>
   <div class="delete-account-text">
-    When the deletion process is initiated by clicking the button below you'll get a confirmation email with the deletion link. Think hard before you press this link!
+    When the deletion process is initiated by clicking the button below you will get a confirmation email with the deletion link. Think hard before you press this link!
     <br><br>
     If you decide to proceed, you should know: once an account has been deleted you cannot go back. There is no undo button. The data is gone permanently and no one can get it back for you.
   </div>

--- a/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.html
+++ b/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.html
@@ -29,8 +29,8 @@
   </div>
   <mat-card-actions>
     <button type="button" mat-stroked-button color="warn" (click)="deleteUser()">
-      <mat-icon>delete</mat-icon>
-      Send deletion confirmation email
+      <mat-icon>email</mat-icon>
+      Send delete account email
     </button>
   </mat-card-actions>
 </ng-template>

--- a/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.scss
+++ b/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.scss
@@ -2,21 +2,22 @@
 	display: flex;
 	align-items: center;
 	height: 50px;
-	margin-bottom: 36px;
+	margin-bottom: 20px;
 	padding-left: 16px;
 	background-color: rgba(24, 24, 24, 1);
 	border-top: 1px solid #333333;
 	stroke: #333333;
 }
 
-.input-field {
-	width: 100%;
-}
-
-.change-password-mobile {
+.danger-zone-mobile {
 	margin-left: 10vw;
 	margin-right: 10vw;
-	margin-bottom: 20px;
+  margin-bottom: 20px;
+}
+
+.delete-account-text {
+  color: #d9d9d9;
+  margin-bottom: 12px;
 }
 
 .mdc-card__actions {
@@ -24,7 +25,7 @@
 }
 
 .mat-mdc-card-content {
-	padding: 0 54px 16px !important;
+	padding: 0 55px 16px !important;
 }
 
 .mat-mdc-card-header {

--- a/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.scss
+++ b/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.scss
@@ -12,7 +12,7 @@
 .danger-zone-mobile {
 	margin-left: 10vw;
 	margin-right: 10vw;
-  margin-bottom: 20px;
+  margin-bottom: 30px;
 }
 
 .delete-account-text {

--- a/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.scss
+++ b/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.scss
@@ -17,7 +17,7 @@
 
 .delete-account-text {
   color: #d9d9d9;
-  margin-bottom: 12px;
+  margin-bottom: 18px;
 }
 
 .mdc-card__actions {

--- a/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.ts
+++ b/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.ts
@@ -1,0 +1,98 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialog } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { Router } from '@angular/router';
+import { NEVER, Subscription, switchMap } from 'rxjs';
+import { ConfirmDialogComponent } from 'src/app/features/confirm-dialog/confirm-dialog.component';
+import { AuthService } from 'src/app/services/auth/auth.service';
+import { MessageService } from 'src/app/services/message/message.service';
+import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.service';
+import { User, UserService } from 'src/app/services/user/user.service';
+import { ApiError } from 'src/app/types/apiError.type';
+
+@Component({
+	selector: 'danger-zone',
+	templateUrl: './danger-zone.component.html',
+	styleUrls: ['./danger-zone.component.scss'],
+	standalone: true,
+	imports: [CommonModule, MatCardModule, MatIconModule, FormsModule, ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatButtonModule],
+})
+export class DangerZoneComponent implements OnInit, OnDestroy {
+	private subscription: Subscription;
+	private deleteSubscription: Subscription;
+
+	currentUser: User;
+
+	constructor(
+		private userService: UserService,
+		private authService: AuthService,
+		private router: Router,
+		public dialog: MatDialog,
+		private messageService: MessageService,
+		public breakpointService: BreakpointService
+	) {}
+
+	ngOnInit(): void {
+		this.subscription = this.authService
+			.getCurrentUser()
+			.pipe(
+				switchMap((user) => {
+					return this.userService.loadUserById(user?.id);
+				})
+			)
+			.subscribe({
+				next: (user) => {
+					this.currentUser = user;
+				},
+				error: (err: ApiError) => {
+					this.messageService.showError('Failed to get user');
+					console.error('something went wrong getting user on user setting page: ' + err?.error?.message);
+				},
+			});
+	}
+
+	deleteUser() {
+		const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+			width: '400px',
+			data: {
+				title: 'Send delete account email',
+				content: 'Are you sure you want to send the delete account email?',
+				confirm: 'Yes, I am sure',
+			},
+			autoFocus: false,
+		});
+
+		this.deleteSubscription = dialogRef
+			.afterClosed()
+			.pipe(
+				switchMap((confirm) => {
+					if (confirm) {
+						return this.userService.deleteUser(this.currentUser.id);
+					} else {
+						return NEVER;
+					}
+				})
+			)
+			.subscribe({
+				next: () => {
+					this.messageService.showSuccess('User deleted successfully');
+					this.router.navigate(['/login']);
+				},
+				error: (err: ApiError) => {
+					this.messageService.showError('Failed to delete user');
+					console.error('something went wrong while deleting user', err?.error?.message);
+				},
+			});
+	}
+
+	ngOnDestroy(): void {
+		this.subscription?.unsubscribe();
+		this.deleteSubscription?.unsubscribe();
+	}
+}

--- a/app/mikane/src/app/pages/account/user/user-settings.component.html
+++ b/app/mikane/src/app/pages/account/user/user-settings.component.html
@@ -73,6 +73,14 @@
 						<mat-error *ngIf="editUserForm.get('phone')?.invalid">Invalid phonenumber</mat-error>
 					</mat-form-field>
 				</div>
+				<div *ngIf="!editMode" class="setting-row">
+					<span class="user-padding">
+						Avatar:
+					</span>
+					<span class="account-avatar-link user-details">
+						Manage with <a href="https://www.gravatar.com/" target="_blank">Gravatar</a>
+					</span>
+				</div>
 				<br />
 				<mat-card-actions class="setting-row">
 					<button *ngIf="!editMode" type="button" mat-raised-button color="primary" (click)="toggleEditMode()">
@@ -88,10 +96,6 @@
 							Save changes
 						</button>
 					</div>
-					<button *ngIf="!editMode" type="button" mat-button color="warn" (click)="deleteUser()">
-						<mat-icon>delete</mat-icon>
-						Delete account
-					</button>
 				</mat-card-actions>
 			</form>
 		</div>
@@ -167,6 +171,14 @@
 					<mat-error *ngIf="editUserForm.get('phone')?.invalid">Invalid phone number</mat-error>
 				</mat-form-field>
 			</div>
+			<div *ngIf="!editMode">
+				<span class="user-property-title">
+					Avatar:
+				</span>
+				<span class="account-avatar-link user-details">
+					Manage with <a href="https://www.gravatar.com/" target="_blank">Gravatar</a>
+				</span>
+			</div>
 			<span class="buttons">
 				<button *ngIf="!editMode" type="button" mat-raised-button color="primary" (click)="toggleEditMode()">
 					<mat-icon>edit</mat-icon>
@@ -181,10 +193,6 @@
 						Save changes
 					</button>
 				</div>
-				<button *ngIf="!editMode" type="button" mat-button color="warn" (click)="deleteUser()">
-					<mat-icon>delete</mat-icon>
-					Delete account
-				</button>
 			</span>
 		</form>
 	</div>

--- a/app/mikane/src/app/pages/account/user/user-settings.component.scss
+++ b/app/mikane/src/app/pages/account/user/user-settings.component.scss
@@ -66,3 +66,12 @@
 	padding: 16px 16px 0;
 }
 
+.account-avatar-link a {
+	color: #d99db5;
+	text-decoration: none;
+
+	&:hover {
+		color: #dec3ce;
+		text-decoration: underline;
+	}
+}

--- a/app/mikane/src/app/pages/account/user/user-settings.component.ts
+++ b/app/mikane/src/app/pages/account/user/user-settings.component.ts
@@ -7,9 +7,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
-import { Router } from '@angular/router';
-import { NEVER, Subscription, switchMap } from 'rxjs';
-import { ConfirmDialogComponent } from 'src/app/features/confirm-dialog/confirm-dialog.component';
+import { Subscription, switchMap } from 'rxjs';
 import { AuthService } from 'src/app/services/auth/auth.service';
 import { MessageService } from 'src/app/services/message/message.service';
 import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.service';
@@ -26,7 +24,6 @@ import { Phonenumber } from 'src/app/types/phonenumber.type';
 })
 export class UserSettingsComponent implements OnInit, OnDestroy {
 	private subscription: Subscription;
-	private deleteSubscription: Subscription;
 	private editSubscription: Subscription;
 
 	private phone!: Phonenumber;
@@ -46,7 +43,6 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
 	constructor(
 		private userService: UserService,
 		private authService: AuthService,
-		private router: Router,
 		public dialog: MatDialog,
 		private messageService: MessageService,
 		public breakpointService: BreakpointService
@@ -104,47 +100,12 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
 			});
 	}
 
-	deleteUser() {
-		const dialogRef = this.dialog.open(ConfirmDialogComponent, {
-			width: '400px',
-			data: {
-				title: 'Delete account',
-				content: 'Are you sure you want to delete your account? Warning: This is not reversible!',
-				confirm: 'Yes, I am sure',
-			},
-			autoFocus: false,
-		});
-
-		this.deleteSubscription = dialogRef
-			.afterClosed()
-			.pipe(
-				switchMap((confirm) => {
-					if (confirm) {
-						return this.userService.deleteUser(this.currentUser.id);
-					} else {
-						return NEVER;
-					}
-				})
-			)
-			.subscribe({
-				next: () => {
-					this.messageService.showSuccess('User deleted successfully');
-					this.router.navigate(['/login']);
-				},
-				error: (err: ApiError) => {
-					this.messageService.showError('Failed to delete user');
-					console.error('something went wrong while deleting user', err?.error?.message);
-				},
-			});
-	}
-
 	toggleEditMode() {
 		this.editMode = !this.editMode;
 	}
 
 	ngOnDestroy(): void {
 		this.subscription?.unsubscribe();
-		this.deleteSubscription?.unsubscribe();
 		this.editSubscription?.unsubscribe();
 	}
 }

--- a/app/mikane/src/app/services/user/user.service.ts
+++ b/app/mikane/src/app/services/user/user.service.ts
@@ -14,6 +14,7 @@ export interface User {
 	email?: string;
 	phone?: string;
 	created?: Date;
+	avatarURL?: string;
 	eventInfo?: {
 		id: string;
 		isAdmin: boolean;

--- a/app/mikane/src/index.html
+++ b/app/mikane/src/index.html
@@ -7,7 +7,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="icon" type="image/png" href="favicon.png" />
 		<link rel="manifest" href="manifest.webmanifest" />
-		<meta name="theme-color" content="#1976d2" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" />
 		<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet" />
 		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />

--- a/app/mikane/src/manifest.webmanifest
+++ b/app/mikane/src/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
-  "name": "mikane",
-  "short_name": "mikane",
-  "theme_color": "#1976d2",
+  "name": "Mikane",
+  "short_name": "Mikane",
+  "theme_color": "#161417",
   "background_color": "#fafafa",
   "display": "standalone",
   "scope": "./",

--- a/app/mikane/src/styles.scss
+++ b/app/mikane/src/styles.scss
@@ -202,6 +202,11 @@ input:-webkit-autofill:active {
 	color: rgba(255, 255, 255, 0.7) !important;
 }
 
+// Prevent mat dialog removing backgrounds when page is scrolled down
+.cdk-global-scrollblock {
+	overflow-y: initial;
+}
+
 // Prevent hover-selection on tooltips
 mat-tooltip-component {
 	user-select: none;

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -39,6 +39,10 @@
                     "username": {
                       "type": "string",
                       "example": "testuser"
+                    },
+                    "avatarURL": {
+                      "type": "string",
+                      "example": "https://gravatar.com/avatar/aaaa"
                     }
                   }
                 }
@@ -860,7 +864,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success - 'user' property is only present when a logged in user makes the request",
+            "description": "Success - 'userInfo' property is only present when a logged in user makes the request",
             "content": {
               "application/json": {
                 "schema": {
@@ -997,7 +1001,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success - 'user' property is only present when a logged in user makes the request",
+            "description": "Success - 'userInfo' property is only present when a logged in user makes the request",
             "content": {
               "application/json": {
                 "schema": {
@@ -1229,7 +1233,7 @@
           "Events"
         ],
         "summary": "Get an event's balance information",
-        "description": "Get an event's balance information for all users (includes 'user in event' information)",
+        "description": "Get an event's balance information for all users (includes 'eventInfo' information)",
         "operationId": "getEventBalances",
         "security": [
           { "cookieAuth": [] }
@@ -1718,7 +1722,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success - 'user' property is only present when a logged in user makes the request",
+            "description": "Success - 'userInfo' property is only present when a logged in user makes the request",
             "content": {
               "application/json": {
                 "schema": {
@@ -2790,6 +2794,10 @@
           "created": {
             "type": "date-time",
             "example": "2023-01-20T18:00:00"
+          },
+          "avatarURL": {
+            "type": "string",
+            "example": "https://gravatar.com/avatar/aaaa"
           }
         }
       },
@@ -2815,6 +2823,10 @@
           "created": {
             "type": "date-time",
             "example": "2023-01-20T18:00:00"
+          },
+          "avatarURL": {
+            "type": "string",
+            "example": "https://gravatar.com/avatar/aaaa"
           },
           "eventInfo": {
             "type": "object",
@@ -2876,6 +2888,10 @@
           "created": {
             "type": "date-time",
             "example": "2023-01-20T18:00:00"
+          },
+          "avatarURL": {
+            "type": "string",
+            "example": "https://gravatar.com/avatar/aaaa"
           }
         }
       },
@@ -2913,6 +2929,10 @@
           "created": {
             "type": "date-time",
             "example": "2023-01-20T18:00:00"
+          },
+          "avatarURL": {
+            "type": "string",
+            "example": "https://gravatar.com/avatar/aaaa"
           }
         }
       },

--- a/server/src/api/authentication.ts
+++ b/server/src/api/authentication.ts
@@ -25,8 +25,9 @@ router.get("/login", (req, res, next) => {
     }
     return res.status(200).json({
       authenticated: req.session.authenticated,
+      id: req.session.userId,
       username: req.session.username,
-      id: req.session.userId
+      avatarURL: req.session.avatarURL
     });
   }
   catch (err) {
@@ -94,6 +95,7 @@ router.post("/login", async (req, res, next) => {
     req.session.authenticated = true;
     req.session.userId = user.id;
     req.session.username = user.username;
+    req.session.avatarURL = user.avatarURL;
     console.log(`User ${user.username} signing in...`, req.sessionID);
     res.status(200).json({
       authenticated: req.session.authenticated,

--- a/server/src/api/expenses.ts
+++ b/server/src/api/expenses.ts
@@ -74,6 +74,9 @@ router.post("/expenses", authCheck, async (req, res, next) => {
     if (isNaN(amount)) {
       throw new ErrorExt(ec.PUD088);
     }
+    if (amount < 0) {
+      throw new ErrorExt(ec.PUD030);
+    }
 
     const expense: Expense = await db.createExpense(req.body.name, req.body.description, amount, categoryId, payerId);
     res.status(200).send(expense);

--- a/server/src/api/users.ts
+++ b/server/src/api/users.ts
@@ -172,11 +172,11 @@ router.put("/users/:id", authCheck, async (req, res, next) => {
       throw new ErrorExt(ec.PUD059);
     }
     const data = {
-      username: req.body.username,
-      firstName: req.body.firstName,
-      lastName: req.body.lastName,
-      email: req.body.email,
-      phone: req.body.phone
+      username: req.body.username as string | undefined,
+      firstName: req.body.firstName as string | undefined,
+      lastName: req.body.lastName as string | undefined,
+      email: req.body.email as string | undefined,
+      phone: req.body.phone as string | undefined
     };
 
     const user = await db.editUser(userId, data);

--- a/server/src/calculations.ts
+++ b/server/src/calculations.ts
@@ -149,7 +149,7 @@ export const calculatePayments = (
     payments.push({
       sender: largestDebtor.user,
       receiver: largestLeander.user,
-      amount: paymentAmount,
+      amount: roundAmount(paymentAmount),
     });
   }
 

--- a/server/src/db/dbEvents.ts
+++ b/server/src/db/dbEvents.ts
@@ -179,7 +179,7 @@ export const getEventPayments = async (eventId: string) => {
       throw new ErrorExt(ec.PUD061);
     }
 
-    const users: User[] = parseUsers(res[0].rows, true);
+    const users: User[] = parseUsers(res[0].rows, false);
     const categories: Category[] = parseCategories(res[1].rows, Target.CALC);
     const expenses: Expense[] = parseExpenses(res[2].rows);
 

--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -9,7 +9,7 @@ else {
 }
 
 interface EnvVariables {
-  NODE_ENV: string;
+  NODE_ENV: "dev" | "production" | "test";
   IN_PROD: boolean;
   PORT: number;
   ALLOWED_ORIGIN: string;
@@ -52,7 +52,7 @@ const validateEnvVariables = (env: NodeJS.ProcessEnv): EnvVariables => {
   }
 
   return {
-    NODE_ENV: env.NODE_ENV || "dev",
+    NODE_ENV: (env.NODE_ENV === "dev" || env.NODE_ENV === "production" || env.NODE_ENV === "test") ? env.NODE_ENV : "dev",
     IN_PROD: env.NODE_ENV === "production",
     PORT: parseInt(env.PORT ?? "") || 3002,
     ALLOWED_ORIGIN: env.ALLOWED_ORIGIN || "http://localhost:4200",

--- a/server/src/parsers/parseUsers.ts
+++ b/server/src/parsers/parseUsers.ts
@@ -1,4 +1,5 @@
 import { setUserUniqueNames } from "../utils/setUserDisplayNames";
+import { getGravatarURL } from "../utils/gravatar";
 import { User } from "../types/types";
 import { UserDB } from "../types/typesDB";
 
@@ -11,6 +12,7 @@ import { UserDB } from "../types/typesDB";
 export const parseUsers = (usersInput: UserDB[], withEventData: boolean): User[] => {
   const users: User[] = [];
   usersInput.forEach(userObj => {
+    const avatarURL = getGravatarURL(userObj.email, { size: 200, default: "mp" });
     const user: User = {
       id: userObj.id,
       username: userObj.username,
@@ -19,6 +21,7 @@ export const parseUsers = (usersInput: UserDB[], withEventData: boolean): User[]
       lastName: userObj.last_name,
       email: userObj.email,
       created: userObj.created,
+      avatarURL: avatarURL,
       eventInfo: withEventData && userObj.event_id && userObj.event_joined_time ? {
         id: userObj.event_id,
         isAdmin: userObj.event_admin ?? false,
@@ -52,6 +55,7 @@ export const parseUsers = (usersInput: UserDB[], withEventData: boolean): User[]
  * @returns User object
  */
 export const parseUser = (userObj: UserDB): User => {
+  const avatarURL = getGravatarURL(userObj.email, { size: 200, default: "mp" });
   return {
     id: userObj.id,
     username: userObj.username,
@@ -61,5 +65,6 @@ export const parseUser = (userObj: UserDB): User => {
     email: userObj.email,
     phone: userObj.phone_number,
     created: userObj.created,
+    avatarURL: avatarURL
   };
 };

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -276,17 +276,14 @@ export const PUD029: ErrorCode = {
   log: true
 };
 
-// OPEN
 /**
- * PUD-030: TDB (500)
+ * PUD-030: Expense amount cannot be negative (400)
  */
 export const PUD030: ErrorCode = {
   code: "PUD-030",
-  message: "TDB",
-  status: 500,
-  log: true
+  message: "Expense amount cannot be negative",
+  status: 400
 };
-// OPEN END
 
 /**
  * PUD-031: get_events (500)

--- a/server/src/types/express-session.d.ts
+++ b/server/src/types/express-session.d.ts
@@ -5,6 +5,7 @@ declare module "express-session" {
     authenticated: boolean;
     userId: string;
     username: string;
+    avatarURL: string;
   }
   export interface Store {
     destroyExpired(): void;

--- a/server/src/types/types.ts
+++ b/server/src/types/types.ts
@@ -9,6 +9,7 @@ export type User = {
   email?: string;
   phone?: string;
   created?: Date;
+  avatarURL?: string;
   eventInfo?: {
     id: string;
     isAdmin: boolean;

--- a/server/src/utils/gravatar.ts
+++ b/server/src/utils/gravatar.ts
@@ -1,0 +1,46 @@
+import { createHash } from "crypto";
+
+type GravatarOptions = {
+  size?: number,
+  rating?: "g" | "pg" | "r" | "x",
+  default?: "404" | "mp" | "identicon" | "monsterid" | "wavatar" | "retro" | "robohash" | "blank",
+  forceDefault?: boolean
+};
+
+const BASE_URL = "https://www.gravatar.com/avatar/";
+
+const generateMD5 = (input: string) => {
+  return createHash("md5").update(input).digest("hex");
+};
+
+const convertToRecord = (options: GravatarOptions): Record<string, string> => {
+  const params: Record<string, string> = {};
+  
+  if (options.size) {
+    params.s = options.size.toString();
+  }
+  if (options.rating) {
+    params.r = options.rating;
+  }
+  if (options.default) {
+    params.d = options.default;
+  }
+  if (options.forceDefault) {
+    params.f = options.forceDefault ? "y" : "n";
+  }
+  
+  return params;
+};
+
+export const getGravatarURL = (email: string, options?: GravatarOptions) => {
+  const fixedEmail = email.trim().toLowerCase();
+  const hash = generateMD5(fixedEmail);
+
+  const url = new URL(BASE_URL + hash);
+  if (options) {
+    const queryParams = new URLSearchParams(convertToRecord(options));
+    url.search = queryParams.toString();
+  }
+
+  return url.href;
+};


### PR DESCRIPTION
Implements user avatars with the Gravatar API. Also fixes some other smaller issues.

Changelog:
- Change generic user profile avatar in the header to the Gravatar avatar associated with the account's email
  - Should the user not have a custom Gravatar, the mystery person Gravatar will be used instead 
- Split-button component now offers content projection for the rightside button as well, with a fallback to the standard arrow should it not be projected.
  - When viewed on mobile, this arrow is now replaced by the user's avatar
- Remove 'eventInfo' from every user in the GET events/:id/payments endpoint
- Prevent negative expense amounts when creating new expenses
- Add missing rounding to 2 decimals for payments
- Move delete account button into own danger zone component
- Change web app theme-color from blue to dark grey

Closes #188, closes #181, closes #189, closes #190