### PR TITLE
fix: Validation endpoints for editing

### DIFF
--- a/server/src/api.json
+++ b/server/src/api.json
@@ -2967,7 +2967,7 @@
           "Validation"
         ],
         "summary": "Validate username",
-        "description": "Check if a given username is available for use. User ID in body is optional, and used when validation against a specific user.",
+        "description": "Check if a given username is available for use. User ID in body is optional, and used when validating against a specific user.",
         "operationId": "getValidateUsername",
         "requestBody": {
           "description": "Username",
@@ -3038,7 +3038,7 @@
           "Validation"
         ],
         "summary": "Validate email",
-        "description": "Check if a given email is available for use. User ID in body is optional, and used when validation against a specific user.",
+        "description": "Check if a given email is available for use. User ID in body is optional, and used when validating against a specific user.",
         "operationId": "getValidateEmail",
         "requestBody": {
           "description": "Email",
@@ -3109,7 +3109,7 @@
           "Validation"
         ],
         "summary": "Validate phone number",
-        "description": "Check if a given phone number is available for use. User ID in body is optional, and used when validation against a specific user.",
+        "description": "Check if a given phone number is available for use. User ID in body is optional, and used when validating against a specific user.",
         "operationId": "getValidatePhone",
         "requestBody": {
           "description": "Phone number",
@@ -3180,7 +3180,7 @@
           "Validation"
         ],
         "summary": "Validate event name",
-        "description": "Check if a given event name is available for use. Event ID in body is optional, and used when validation against a specific event.",
+        "description": "Check if a given event name is available for use. Event ID in body is optional, and used when validating against a specific event.",
         "operationId": "getValidateEventName",
         "security": [
           { "cookieAuth": [] }
@@ -3254,7 +3254,7 @@
           "Validation"
         ],
         "summary": "Validate category name",
-        "description": "Check if a given category name is available for use within an event. Category ID in body is optional, and used when validation against a specific category.",
+        "description": "Check if a given category name is available for use within an event. Category ID in body is optional, and used when validating against a specific category.",
         "operationId": "getValidateCategoryName",
         "security": [
           { "cookieAuth": [] }

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -2967,7 +2967,7 @@
           "Validation"
         ],
         "summary": "Validate username",
-        "description": "Check if a given username is available for use",
+        "description": "Check if a given username is available for use. User ID in body is optional, and used when validation against a specific user.",
         "operationId": "getValidateUsername",
         "requestBody": {
           "description": "Username",
@@ -2979,8 +2979,15 @@
                   "username": {
                     "type": "string",
                     "example": "testuser"
+                  },
+                  "userId": {
+                    "type": "string",
+                    "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
                   }
-                }
+                },
+                "required": [
+                  "username"
+                ]
               }
             }
           }
@@ -3031,7 +3038,7 @@
           "Validation"
         ],
         "summary": "Validate email",
-        "description": "Check if a given email is available for use",
+        "description": "Check if a given email is available for use. User ID in body is optional, and used when validation against a specific user.",
         "operationId": "getValidateEmail",
         "requestBody": {
           "description": "Email",
@@ -3043,8 +3050,15 @@
                   "email": {
                     "type": "string",
                     "example": "a@b.com"
+                  },
+                  "userId": {
+                    "type": "string",
+                    "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
                   }
-                }
+                },
+                "required": [
+                  "email"
+                ]
               }
             }
           }
@@ -3095,7 +3109,7 @@
           "Validation"
         ],
         "summary": "Validate phone number",
-        "description": "Check if a given phone number is available for use",
+        "description": "Check if a given phone number is available for use. User ID in body is optional, and used when validation against a specific user.",
         "operationId": "getValidatePhone",
         "requestBody": {
           "description": "Phone number",
@@ -3107,8 +3121,15 @@
                   "phone": {
                     "type": "string",
                     "example": "12131415"
+                  },
+                  "userId": {
+                    "type": "string",
+                    "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
                   }
-                }
+                },
+                "required": [
+                  "phone"
+                ]
               }
             }
           }
@@ -3159,7 +3180,7 @@
           "Validation"
         ],
         "summary": "Validate event name",
-        "description": "Check if a given event name is available for use",
+        "description": "Check if a given event name is available for use. Event ID in body is optional, and used when validation against a specific event.",
         "operationId": "getValidateEventName",
         "security": [
           { "cookieAuth": [] }
@@ -3174,8 +3195,15 @@
                   "name": {
                     "type": "string",
                     "example": "Text event"
+                  },
+                  "eventId": {
+                    "type": "string",
+                    "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
                   }
-                }
+                },
+                "required": [
+                  "name"
+                ]
               }
             }
           }
