### PR TITLE
feat: Show user avatars, and more

### DIFF
--- a/app/mikane/src/app/pages/category/category.component.html
+++ b/app/mikane/src/app/pages/category/category.component.html
@@ -24,7 +24,8 @@
 						<!-- Name Column -->
 						<ng-container matColumnDef="name">
 							<th mat-header-cell *matHeaderCellDef>Participant</th>
-							<td mat-cell *matCellDef="let user">
+							<td mat-cell *matCellDef="let user" class="user">
+								<img [src]="user.avatarURL" class="avatar" />
 								{{ user.name }}
 							</td>
 							<td mat-footer-cell *matFooterCellDef>
@@ -40,7 +41,10 @@
 										required
 									>
 										<mat-option *ngFor="let user of filterUsers(category.id)" [value]="user.id">
-											{{ user.name }}
+											<span class="user">
+												<img [src]="user.avatarURL" class="avatar option" />
+												{{ user.name }}
+											</span>
 										</mat-option>
 									</mat-select>
 								</mat-form-field>

--- a/app/mikane/src/app/pages/category/category.component.scss
+++ b/app/mikane/src/app/pages/category/category.component.scss
@@ -28,3 +28,22 @@
 .category-icon {
 	margin-right: 20px;
 }
+
+.user {
+	display: flex;
+	align-items: center;
+	height: inherit;
+
+	.avatar {
+		position: relative;
+		width: 24px;
+		height: 24px;
+		margin-right: 16px;
+		border-radius: 50%;
+		object-fit: cover;
+
+		&.option {
+			margin-right: 12px;
+		}
+	}
+}

--- a/app/mikane/src/app/pages/expenditures/expenditure-dialog/expenditure-dialog.component.html
+++ b/app/mikane/src/app/pages/expenditures/expenditure-dialog/expenditure-dialog.component.html
@@ -39,7 +39,10 @@
 			<mat-label>Payer</mat-label>
 			<mat-select formControlName="payer" required>
 				<mat-option *ngFor="let user of users" [value]="user.id">
-					{{ user.name }}
+					<span class="user">
+						<img [src]="user.avatarURL" class="avatar" />
+						{{ user.name }}
+					</span>
 				</mat-option>
 			</mat-select>
 			<mat-error *ngIf="addExpenseForm.get('payer')?.errors?.['required']"> Payer is required </mat-error>

--- a/app/mikane/src/app/pages/expenditures/expenditure-dialog/expenditure-dialog.component.scss
+++ b/app/mikane/src/app/pages/expenditures/expenditure-dialog/expenditure-dialog.component.scss
@@ -1,3 +1,17 @@
 mat-form-field {
 	width: 100%;
 }
+
+.user {
+	display: flex;
+	align-items: center;
+
+	.avatar {
+		position: relative;
+		width: 24px;
+		height: 24px;
+		margin-right: 12px;
+		border-radius: 50%;
+		object-fit: cover;
+	}
+}

--- a/app/mikane/src/app/pages/participant/participant.component.html
+++ b/app/mikane/src/app/pages/participant/participant.component.html
@@ -19,6 +19,7 @@
 				<mat-expansion-panel-header>
 					<mat-panel-title class="user-panel-title">
 						<div class="first">Name</div>
+						<div class="count">Number of expenses</div>
 						<div>Costs</div>
 						<div>Expenses</div>
 						<div>Balance</div>
@@ -32,9 +33,11 @@
 			>
 				<mat-expansion-panel-header>
 					<mat-panel-title>
-						<div class="first">
+						<div class="user first">
+							<img [src]="userWithBalance.user.avatarURL" class="avatar" />
 							{{ userWithBalance.user.name }}
 						</div>
+						<div class="count">{{ userWithBalance.expensesCount }}</div>
 						<div>{{ userWithBalance.spending | currency : "" : "" : "1.2-2" : "no" }} kr</div>
 						<div>{{ userWithBalance.expenses | currency : "" : "" : "1.2-2" : "no" }} kr</div>
 						<div class="amount-color">{{ userWithBalance.balance | currency : "" : "" : "1.2-2" : "no" }} kr</div>
@@ -106,9 +109,16 @@
 						<button mat-raised-button color="accent" (click)="createExpenseDialog(userWithBalance.user.id, dataSources[i])">
 							Add expense
 						</button>
