### PR TITLE
feat: Endpoints for editing expense/category

### DIFF
--- a/server/db_scripts/edit_category.sql
+++ b/server/db_scripts/edit_category.sql
@@ -1,7 +1,8 @@
 drop function if exists edit_category;
 create or replace function edit_category(
   ip_category_id uuid,
-  ip_name varchar(255)
+  ip_name varchar(255),
+  ip_icon varchar(255)
 )
 returns table (
   id uuid,
@@ -22,7 +23,8 @@ begin
   update
     category c
   set
-    "name" = ip_name
+    "name" = coalesce(ip_name, c.name),
+    icon = coalesce(ip_icon, c.icon)
   where
     c.id = ip_category_id;
 

--- a/server/db_scripts/edit_expense.sql
+++ b/server/db_scripts/edit_expense.sql
@@ -1,0 +1,60 @@
+drop function if exists edit_expense;
+create or replace function edit_expense(
+  ip_expense_id uuid,
+  ip_name varchar(255),
+  ip_description varchar(255),
+  ip_amount numeric(16, 2),
+  ip_category_id uuid,
+  ip_payer_id uuid
+)
+returns table (
+  id uuid,
+  name varchar(255),
+  description varchar(255),
+  amount numeric(16, 2),
+  created timestamp,
+  category_id uuid,
+  category_name varchar(255),
+  category_icon varchar(255),
+  payer_id uuid,
+  payer_first_name varchar(255),
+  payer_last_name varchar(255),
+  payer_username varchar(255),
+  payer_email varchar(255)
+) as
+$$
+begin
+
+  if not exists (select 1 from expense ex where ex.id = ip_expense_id) then
+    raise exception 'Expense not found' using errcode = 'P0084';
+  end if;
+
+  if ip_category_id is not null and not exists (select 1 from category c where c.id = ip_category_id) then
+    raise exception 'Category not found' using errcode = 'P0007';
+  end if;
+
+  if ip_payer_id is not null and not exists (select 1 from "user" u where u.id = ip_payer_id) then
+    raise exception 'User not found' using errcode = 'P0008';
+  end if;
+
+  if ip_payer_id is not null and not exists (select ue.user_id from user_event ue inner join category c on ue.event_id = c.event_id where c.id = coalesce(ip_category_id, c.id) and ue.user_id = ip_payer_id) then
+    raise exception 'User cannot pay for expense as user is not in event' using errcode = 'P0062';
+  end if;
+
+  update
+    expense e
+  set
+    name = coalesce(ip_name, e.name),
+    description = coalesce(ip_description, e.description),
+    amount = coalesce(ip_amount, e.amount),
+    category_id = coalesce(ip_category_id, e.category_id),
+    payer_id = coalesce(ip_payer_id, e.payer_id)
+  where
+    e.id = ip_expense_id;
+  
+  return query
+  select * from get_expenses(null, null, ip_expense_id);
+
+end;
+$$
+language plpgsql;

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -2962,7 +2962,7 @@
       }
     },
     "/validation/user/username": {
-      "get": {
+      "post": {
         "tags": [
           "Validation"
         ],
@@ -3029,7 +3029,7 @@
       }
     },
     "/validation/user/email": {
-      "get": {
+      "post": {
         "tags": [
           "Validation"
         ],
@@ -3046,7 +3046,7 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "username": {
+                  "email": {
                     "type": "string",
                     "example": "a@b.com"
                   }
@@ -3096,7 +3096,7 @@
       }
     },
     "/validation/user/phone": {
-      "get": {
+      "post": {
         "tags": [
           "Validation"
         ],
@@ -3113,7 +3113,7 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "username": {
+                  "phone": {
                     "type": "string",
                     "example": "12131415"
                   }
@@ -3163,7 +3163,7 @@
       }
     },
     "/validation/event/name": {
-      "get": {
+      "post": {
         "tags": [
           "Validation"
         ],
@@ -3180,7 +3180,7 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "username": {
+                  "name": {
                     "type": "string",
                     "example": "Text event"
                   }
@@ -3230,7 +3230,7 @@
       }
     },
     "/validation/category/name": {
-      "get": {
+      "post": {
         "tags": [
           "Validation"
         ],
@@ -3247,7 +3247,7 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "username": {
+                  "name": {
                     "type": "string",
                     "example": "Text event"
                   },

--- a/server/src/api/categories.ts
+++ b/server/src/api/categories.ts
@@ -117,7 +117,7 @@ router.post("/categories/:id/user/:userId", authCheck, async (req, res, next) =>
 /* --- */
 
 /*
-* Rename a category
+* Edit a category
 */
 router.put("/categories/:id", authCheck, async (req, res, next) => {
   try {
@@ -125,14 +125,25 @@ router.put("/categories/:id", authCheck, async (req, res, next) => {
     if (!isUUID(catId)) {
       throw new ErrorExt(ec.PUD045);
     }
-    if (!req.body.name) {
-      throw new ErrorExt(ec.PUD050);
+
+    const name: string | undefined = req.body.name;
+    const icon: CategoryIcon | undefined = req.body.icon;
+    if (!name && !icon) {
+      throw new ErrorExt(ec.PUD115);
     }
-    if (req.body.name.trim() === "") {
+    if (name && name.trim() === "") {
       throw new ErrorExt(ec.PUD059);
     }
+    if (icon && !Object.values(CategoryIcon).includes(icon)) {
+      throw new ErrorExt(ec.PUD096);
+    }
 
-    const category = await db.renameCategory(catId, req.body.name);
+    const data = {
+      name: name,
+      icon: icon
+    };
+
+    const category = await db.editCategory(catId, data);
     if (!category) {
       throw new ErrorExt(ec.PUD007);
     }

--- a/server/src/api/expenses.ts
+++ b/server/src/api/expenses.ts
@@ -77,8 +77,69 @@ router.post("/expenses", authCheck, async (req, res, next) => {
     if (amount < 0) {
       throw new ErrorExt(ec.PUD030);
     }
+    if (req.body.name?.trim() === "" || req.body.description?.trim() === "") {
+      throw new ErrorExt(ec.PUD059);
+    }
 
     const expense: Expense = await db.createExpense(req.body.name, req.body.description, amount, categoryId, payerId);
+    res.status(200).send(expense);
+  }
+  catch (err) {
+    next(err);
+  }
+});
+
+/* --- */
+/* PUT */
+/* --- */
+
+/*
+* Edit expense
+*/
+router.put("/expenses/:id", authCheck, async (req, res, next) => {
+  try {
+    const expenseId = req.params.id;
+    if (!isUUID(expenseId)) {
+      throw new ErrorExt(ec.PUD056);
+    }
+
+    const name: string | undefined = req.body.name;
+    const description: string | undefined = req.body.description;
+    const amount: number | undefined = req.body.amount !== undefined ? Number(req.body.amount) : undefined;
+    const categoryId: string | undefined = req.body.categoryId;
+    const payerId: string | undefined = req.body.payerId;
+
+    if (!name && !description && !categoryId && !amount && !payerId) {
+      throw new ErrorExt(ec.PUD116);
+    }
+    if (categoryId && !isUUID(categoryId)) {
+      throw new ErrorExt(ec.PUD045);
+    }
+    if (payerId && !isUUID(payerId)) {
+      throw new ErrorExt(ec.PUD089);
+    }
+    if (amount && isNaN(amount)) {
+      throw new ErrorExt(ec.PUD088);
+    }
+    if (amount && amount < 0) {
+      throw new ErrorExt(ec.PUD030);
+    }
+    if (name?.trim() === "" || description?.trim() === "") {
+      throw new ErrorExt(ec.PUD059);
+    }
+
+    const data = {
+      name: name,
+      description: description,
+      amount: amount,
+      categoryId: categoryId,
+      payerId: payerId
+    };
+
+    const expense = await db.editExpense(expenseId, data);
+    if (!expense) {
+      throw new ErrorExt(ec.PUD084);
+    }
     res.status(200).send(expense);
   }
   catch (err) {

--- a/server/src/api/validation.ts
+++ b/server/src/api/validation.ts
@@ -11,7 +11,7 @@ const router = express.Router();
 /*
 * User: Username validation
 */
-router.get("/validation/user/username", authCheck, async (req, res, next) => {
+router.post("/validation/user/username", authCheck, async (req, res, next) => {
   try {
     const username: string = req.body.username;
     if (!username) {
@@ -35,7 +35,7 @@ router.get("/validation/user/username", authCheck, async (req, res, next) => {
 /*
 * User: Email validation
 */
-router.get("/validation/user/email", authCheck, async (req, res, next) => {
+router.post("/validation/user/email", authCheck, async (req, res, next) => {
   try {
     const email: string = req.body.email;
     if (!email) {
@@ -59,7 +59,7 @@ router.get("/validation/user/email", authCheck, async (req, res, next) => {
 /*
 * User: Phone number validation
 */
-router.get("/validation/user/phone", authCheck, async (req, res, next) => {
+router.post("/validation/user/phone", authCheck, async (req, res, next) => {
   try {
     const phoneNumber: string = req.body.phone;
     if (!phoneNumber) {
@@ -83,7 +83,7 @@ router.get("/validation/user/phone", authCheck, async (req, res, next) => {
 /*
 * Event: Name validation
 */
-router.get("/validation/event/name", authCheck, async (req, res, next) => {
+router.post("/validation/event/name", authCheck, async (req, res, next) => {
   try {
     const name: string = req.body.name;
     if (!name) {
@@ -107,7 +107,7 @@ router.get("/validation/event/name", authCheck, async (req, res, next) => {
 /*
 * Category: Name validation
 */
-router.get("/validation/category/name", authCheck, async (req, res, next) => {
+router.post("/validation/category/name", authCheck, async (req, res, next) => {
   try {
     const name: string = req.body.name;
     const eventId: string = req.body.eventId;

--- a/server/src/db/dbCategories.ts
+++ b/server/src/db/dbCategories.ts
@@ -128,15 +128,15 @@ export const addUserToCategory = async (categoryId: string, userId: string, weig
 };
 
 /**
- * DB interface: Rename a category
+ * DB interface: Edit a category
  * @param categoryId 
- * @param name New name of category
+ * @param data Data object
  * @returns Edited category
  */
-export const renameCategory = async (categoryId: string, name: string) => {
+export const editCategory = async (categoryId: string, data: { name?: string, icon?: CategoryIcon }) => {
   const query = {
-    text: "SELECT * FROM edit_category($1, $2);",
-    values: [categoryId, name]
+    text: "SELECT * FROM edit_category($1, $2, $3);",
+    values: [categoryId, data.name, data.icon]
   };
   const category: Category[] = await pool.query(query)
     .then(data => {

--- a/server/src/db/dbExpenses.ts
+++ b/server/src/db/dbExpenses.ts
@@ -101,6 +101,37 @@ export const createExpense = async (name: string, description: string, amount: n
 };
 
 /**
+ * DB interface: Edit an expense
+ * @param userId Expense ID to edit
+ * @param data Data object
+ * @returns Edited expense
+ */
+export const editExpense = async (expenseId: string, data: { name?: string, description?: string, amount?: number, categoryId?: string, payerId?: string }) => {
+  const query = {
+    text: "SELECT * FROM edit_expense($1, $2, $3, $4, $5, $6)",
+    values: [expenseId, data.name, data.description, data.amount, data.categoryId, data.payerId]
+  };
+  const expense: Expense[] = await pool.query(query)
+    .then(data => {
+      return parseExpenses(data.rows);
+    })
+    .catch(err => {
+      if (err.code === "P0084")
+        throw new ErrorExt(ec.PUD084, err);
+      else if (err.code === "P0007")
+        throw new ErrorExt(ec.PUD007, err);
+      else if (err.code === "P0008")
+        throw new ErrorExt(ec.PUD008, err);
+      else if (err.code === "P0062")
+        throw new ErrorExt(ec.PUD062, err);
+      else
+        throw new ErrorExt(ec.PUD117, err);
+    });
+
+  return expense[0];
+};
+
+/**
  * DB interface: Delete an expense
  * @param expenseId 
  * @returns True if successful

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -395,11 +395,11 @@ export const PUD040: ErrorCode = {
 };
 
 /**
- * PUD-041: rename_category (500)
+ * PUD-041: edit_category (500)
  */
 export const PUD041: ErrorCode = {
   code: "PUD-041",
-  message: "Something went wrong while renaming category",
+  message: "Something went wrong while editing category",
   status: 500,
   log: true
 };
@@ -1084,4 +1084,32 @@ export const PUD114: ErrorCode = {
   code: "PUD-114",
   message: "Cannot remove user from event, as the user has one or more expenses in the event",
   status: 400
+};
+
+/**
+ * PUD-115: Request body must include at least one category property (400)
+ */
+export const PUD115: ErrorCode = {
+  code: "PUD-115",
+  message: "Request body must include at least one category property",
+  status: 400
+};
+
+/**
+ * PUD-116: Request body must include at least one expense property (400)
+ */
+export const PUD116: ErrorCode = {
+  code: "PUD-116",
+  message: "Request body must include at least one expense property",
+  status: 400
+};
+
+/**
+ * PUD-117: edit_expense (500)
+ */
+export const PUD117: ErrorCode = {
+  code: "PUD-117",
+  message: "Something went wrong while editing expense",
+  status: 500,
+  log: true
 };

--- a/server/tests/categories.test.ts
+++ b/server/tests/categories.test.ts
@@ -98,6 +98,21 @@ describe("categories", async () => {
       expect(res.body.code).toEqual(ec.PUD046.code);
     });
 
+    test("fail create category with invalid UUID event ID", async () => {
+      const res = await request(app)
+        .post("/api/categories")
+        .set("Cookie", authToken)
+        .send({
+          name: "Test category 2",
+          icon: "shopping_cart",
+          weighted: false,
+          eventId: "56e901ad-374f"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD013.code);
+    });
+
     test("fail create category with invalid event ID", async () => {
       const res = await request(app)
         .post("/api/categories")
@@ -181,20 +196,19 @@ describe("categories", async () => {
   /* PUT /categories/:id */
   /* ------------------- */
   describe("PUT /categories/:id", async () => {
-    test("should edit category", async () => {
+    test("fail edit category - invalid UUID", async () => {
       const res = await request(app)
-        .put("/api/categories/" + category.id)
+        .put("/api/categories/56e901ad-374f")
         .set("Cookie", authToken)
         .send({
           name: "New test category name"
         });
 
-      expect(res.status).toEqual(200);
-      expect(res.body.id).toEqual(category.id);
-      category.name = res.body.name;
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD045.code);
     });
 
-    test("fail edit category with invalid ID", async () => {
+    test("fail edit category - invalid ID", async () => {
       const res = await request(app)
         .put("/api/categories/56e901ad-374f-4e1d-92f1-d02dd22d11d3")
         .set("Cookie", authToken)
@@ -204,6 +218,55 @@ describe("categories", async () => {
 
       expect(res.status).toEqual(404);
       expect(res.body.code).toEqual(ec.PUD007.code);
+    });
+
+    test("fail edit category - no properties provided", async () => {
+      const res = await request(app)
+        .put("/api/categories/56e901ad-374f-4e1d-92f1-d02dd22d11d3")
+        .set("Cookie", authToken)
+        .send({});
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD115.code);
+    });
+
+    test("fail edit category - name is empty string", async () => {
+      const res = await request(app)
+        .put("/api/categories/56e901ad-374f-4e1d-92f1-d02dd22d11d3")
+        .set("Cookie", authToken)
+        .send({
+          name: " "
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD059.code);
+    });
+
+    test("fail edit category - icon not valid", async () => {
+      const res = await request(app)
+        .put("/api/categories/56e901ad-374f-4e1d-92f1-d02dd22d11d3")
+        .set("Cookie", authToken)
+        .send({
+          icon: "goofy"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD096.code);
+    });
+
+    test("should edit category", async () => {
+      const res = await request(app)
+        .put("/api/categories/" + category.id)
+        .set("Cookie", authToken)
+        .send({
+          name: "New test category name",
+          icon: "movie"
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.id).toEqual(category.id);
+      expect(res.body.icon).toEqual("movie");
+      category.name = res.body.name;
     });
   });
 
@@ -283,6 +346,18 @@ describe("categories", async () => {
   /* PUT /categories/:id/user/:userId */
   /* -------------------------------- */
   describe("PUT /categories/:id/user/:userId", async () => {
+    test("fail edit user's weight in category with less than 1", async () => {
+      const res = await request(app)
+        .put(`/api/categories/${category.id}/user/${user.id}`)
+        .set("Cookie", authToken)
+        .send({
+          weight: -1
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD049.code);
+    });
+
     test("should edit user's weight in category", async () => {
       const res = await request(app)
         .put(`/api/categories/${category.id}/user/${user.id}`)
@@ -318,6 +393,15 @@ describe("categories", async () => {
   /* DELETE /categories/:id */
   /* ---------------------- */
   describe("DELETE /categories/:id", async () => {
+    test("fail delete category with invalid UUID", async () => {
+      const res = await request(app)
+        .delete("/api/categories/a7dfg-dfg3")
+        .set("Cookie", authToken);
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD045.code);
+    });
+
     test("should delete category", async () => {
       const res = await request(app)
         .delete("/api/categories/" + category.id)

--- a/server/tests/expenses.test.ts
+++ b/server/tests/expenses.test.ts
@@ -92,6 +92,70 @@ describe("expenses", async () => {
   /* POST /expenses */
   /* -------------- */
   describe("POST /expenses", async () => {
+    test("fail creating expense - amount is not a number", async () => {
+      const res = await request(app)
+        .post("/api/expenses")
+        .set("Cookie", authToken)
+        .send({
+          name: "Test expense 1",
+          description: "This is test",
+          amount: "a33",
+          categoryId: category.id,
+          payerId: user.id
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD088.code);
+    });
+
+    test("fail creating expense - amount is negative", async () => {
+      const res = await request(app)
+        .post("/api/expenses")
+        .set("Cookie", authToken)
+        .send({
+          name: "Test expense 1",
+          description: "This is test",
+          amount: -1,
+          categoryId: category.id,
+          payerId: user.id
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD030.code);
+    });
+
+    test("fail creating expense - categoryId is invalid UUID", async () => {
+      const res = await request(app)
+        .post("/api/expenses")
+        .set("Cookie", authToken)
+        .send({
+          name: "Test expense 1",
+          description: "This is test",
+          amount: 100,
+          categoryId: "nb3hgi",
+          payerId: user.id
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD045.code);
+    });
+
+    test("fail creating expense - name is empty string", async () => {
+      const res = await request(app)
+        .post("/api/expenses")
+        .set("Cookie", authToken)
+        .send({
+          name: " ",
+          description: "This is test",
+          amount: 100,
+          categoryId: category.id,
+          payerId: user.id
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD059.code);
+    });
+
     test("should create expense", async () => {
       const res = await request(app)
         .post("/api/expenses")
@@ -234,6 +298,107 @@ describe("expenses", async () => {
       expect(res.body[0].sender.id).toEqual(user2.id);
       expect(res.body[0].receiver.id).toEqual(user.id);
       expect(res.body[0].amount).toEqual(50);
+    });
+  });
+
+  /* ----------------- */
+  /* PUT /expenses/:id */
+  /* ----------------- */
+  describe("PUT /expenses/:id", async () => {
+    test("fail editing expense - no properties provided", async () => {
+      const res = await request(app)
+        .put("/api/expenses/" + expense.id)
+        .set("Cookie", authToken)
+        .send({});
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD116.code);
+    });
+
+    test("fail editing expense amount - not a number", async () => {
+      const res = await request(app)
+        .put("/api/expenses/" + expense.id)
+        .set("Cookie", authToken)
+        .send({
+          amount: "expenseAmount"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD116.code);
+    });
+
+    test("fail editing expense amount - negative number", async () => {
+      const res = await request(app)
+        .put("/api/expenses/" + expense.id)
+        .set("Cookie", authToken)
+        .send({
+          amount: -1
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD030.code);
+    });
+
+    test("fail editing expense categoryId - invalid UUID", async () => {
+      const res = await request(app)
+        .put("/api/expenses/" + expense.id)
+        .set("Cookie", authToken)
+        .send({
+          categoryId: "nb3hgi"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD045.code);
+    });
+
+    test("fail editing expense name - empty string", async () => {
+      const res = await request(app)
+        .put("/api/expenses/" + expense.id)
+        .set("Cookie", authToken)
+        .send({
+          name: " "
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD059.code);
+    });
+
+    test("fail editing expense payer - user is not in event", async () => {
+      const userRes = await request(app)
+      .post("/api/users")
+      .send({
+        username: "expenseuser",
+        firstName: "Test",
+        lastName: "User",
+        email: "expense@user.com",
+        phone: "11111133",
+        password: "secret"
+      });
+      const user3 = userRes.body;
+      expect(user3.id).toBeDefined();
+
+      const res = await request(app)
+        .put("/api/expenses/" + expense.id)
+        .set("Cookie", authToken)
+        .send({
+          payerId: user3.id
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD062.code);
+    });
+
+    test("should edit expense amount", async () => {
+      const res = await request(app)
+        .put("/api/expenses/" + expense.id)
+        .set("Cookie", authToken)
+        .send({
+          name: "Edited expense",
+          amount: 200
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.amount).toEqual(200);
     });
   });
 

--- a/server/tests/validation.test.ts
+++ b/server/tests/validation.test.ts
@@ -71,7 +71,7 @@ describe("validation", async () => {
   describe("GET /validation/user/username", async () => {
     test("fail when validating username already in use", async () => {
       const res = await request(app)
-        .get("/api/validation/user/username")
+        .post("/api/validation/user/username")
         .set("Cookie", authToken)
         .send({
           username: user.username
@@ -83,7 +83,7 @@ describe("validation", async () => {
 
     test("fail when validating username without username in body", async () => {
       const res = await request(app)
-        .get("/api/validation/user/username")
+        .post("/api/validation/user/username")
         .set("Cookie", authToken)
         .send({});
 
@@ -93,7 +93,7 @@ describe("validation", async () => {
 
     test("fail when validating invalid username", async () => {
       const res = await request(app)
-        .get("/api/validation/user/username")
+        .post("/api/validation/user/username")
         .set("Cookie", authToken)
         .send({
           username: " "
@@ -105,7 +105,7 @@ describe("validation", async () => {
 
     test("should successfully validate username not already in use", async () => {
       const res = await request(app)
-        .get("/api/validation/user/username")
+        .post("/api/validation/user/username")
         .set("Cookie", authToken)
         .send({
           username: "testuser2"
@@ -122,7 +122,7 @@ describe("validation", async () => {
   describe("GET /validation/user/email", async () => {
     test("fail when validating email already in use", async () => {
       const res = await request(app)
-        .get("/api/validation/user/email")
+        .post("/api/validation/user/email")
         .set("Cookie", authToken)
         .send({
           email: user.email
@@ -134,7 +134,7 @@ describe("validation", async () => {
 
     test("fail when validating email without email in body", async () => {
       const res = await request(app)
-        .get("/api/validation/user/email")
+        .post("/api/validation/user/email")
         .set("Cookie", authToken)
         .send({});
 
@@ -144,7 +144,7 @@ describe("validation", async () => {
 
     test("fail when validating invalid email", async () => {
       const res = await request(app)
-        .get("/api/validation/user/email")
+        .post("/api/validation/user/email")
         .set("Cookie", authToken)
         .send({
           email: "testuser.com"
@@ -156,7 +156,7 @@ describe("validation", async () => {
 
     test("fail when validating invalid email (too long domain)", async () => {
       const res = await request(app)
-        .get("/api/validation/user/email")
+        .post("/api/validation/user/email")
         .set("Cookie", authToken)
         .send({
           email: "test@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com"
@@ -168,7 +168,7 @@ describe("validation", async () => {
 
     test("should successfully validate email not already in use", async () => {
       const res = await request(app)
-        .get("/api/validation/user/email")
+        .post("/api/validation/user/email")
         .set("Cookie", authToken)
         .send({
           email: "anothertest@user.com"
@@ -185,7 +185,7 @@ describe("validation", async () => {
   describe("GET /validation/user/phone", async () => {
     test("fail when validating phone number already in use", async () => {
       const res = await request(app)
-        .get("/api/validation/user/phone")
+        .post("/api/validation/user/phone")
         .set("Cookie", authToken)
         .send({
           phone: user.phone
@@ -197,7 +197,7 @@ describe("validation", async () => {
 
     test("fail when validating phone number without phone in body", async () => {
       const res = await request(app)
-        .get("/api/validation/user/phone")
+        .post("/api/validation/user/phone")
         .set("Cookie", authToken)
         .send({});
 
@@ -207,7 +207,7 @@ describe("validation", async () => {
 
     test("fail when validating invalid phone number", async () => {
       const res = await request(app)
-        .get("/api/validation/user/phone")
+        .post("/api/validation/user/phone")
         .set("Cookie", authToken)
         .send({
           phone: "1234"
@@ -219,7 +219,7 @@ describe("validation", async () => {
 
     test("should successfully validate phone number not already in use", async () => {
       const res = await request(app)
-        .get("/api/validation/user/phone")
+        .post("/api/validation/user/phone")
         .set("Cookie", authToken)
         .send({
           phone: "11111112"
@@ -236,7 +236,7 @@ describe("validation", async () => {
   describe("GET /validation/event/name", async () => {
     test("fail when validating event name already in use", async () => {
       const res = await request(app)
-        .get("/api/validation/event/name")
+        .post("/api/validation/event/name")
         .set("Cookie", authToken)
         .send({
           name: event.name
@@ -248,7 +248,7 @@ describe("validation", async () => {
 
     test("fail when validating event name without name in body", async () => {
       const res = await request(app)
-        .get("/api/validation/event/name")
+        .post("/api/validation/event/name")
         .set("Cookie", authToken)
         .send({});
 
@@ -258,7 +258,7 @@ describe("validation", async () => {
 
     test("fail when validating invalid event name", async () => {
       const res = await request(app)
-        .get("/api/validation/event/name")
+        .post("/api/validation/event/name")
         .set("Cookie", authToken)
         .send({
           name: " "
@@ -270,7 +270,7 @@ describe("validation", async () => {
 
     test("should successfully validate event name not already in use", async () => {
       const res = await request(app)
-        .get("/api/validation/event/name")
+        .post("/api/validation/event/name")
         .set("Cookie", authToken)
         .send({
           name: "New event"
@@ -287,7 +287,7 @@ describe("validation", async () => {
   describe("GET /validation/category/name", async () => {
     test("fail when validating category name already in use within event", async () => {
       const res = await request(app)
-        .get("/api/validation/category/name")
+        .post("/api/validation/category/name")
         .set("Cookie", authToken)
         .send({
           name: category.name,
@@ -300,7 +300,7 @@ describe("validation", async () => {
 
     test("fail when validating category name without name in body", async () => {
       const res = await request(app)
-        .get("/api/validation/category/name")
+        .post("/api/validation/category/name")
         .set("Cookie", authToken)
         .send({
           eventId: event.id
@@ -312,7 +312,7 @@ describe("validation", async () => {
 
     test("fail when validating invalid category name", async () => {
       const res = await request(app)
-        .get("/api/validation/category/name")
+        .post("/api/validation/category/name")
         .set("Cookie", authToken)
         .send({
           name: " ",
@@ -325,7 +325,7 @@ describe("validation", async () => {
 
     test("fail when validating category name with invalid UUID as event ID", async () => {
       const res = await request(app)
-        .get("/api/validation/category/name")
+        .post("/api/validation/category/name")
         .set("Cookie", authToken)
         .send({
           name: "New category",
@@ -338,7 +338,7 @@ describe("validation", async () => {
 
     test("fail when validating category name with invalid event ID", async () => {
       const res = await request(app)
-        .get("/api/validation/category/name")
+        .post("/api/validation/category/name")
         .set("Cookie", authToken)
         .send({
           name: "New category",
@@ -351,7 +351,7 @@ describe("validation", async () => {
 
     test("should successfully validate category name not already in use within event", async () => {
       const res = await request(app)
-        .get("/api/validation/category/name")
+        .post("/api/validation/category/name")
         .set("Cookie", authToken)
         .send({
           name: "New category",


### PR DESCRIPTION
Changelog:
- Add endpoint for editing expense. Supports following data:
  - name
  - description
  - categoryID
  - amount
  - payer
- Add endpoint for editing category. Supports following data:
  - name
  - icon
- Change validator endpoints from GET to POST
- Fix some API documentation bugs

Closes #2, closes #10 