### PR TITLE
Run postgres functions upon container start

### DIFF
--- a/server/bash_scripts/custom-entrypoint.sh
+++ b/server/bash_scripts/custom-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Check if the data directory exists and contains the PG_VERSION file
+if [ -f /var/lib/postgresql/data/PG_VERSION ]; then
+
+  echo "Database already exists - will run db_run_functions.sh"
+  ./bash_scripts/db_run_functions.sh & exec usr/local/bin/docker-entrypoint.sh postgres
+
+else
+
+  echo "Database does not already exist - will start postgres as normal"
+  exec usr/local/bin/docker-entrypoint.sh postgres
+
+fi

--- a/server/bash_scripts/db_init.sh
+++ b/server/bash_scripts/db_init.sh
@@ -22,7 +22,7 @@ fi
 echo "Successfully inserted tables into $DATABASE_NAME"
 
 # Run all scripts within the db_scripts folder
-echo "Running all procedure scripts"
+echo "Running all function scripts"
 for script_file in db_scripts/*.sql; do
   echo "Running script: $script_file"
   psql -U "$USER" -d "$DATABASE_NAME" -f "$script_file"

--- a/server/bash_scripts/db_run_functions.sh
+++ b/server/bash_scripts/db_run_functions.sh
@@ -1,0 +1,19 @@
+USER=${DB_USER:-postgres}
+
+# Wait to be sure that PostgreSQL database is ready
+echo "Waiting for PostgreSQL server to be ready before running functions"
+bash ./bash_scripts/wait-until.sh "psql -U '${USER}' -d mikane -c 'SELECT '\''database mikane is running'\'';'" 60
+exit_status1=$?
+if [ "${exit_status1}" -gt 0 ]; then
+  echo "Could not connect to mikane, aborting running function scripts"
+  exit 1
+fi
+echo "PostgreSQL server is ready to run functions"
+
+# Run all scripts within the db_scripts folder
+echo "Container startup: Running all function scripts"
+for script_file in db_scripts/*.sql; do
+  echo "Running script: $script_file"
+  psql -U "$USER" -d mikane -f "$script_file"
+done
+echo "Scripts execution completed"

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -28,4 +28,5 @@ services:
       - ./bash_scripts/db_init.sh:/docker-entrypoint-initdb.d/db_init.sh
       - ./bash_scripts:/bash_scripts
       - ./db_scripts:/db_scripts
+    entrypoint: bash_scripts/custom-entrypoint.sh
     restart: unless-stopped


### PR DESCRIPTION
When the postgres database container starts, even if a database data directory already exists, all functions will now still run.