-						<button mat-raised-button type="button" color="warn" (click)="deleteUserDialog(userWithBalance.user.id)">
+						<button *ngIf="userWithBalance.expensesCount === 0; else noRemoveButton" mat-raised-button type="button" color="warn" (click)="deleteUserDialog(userWithBalance.user.id)">
 							Remove User
 						</button>
+						<ng-template #noRemoveButton>
+							<span matTooltip="Cannot remove users with expenses in event" style="padding: 8px 0">
+								<button mat-stroked-button disabled>
+									Remove User
+								</button>
+							</span>
+						</ng-template>
 					</div>
 				</ng-template>
 			</mat-expansion-panel>

--- a/app/mikane/src/app/pages/participant/participant.component.scss
+++ b/app/mikane/src/app/pages/participant/participant.component.scss
@@ -13,6 +13,25 @@
 	padding-top: 10px;
 }
 
+.user {
+	display: flex;
+	align-items: center;
+
+	.avatar {
+		position: relative;
+		width: 24px;
+		height: 24px;
+		margin-right: 16px;
+		border-radius: 50%;
+		object-fit: cover;
+	}
+}
+
+.count {
+	width: 20%;
+	text-align: left;
+}
+
 .header-mobile {
 	display: flex;
 	align-items: center;

--- a/app/mikane/src/app/pages/participant/participant.component.ts
+++ b/app/mikane/src/app/pages/participant/participant.component.ts
@@ -8,6 +8,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { ActivatedRoute } from '@angular/router';
 import { BehaviorSubject, Observable, Subject, Subscription, combineLatest, forkJoin, map, of, switchMap, takeUntil } from 'rxjs';
 import { ConfirmDialogComponent } from 'src/app/features/confirm-dialog/confirm-dialog.component';
@@ -38,6 +39,7 @@ import { ParticipantDialogComponent } from './user-dialog/participant-dialog.com
 		MatExpansionModule,
 		MatProgressSpinnerModule,
 		MatTableModule,
+		MatTooltipModule,
 		ProgressSpinnerComponent,
 		MatCardModule,
 		CurrencyPipe,
@@ -212,7 +214,7 @@ export class ParticipantComponent implements OnInit, OnDestroy {
 			width: '380px',
 			data: {
 				title: 'Remove User',
-				content: 'Are you sure you want to remove this user? All of their expenses will be permanently deleted!',
+				content: 'Are you sure you want to remove this user?',
 				confirm: 'I am sure',
 			},
 		});

--- a/app/mikane/src/app/pages/participant/user-dialog/participant-dialog.component.html
+++ b/app/mikane/src/app/pages/participant/user-dialog/participant-dialog.component.html
@@ -4,7 +4,12 @@
 		<mat-form-field appearance="fill">
 			<mat-label>User</mat-label>
 			<mat-select formControlName="users" multiple>
-				<mat-option *ngFor="let user of users" [value]="user">{{ user.name }}</mat-option>
+				<mat-option *ngFor="let user of users" [value]="user">
+					<span class="user">
+						<img [src]="user.avatarURL" class="avatar" />
+						{{ user.name }}
+					</span>
+				</mat-option>
 			</mat-select>
 		</mat-form-field>
 	</form>

--- a/app/mikane/src/app/pages/participant/user-dialog/participant-dialog.component.scss
+++ b/app/mikane/src/app/pages/participant/user-dialog/participant-dialog.component.scss
@@ -1,3 +1,17 @@
 mat-form-field {
 	width: 100%;
 }
+
+.user {
+	display: flex;
+	align-items: center;
+
+	.avatar {
+		position: relative;
+		width: 24px;
+		height: 24px;
+		margin-right: 12px;
+		border-radius: 50%;
+		object-fit: cover;
+	}
+}

--- a/app/mikane/src/app/pages/payment-structure/payment-structure.component.html
+++ b/app/mikane/src/app/pages/payment-structure/payment-structure.component.html
@@ -8,14 +8,18 @@
 	<mat-accordion *ngIf="senders.length > 0; else noPayments" class="payments" multi>
 		<mat-expansion-panel *ngFor="let sender of senders" expanded="true">
 			<mat-expansion-panel-header (click)="panelToggled()">