@@ -3226,7 +3254,7 @@
           "Validation"
         ],
         "summary": "Validate category name",
-        "description": "Check if a given category name is available for use within an event",
+        "description": "Check if a given category name is available for use within an event. Category ID in body is optional, and used when validation against a specific category.",
         "operationId": "getValidateCategoryName",
         "security": [
           { "cookieAuth": [] }
@@ -3245,8 +3273,16 @@
                   "eventId": {
                     "type": "string",
                     "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
+                  },
+                  "categoryId": {
+                    "type": "string",
+                    "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
                   }
-                }
+                },
+                "required": [
+                  "name",
+                  "eventId"
+                ]
               }
             }
           }

--- a/server/src/api/validation.ts
+++ b/server/src/api/validation.ts
@@ -14,14 +14,18 @@ const router = express.Router();
 router.post("/validation/user/username", async (req, res, next) => {
   try {
     const username: string = req.body.username;
+    const userId: string | undefined = req.body.userId;
     if (!username) {
       throw new ErrorExt(ec.PUD109);
     }
     if (username.trim() === "") {
       throw new ErrorExt(ec.PUD059);
     }
+    if (userId !== undefined && !isUUID(userId)) {
+      throw new ErrorExt(ec.PUD016);
+    }
 
-    const valid = await db.validateUsername(username.trim());
+    const valid = await db.validateUsername(username.trim(), userId);
     if (!valid) {
       throw new ErrorExt(ec.PUD017);
     }
@@ -38,14 +42,18 @@ router.post("/validation/user/username", async (req, res, next) => {
 router.post("/validation/user/email", async (req, res, next) => {
   try {
     const email: string = req.body.email;
+    const userId: string | undefined = req.body.userId;
     if (!email) {
       throw new ErrorExt(ec.PUD110);
     }
     if (!isEmail(email)) {
       throw new ErrorExt(ec.PUD004);
     }
+    if (userId !== undefined && !isUUID(userId)) {
+      throw new ErrorExt(ec.PUD016);
+    }
 
-    const valid = await db.validateEmail(email.trim());
+    const valid = await db.validateEmail(email.trim(), userId);
     if (!valid) {
       throw new ErrorExt(ec.PUD018);
     }
@@ -62,14 +70,18 @@ router.post("/validation/user/email", async (req, res, next) => {
 router.post("/validation/user/phone", async (req, res, next) => {
   try {
     const phoneNumber: string = req.body.phone;
+    const userId: string | undefined = req.body.userId;
     if (!phoneNumber) {
       throw new ErrorExt(ec.PUD111);
     }
     if (!isPhoneNumber(phoneNumber)) {
       throw new ErrorExt(ec.PUD113);
     }
+    if (userId !== undefined && !isUUID(userId)) {
+      throw new ErrorExt(ec.PUD016);
+    }
 
-    const valid = await db.validatePhoneNumber(phoneNumber.trim());
+    const valid = await db.validatePhoneNumber(phoneNumber.trim(), userId);
     if (!valid) {
       throw new ErrorExt(ec.PUD019);
     }
@@ -86,14 +98,18 @@ router.post("/validation/user/phone", async (req, res, next) => {
 router.post("/validation/event/name", authCheck, async (req, res, next) => {
   try {
     const name: string = req.body.name;
+    const eventId: string | undefined = req.body.eventId;
     if (!name) {
       throw new ErrorExt(ec.PUD112);
     }
     if (name.trim() === "") {
       throw new ErrorExt(ec.PUD059);
     }
+    if (eventId !== undefined && !isUUID(eventId)) {
+      throw new ErrorExt(ec.PUD013);
+    }
 
-    const valid = await db.validateEventName(name.trim());
+    const valid = await db.validateEventName(name.trim(), eventId);
     if (!valid) {
       throw new ErrorExt(ec.PUD005);
     }
@@ -111,6 +127,7 @@ router.post("/validation/category/name", authCheck, async (req, res, next) => {
   try {
     const name: string = req.body.name;
     const eventId: string = req.body.eventId;
+    const categoryId: string | undefined = req.body.categoryId;
     if (!name) {
       throw new ErrorExt(ec.PUD112);
     }
@@ -120,8 +137,11 @@ router.post("/validation/category/name", authCheck, async (req, res, next) => {
     if (!isUUID(eventId)) {
       throw new ErrorExt(ec.PUD013);
     }
+    if (categoryId !== undefined && !isUUID(categoryId)) {
+      throw new ErrorExt(ec.PUD045);
+    }
 
-    const valid = await db.validateCategoryName(name.trim(), eventId);
+    const valid = await db.validateCategoryName(name.trim(), eventId, categoryId);
     if (!valid) {
       throw new ErrorExt(ec.PUD097);
     }

--- a/server/src/db/dbValidation.ts
+++ b/server/src/db/dbValidation.ts
@@ -9,14 +9,15 @@ import { PUD006 } from "../types/errorCodes";
 /**
  * DB interface: Check if a username is available
  * @param username
+ * @param userId Provide user ID if checking against a specific user
  * @returns True if username is available
  */
-export const validateUsername = async (username: string) => {
+export const validateUsername = async (username: string, userId?: string) => {
   const query = {
     text: `
-      SELECT false AS available FROM "user" u WHERE u.username ILIKE $1;
+      SELECT false AS available FROM "user" u WHERE u.username ILIKE $1 AND ($2::uuid is null OR u.id != $2::uuid);
     `,
-    values: [username]
+    values: [username, userId]
   };
   const data = await pool.query(query);
   if (data.rows[0] && data.rows[0].available === false) {
@@ -28,14 +29,15 @@ export const validateUsername = async (username: string) => {
 /**
  * DB interface: Check if a user email is available
  * @param email
+ * @param userId Provide user ID if checking against a specific user
  * @returns True if email is available
  */
-export const validateEmail = async (email: string) => {
+export const validateEmail = async (email: string, userId?: string) => {
   const query = {
     text: `
-      SELECT false AS available FROM "user" u WHERE u.email ILIKE $1;
+      SELECT false AS available FROM "user" u WHERE u.email ILIKE $1 AND ($2::uuid is null OR u.id != $2::uuid);
     `,
-    values: [email]
+    values: [email, userId]
   };
   const data = await pool.query(query);
   if (data.rows[0] && data.rows[0].available === false) {
@@ -47,14 +49,15 @@ export const validateEmail = async (email: string) => {
 /**
  * DB interface: Check if a user phone number is available
  * @param phoneNumber
+ * @param userId Provide user ID if checking against a specific user
  * @returns True if phone number is available
  */
-export const validatePhoneNumber = async (phoneNumber: string) => {
+export const validatePhoneNumber = async (phoneNumber: string, userId?: string) => {
   const query = {
     text: `
-      SELECT false AS available FROM "user" u WHERE u.phone_number ILIKE $1;
+      SELECT false AS available FROM "user" u WHERE u.phone_number ILIKE $1 AND ($2::uuid is null OR u.id != $2::uuid);
     `,
-    values: [phoneNumber]
+    values: [phoneNumber, userId]
   };
   const data = await pool.query(query);
   if (data.rows[0] && data.rows[0].available === false) {
@@ -70,14 +73,15 @@ export const validatePhoneNumber = async (phoneNumber: string) => {
 /**
  * DB interface: Check if a event name is available
  * @param name
+ * @param userId Provide event ID if checking against a specific event
  * @returns True if event name is available
  */
-export const validateEventName = async (name: string) => {
+export const validateEventName = async (name: string, eventId?: string) => {
   const query = {
     text: `
-      SELECT false AS available FROM "event" e WHERE e.name ILIKE $1;
+      SELECT false AS available FROM "event" e WHERE e.name ILIKE $1 AND ($2::uuid is null OR e.id != $2::uuid);
     `,
-    values: [name]
+    values: [name, eventId]
   };
   const data = await pool.query(query);
   if (data.rows[0] && data.rows[0].available === false) {
@@ -94,9 +98,10 @@ export const validateEventName = async (name: string) => {
  * DB interface: Check if a category name is available within an event
  * @param name
  * @param eventId
+ * @param userId Provide category ID if checking against a specific category
  * @returns True if category name is available
  */
-export const validateCategoryName = async (name: string, eventId: string) => {
+export const validateCategoryName = async (name: string, eventId: string, categoryId?: string) => {
   const queryEventCheck = {
     text: `
       SELECT true AS exists FROM "event" e WHERE e.id = $1;
@@ -112,9 +117,9 @@ export const validateCategoryName = async (name: string, eventId: string) => {
 
   const query = {
     text: `
-      SELECT false AS available FROM category c WHERE c.name ILIKE $1 AND c.event_id = $2;
+      SELECT false AS available FROM category c WHERE c.name ILIKE $1 AND c.event_id = $2 AND ($3::uuid is null OR c.id != $3::uuid);
     `,
-    values: [name, eventId]
+    values: [name, eventId, categoryId]
   };
   const data = await pool.query(query);
   if (data.rows[0] && data.rows[0].available === false) {

--- a/server/tests/validation.test.ts
+++ b/server/tests/validation.test.ts
@@ -96,11 +96,36 @@ describe("validation", async () => {
       expect(res.body.code).toEqual(ec.PUD059.code);
     });
 
+    test("fail when validating username with invalid user ID", async () => {
+      const res = await request(app)
+        .post("/api/validation/user/username")
+        .set("Cookie", authToken)
+        .send({
+          username: "testuser2",
+          userId: "a212e758"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD016.code);
+    });
+
     test("should successfully validate username not already in use", async () => {
       const res = await request(app)
         .post("/api/validation/user/username")
         .send({
           username: "testuser2"
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.valid).toEqual(true);
+    });
+
+    test("should successfully validate username already in use when given same user in body", async () => {
+      const res = await request(app)
+        .post("/api/validation/user/username")
+        .send({
+          username: user.username,
+          userId: user.id
         });
 
       expect(res.status).toEqual(200);
@@ -158,12 +183,37 @@ describe("validation", async () => {
       expect(res.body.code).toEqual(ec.PUD004.code);
     });
 
+    test("fail when validating email with invalid user ID", async () => {
+      const res = await request(app)
+        .post("/api/validation/user/email")
+        .set("Cookie", authToken)
+        .send({
+          email: "anothertest@user.com",
+          userId: "a212e758"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD016.code);
+    });
+
     test("should successfully validate email not already in use", async () => {
       const res = await request(app)
         .post("/api/validation/user/email")
         .set("Cookie", authToken)
         .send({
           email: "anothertest@user.com"
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.valid).toEqual(true);
+    });
+
+    test("should successfully validate email already in use when given same user in body", async () => {
+      const res = await request(app)
+        .post("/api/validation/user/email")
+        .send({
+          email: user.email,
+          userId: user.id
         });
 
       expect(res.status).toEqual(200);
@@ -209,12 +259,37 @@ describe("validation", async () => {
       expect(res.body.code).toEqual(ec.PUD113.code);
     });
 
+    test("fail when validating phone number with invalid user ID", async () => {
+      const res = await request(app)
+        .post("/api/validation/user/phone")
+        .set("Cookie", authToken)
+        .send({
+          phone: "11111112",
+          userId: "a212e758"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD016.code);
+    });
+
     test("should successfully validate phone number not already in use", async () => {
       const res = await request(app)
         .post("/api/validation/user/phone")
         .set("Cookie", authToken)
         .send({
           phone: "11111112"
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.valid).toEqual(true);
+    });
+
+    test("should successfully validate phone number already in use when given same user in body", async () => {
+      const res = await request(app)
+        .post("/api/validation/user/phone")
+        .send({
+          phone: user.phone,
+          userId: user.id
         });
 
       expect(res.status).toEqual(200);
@@ -260,12 +335,38 @@ describe("validation", async () => {
       expect(res.body.code).toEqual(ec.PUD059.code);
     });
 
+    test("fail when validating event name with invalid event ID", async () => {
+      const res = await request(app)
+        .post("/api/validation/event/name")
+        .set("Cookie", authToken)
+        .send({
+          name: "New event",
+          eventId: "a212e758"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD013.code);
+    });
+
     test("should successfully validate event name not already in use", async () => {
       const res = await request(app)
         .post("/api/validation/event/name")
         .set("Cookie", authToken)
         .send({
           name: "New event"
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.valid).toEqual(true);
+    });
+
+    test("should successfully validate event name already in use when given same event in body", async () => {
+      const res = await request(app)
+        .post("/api/validation/event/name")
+        .set("Cookie", authToken)
+        .send({
+          name: event.name,
+          eventId: event.id
         });
 
       expect(res.status).toEqual(200);
@@ -341,6 +442,20 @@ describe("validation", async () => {
       expect(res.body.code).toEqual(ec.PUD006.code);
     });
 
+    test("fail when validating category name with invalid category ID", async () => {
+      const res = await request(app)
+        .post("/api/validation/category/name")
+        .set("Cookie", authToken)
+        .send({
+          name: "New category",
+          eventId: event.id,
+          categoryId: "a212e758"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD045.code);
+    });
+
     test("should successfully validate category name not already in use within event", async () => {
       const res = await request(app)
         .post("/api/validation/category/name")
@@ -348,6 +463,20 @@ describe("validation", async () => {
         .send({
           name: "New category",
           eventId: event.id
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.valid).toEqual(true);
+    });
+
+    test("should successfully validate category name already in use when given same category in body", async () => {
+      const res = await request(app)
+        .post("/api/validation/category/name")
+        .set("Cookie", authToken)
+        .send({
+          name: category.name,
+          eventId: event.id,
+          categoryId: category.id
         });
 
       expect(res.status).toEqual(200);


### PR DESCRIPTION
Now all validation endpoints take in an optional resource ID in the body, so it can validate with information about the current resource. This allows the validation endpoints to be used for editing.

Closes #231 