-				<mat-panel-title>{{ sender.sender.name }}</mat-panel-title>
+				<div class="user">
+					<img [src]="sender.sender.avatarURL" class="avatar" />
+					<mat-panel-title>{{ sender.sender.name }}</mat-panel-title>
+				</div>
 			</mat-expansion-panel-header>
 			<ng-template matExpansionPanelContent>
 				<table mat-table class="expense-table" [dataSource]="sender.receivers">
 					<!-- Name Column -->
 					<ng-container matColumnDef="name">
 						<th mat-header-cell *matHeaderCellDef>Owes money to</th>
-						<td mat-cell *matCellDef="let receiver">
+						<td mat-cell *matCellDef="let receiver" class="user">
+							<img [src]="receiver.receiver.avatarURL" class="avatar" />
 							{{ receiver.receiver.name }}
 						</td>
 					</ng-container>

--- a/app/mikane/src/app/pages/payment-structure/payment-structure.component.scss
+++ b/app/mikane/src/app/pages/payment-structure/payment-structure.component.scss
@@ -8,3 +8,18 @@
 .amount-cell {
 	width: 50%;
 }
+
+.user {
+	display: flex;
+	align-items: center;
+	height: inherit;
+
+	.avatar {
+		position: relative;
+		width: 24px;
+		height: 24px;
+		margin-right: 16px;
+		border-radius: 50%;
+		object-fit: cover;
+	}
+}

--- a/app/mikane/src/styles.scss
+++ b/app/mikane/src/styles.scss
@@ -132,13 +132,14 @@ a.nostyle:visited {
 
 .user-list {
 	mat-panel-title {
-		display: contents;
+		display: flex;
+		align-items: center;
 		div {
 			width: 30%;
 			text-align: right;
 		}
 		div.first {
-			width: 10%;
+			min-width: 150px;
 			text-align: left;
 		}
 	}
@@ -198,6 +199,11 @@ input:-webkit-autofill:active {
 // Change color of input labels
 .mdc-text-field--focused:not(.mdc-text-field--disabled) .mdc-floating-label {
 	color: rgba(255, 255, 255, 0.7) !important;
+}
+
+// Change color of selected items in dropdown
+.mdc-list-item--selected .mdc-list-item__primary-text {
+	color: #ff589a !important;
 }
 
 // Prevent mat dialog removing backgrounds when page is scrolled down

--- a/server/db_scripts/get_categories.sql
+++ b/server/db_scripts/get_categories.sql
@@ -54,6 +54,7 @@ begin
           'username', u.username,
           'first_name', u.first_name,
           'last_name', u.last_name,
+          'email', u.email,
           'weight', wt.weight
         ))
       from

--- a/server/db_scripts/remove_user_from_event.sql
+++ b/server/db_scripts/remove_user_from_event.sql
@@ -27,20 +27,30 @@ begin
     raise exception 'User not found' using errcode = 'P0008';
   end if;
 
+  if exists (select 1 from expense ex inner join category c on ex.category_id = c.id where c.event_id = ip_event_id and ex.payer_id = ip_user_id) then
+    raise exception 'Cannot remove user from event, as the user has one or more expenses in the event' using errcode = 'P0114';
+  end if;
+
   select count(*) into tmp_number_of_admins from user_event ue where ue.event_id = ip_event_id and ue."admin" = true;
   if exists (select 1 from user_event ue where ue.event_id = ip_event_id and ue.user_id = ip_user_id and ue."admin" = true) and (tmp_number_of_admins < 2) then
     raise exception 'Cannot remove user from event, as the user is the only event admin and all events need at least one event admin' using errcode = 'P0098';
   end if;
 
+  -- Remove user from the event
   delete from user_event ue where ue.event_id = ip_event_id and ue.user_id = ip_user_id;
 
-  -- Delete expenses belonging to user from event
-  delete from expense e
-  where e.id in (
-    select ex.id
-    from expense ex
-      inner join category c on ex.category_id = c.id
-    where c.event_id = ip_event_id and ex.payer_id = ip_user_id
+  -- Remove user from all categories belonging to the event
+  delete from user_category duc
+  where (duc.category_id, duc.user_id) in (
+    select
+      uc.category_id, uc.user_id
+    from
+      user_category uc
+      inner join category c on c.id = uc.category_id
+      inner join "event" e on e.id = c.event_id
+    where
+      e.id = ip_event_id and
+      uc.user_id = ip_user_id
   );
 
   return query

--- a/server/src/db/dbEvents.ts
+++ b/server/src/db/dbEvents.ts
@@ -304,6 +304,8 @@ export const removeUserFromEvent = async (eventId: string, userId: string) => {
         throw new ErrorExt(ec.PUD008, err);
       else if (err.code === "P0098")
         throw new ErrorExt(ec.PUD098, err);
+      else if (err.code === "P0114")
+        throw new ErrorExt(ec.PUD114, err);
       else
         throw new ErrorExt(ec.PUD040, err);
     });

--- a/server/src/errorHandler.ts
+++ b/server/src/errorHandler.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { ErrorExt } from "./types/errorExt";
 
-export const errorHandler = (err: ErrorExt | Error, req: Request, res: Response, next: NextFunction) => {
+export const errorHandler = (err: ErrorExt | Error, _req: Request, res: Response, next: NextFunction) => {
   if (!err) {
     return next();
   }

--- a/server/src/parsers/parseCategories.ts
+++ b/server/src/parsers/parseCategories.ts
@@ -1,4 +1,5 @@
 import { setDisplayNames } from "../utils/setDisplayNames";
+import { getGravatarURL } from "../utils/gravatar";
 import { Category, User } from "../types/types";
 import { CategoryDB, UserNamesDB } from "../types/typesDB";
 import { Target, CategoryIcon } from "../types/enums";
@@ -36,21 +37,22 @@ export const parseCategories = (catInput: CategoryDB[], target: Target, usersInE
 
     try {
       if (catObj.user_weights) {
-        catObj.user_weights.forEach(weight => {
+        catObj.user_weights.forEach(user => {
           if (target === Target.CLIENT && category.users) {
             category.users.push(
               {
-                id: weight.user_id,
-                name: weight.first_name,
-                username: weight.username,
-                firstName: weight.first_name,
-                lastName: weight.last_name,
-                weight: weight.weight
+                id: user.user_id,
+                name: user.first_name,
+                username: user.username,
+                firstName: user.first_name,
+                lastName: user.last_name,
+                avatarURL: getGravatarURL(user.email, { size: 50, default: "mp" }),
+                weight: user.weight
               }
             );
           }
           else if (target === Target.CALC && category.userWeights) {
-            category.userWeights.set(weight.user_id, weight.weight);
+            category.userWeights.set(user.user_id, user.weight);
           }
         });
       }

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -1076,3 +1076,12 @@ export const PUD113: ErrorCode = {
   message: "Not a valid phone number",
   status: 400
 };
+
+/**
+ * PUD-114: Cannot remove user from event, as the user has one or more expenses in the event (400)
+ */
+export const PUD114: ErrorCode = {
+  code: "PUD-114",
+  message: "Cannot remove user from event, as the user has one or more expenses in the event",
+  status: 400
+};

--- a/server/src/types/types.ts
+++ b/server/src/types/types.ts
@@ -44,7 +44,8 @@ export type Category = {
     username?: string;
     firstName?: string;
     lastName?: string;
-    weight?: number;
+    avatarURL: string;
+    weight: number;
   }[];
 };
 

--- a/server/src/types/typesDB.ts
+++ b/server/src/types/typesDB.ts
@@ -36,6 +36,7 @@ export type CategoryDB = {
     username: string;
     first_name: string,
     last_name: string,
+    email: string,
     weight: number
   }[]
 };


### PR DESCRIPTION
Changelog (frontend):
- Show user avatars in these additional locations:
  - Participants page
  - 'Add users to event' dropdown
  - User list for a category
  - 'Choose participants' dropdown for a category
  - Payments page
  - 'Add expense' payer dropdown
- Add number of expenses to participants page also in full view
- Disable 'remove user' button in the participants page, if the user has one or more expenses in the event
- Ligten text color of selected value in dropdowns, as it was too dark

Changelog (backend):
- Do not allow users to be removed from an event if they have one or more expenses in it
- Return users' avatar URL when retrieving categories
- Sort the event payments array so that the logged in user is first in the list

Closes #222, closes #223 