### PR TITLE
feat: Split payments into separate lists

### DIFF
--- a/app/mikane/src/app/features/mobile/payment-item/payment-item.component.html
+++ b/app/mikane/src/app/features/mobile/payment-item/payment-item.component.html
@@ -7,10 +7,10 @@
 			</mat-icon>
 			<div>
 				<div class="name">
-					{{ self ? "You" : sender.sender.name }}
+					{{ self && sender.sender.id === currentUser.id ? "You" : sender.sender.name }}
 				</div>
 				<div class="subtext">
-					{{ self ? "Owe money to..." : "Owes money to..." }}
+					{{ self && sender.sender.id === currentUser.id ? "Owe money to..." : "Owes money to..." }}
 				</div>
 			</div>
 		</div>
@@ -20,7 +20,7 @@
 			<div class="payment">
 				<span class="name">
 					<img [src]="receiver.receiver.avatarURL" class="avatar" />
-					{{ receiver.receiver.name }}
+					{{ self && receiver.receiver.id === currentUser.id ? 'You' : receiver.receiver.name }}
 				</span>
 				<span class="amount-color">
 					{{ receiver.amount | currency : "" : "" : "1.2-2" : "no" }} kr

--- a/app/mikane/src/app/features/mobile/payment-item/payment-item.component.ts
+++ b/app/mikane/src/app/features/mobile/payment-item/payment-item.component.ts
@@ -38,6 +38,7 @@ export class PaymentItemComponent {
 		}[];
 	};
 	@Input() self: boolean;
+	@Input() currentUser: User;
 
 	dropdownOpen: boolean;
 	lowerHeight: number | string;

--- a/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.html
+++ b/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.html
@@ -1,0 +1,37 @@
+<mat-accordion multi>
+<mat-expansion-panel *ngFor="let sender of senders" [expanded]="self">
+	<mat-expansion-panel-header (click)="panelToggled()">
+		<div class="user"> 
+			<img [src]="sender.sender.avatarURL" class="avatar" />
+			<mat-panel-title>{{ self && sender.sender.id === currentUser.id ? 'You' : sender.sender.name }}</mat-panel-title>
+		</div>
+	</mat-expansion-panel-header>
+	<ng-template matExpansionPanelContent>
+		<table mat-table class="expense-table" [dataSource]="sender.receivers">
+			<!-- Name Column -->
+			<ng-container matColumnDef="name">
+				<th mat-header-cell *matHeaderCellDef>{{ self && sender.sender.id === currentUser.id ? 'Owe money to' : 'Owes money to' }}</th>
+				<td mat-cell *matCellDef="let receiver" class="user">
+					<img [src]="receiver.receiver.avatarURL" class="avatar" />
+					{{ self && receiver.receiver.id === currentUser.id ? 'You' : receiver.receiver.name }}
+				</td>
+			</ng-container>
+		
+			<!-- Amount Column -->
+			<ng-container matColumnDef="amount">
+				<th mat-header-cell *matHeaderCellDef>Amount</th>
+				<td mat-cell *matCellDef="let receiver" class="amount-cell amount-color">
+					{{ receiver.amount | currency : "" : "" : "1.2-2" : "no" }}
+					kr
+				</td>
+			</ng-container>
+		
+			<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+			<tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+			<tr class="mat-row" *matNoDataRow>
+				<td class="mat-cell" [attr.colspan]="displayedColumns.length">No payments</td>
+			</tr>
+		</table>				
+	</ng-template>
+</mat-expansion-panel>
+</mat-accordion>

--- a/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.scss
+++ b/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.scss
@@ -1,0 +1,18 @@
+.amount-cell {
+	width: 50%;
+}
+
+.user {
+	display: flex;
+	align-items: center;
+	height: inherit;
+
+	.avatar {
+		position: relative;
+		width: 24px;
+		height: 24px;
+		margin-right: 16px;
+		border-radius: 50%;
+		object-fit: cover;
+	}
+}

--- a/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.ts
+++ b/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.ts
@@ -1,0 +1,61 @@
+import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { MatAccordion, MatExpansionModule } from '@angular/material/expansion';
+import { User } from 'src/app/services/user/user.service';
+import { MatCardModule } from '@angular/material/card';
+import { MatListModule } from '@angular/material/list';
+import { MatTableModule } from '@angular/material/table';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { NgIf, NgFor, AsyncPipe, CurrencyPipe } from '@angular/common';
+import { PaymentItemComponent } from 'src/app/features/mobile/payment-item/payment-item.component';
+
+@Component({
+	selector: 'payment-expansion-panel-item',
+	templateUrl: './payment-expansion-panel-item.component.html',
+	styleUrls: ['./payment-expansion-panel-item.component.scss'],
+	standalone: true,
+	imports: [
+		NgIf,
+		MatButtonModule,
+		MatIconModule,
+		MatExpansionModule,
+		NgFor,
+		MatTableModule,
+		MatCardModule,
+		MatListModule,
+		AsyncPipe,
+		CurrencyPipe,
+		PaymentItemComponent,
+	],
+})
+export class PaymentExpansionPanelItemComponent {
+	@ViewChild(MatAccordion) accordion!: MatAccordion;
+	@Input('senders') senders: {
+		sender: User;
+		receivers: {
+			receiver: User;
+			amount: number;
+		}[];
+	}[];
+	@Input() self: boolean;
+	@Input() currentUser: User;
+	@Output() allPanelsExpanded = new EventEmitter();
+
+	displayedColumns: string[] = ['name', 'amount'];
+
+	openExpand(open: boolean) {
+		if (open) {
+			this.accordion.openAll();
+		} else {
+			this.accordion.closeAll();
+		}
+	}
+
+	panelToggled() {
+		if (this.accordion._headers.toArray().every((panel) => panel._isExpanded())) {
+			this.allPanelsExpanded.emit(true);
+		} else if (!this.accordion._headers.some((panel) => panel._isExpanded())) {
+			this.allPanelsExpanded.emit(false);
+		}
+	}
+}

--- a/app/mikane/src/app/pages/payment-structure/payment-structure.component.html
+++ b/app/mikane/src/app/pages/payment-structure/payment-structure.component.html
@@ -1,60 +1,73 @@
-<div class="payment-actions" *ngIf="senders.length > 0 && (breakpointService.isMobile() | async) === false">
-	<button mat-button color="accent" (click)="toggleExpand()">
-		<mat-icon>{{ allExpanded ? "visibility_off" : "visibility" }}</mat-icon>
-		{{ allExpanded ? "Collapse all payments" : "Show all payments" }}
-	</button>
-</div>
 <div *ngIf="(loading | async) === false; else loadingSpinner">
 	<div *ngIf="(breakpointService.isMobile() | async) === false; else mobileView">
-		<mat-accordion *ngIf="senders.length > 0; else noPayments" class="payments" multi>
-			<mat-expansion-panel *ngFor="let sender of senders" expanded="true">
-				<mat-expansion-panel-header (click)="panelToggled()">
-					<div class="user">
-						<img [src]="sender.sender.avatarURL" class="avatar" />
-						<mat-panel-title>{{ sender.sender.name }}</mat-panel-title>
-					</div>
-				</mat-expansion-panel-header>
-				<ng-template matExpansionPanelContent>
-					<table mat-table class="expense-table" [dataSource]="sender.receivers">
-						<!-- Name Column -->
-						<ng-container matColumnDef="name">
-							<th mat-header-cell *matHeaderCellDef>Owes money to</th>
-							<td mat-cell *matCellDef="let receiver" class="user">
-								<img [src]="receiver.receiver.avatarURL" class="avatar" />
-								{{ receiver.receiver.name }}
-							</td>
-						</ng-container>
-
-						<!-- Amount Column -->
-						<ng-container matColumnDef="amount">
-							<th mat-header-cell *matHeaderCellDef>Amount</th>
-							<td mat-cell *matCellDef="let receiver" class="amount-cell amount-color">
-								{{ receiver.amount | currency : "" : "" : "1.2-2" : "no" }}
-								kr
-							</td></ng-container
-						>
-
-						<tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-						<tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-						<tr class="mat-row" *matNoDataRow>
-							<td class="mat-cell" [attr.colspan]="displayedColumns.length">No payments</td>
-						</tr>
-					</table>
-				</ng-template>
-			</mat-expansion-panel>
-		</mat-accordion>
+		<div *ngIf="senders.length > 0; else noPayments">
+			<div  class="payments-header" [ngClass]="{ 'no-payments': paymentsSelf.length === 0}">
+				<h3 class="payments-title">Your payments</h3>
+				<button *ngIf="paymentsSelf.length > 0" mat-button color="accent" (click)="toggleExpand(1)" class="collapse-button">
+					<mat-icon>{{ allExpandedSelf ? "visibility_off" : "visibility" }}</mat-icon>
+					{{ allExpandedSelf ? "Collapse all payments" : "Show all payments" }}
+				</button>
+			</div>
+			<payment-expansion-panel-item
+				#paymentsSelfRef
+				*ngIf="paymentsSelf.length > 0; else noPaymentsSelf"
+				[senders]="paymentsSelf"
+				[self]="true"
+				[currentUser]="currentUser"
+				(allPanelsExpanded)="panelToggled(1, $event)"
+			>
+			</payment-expansion-panel-item>
+			<ng-template #noPaymentsSelf>
+				<span class="no-payments-text">You have no payments in this event</span>
+			</ng-template>
+			<div class="payments-header" [ngClass]="{ 'no-payments': paymentsOthers.length === 0}">
+				<h3 class="payments-title">Other payments</h3>
+				<button *ngIf="paymentsOthers.length > 0" mat-button color="accent" (click)="toggleExpand(2)" class="collapse-button">
+					<mat-icon>{{ allExpandedOthers ? "visibility_off" : "visibility" }}</mat-icon>
+					{{ allExpandedOthers ? "Collapse all payments" : "Show all payments" }}
+				</button>
+			</div>
+			<payment-expansion-panel-item
+				#paymentsOthersRef
+				*ngIf="paymentsOthers.length > 0; else noPaymentsOthers"
+				[senders]="paymentsOthers"
+				[self]="false"
+				[currentUser]="currentUser"
+				(allPanelsExpanded)="panelToggled(2, $event)"
+			>
+			</payment-expansion-panel-item>
+			<ng-template #noPaymentsOthers>
+				<span class="no-payments-text">There are no other payments in this event</span>
+			</ng-template>
+		</div>
 	</div>
 </div>
 
 <ng-template #mobileView>
-	<mat-nav-list class="payments-list-mobile">
-		<payment-item
-			*ngFor="let sender of senders"
-			[sender]="sender"
-			[self]="sender.sender.id === currentUser.id"
-			>
-		</payment-item>
-	</mat-nav-list>
+	<div *ngIf="paymentsSelf.length > 0">
+		<div *ngIf="paymentsOthers.length > 0" class="title-mobile">Your payments</div>
+		<mat-nav-list class="payments-list-mobile">
+			<payment-item
+				*ngFor="let sender of paymentsSelf"
+				[sender]="sender"
+				[self]="true"
+				[currentUser]="currentUser"
+				>
+			</payment-item>
+		</mat-nav-list>
+	</div>
+	<div *ngIf="paymentsOthers.length > 0">
+		<div *ngIf="paymentsSelf.length > 0" class="title-mobile">Other payments</div>
+		<mat-nav-list class="payments-list-mobile">
+			<payment-item
+				*ngFor="let sender of paymentsOthers"
+				[sender]="sender"
+				[self]="false"
+				[currentUser]="currentUser"
+				>
+			</payment-item>
+		</mat-nav-list>
+	</div>
 </ng-template>
 
 <ng-template #loadingSpinner>
@@ -64,7 +77,7 @@
 <ng-template #noPayments>
 	<div class="payments-empty">
 		<mat-card appearance="outlined">
-			<mat-card-content> <h1>No payments</h1></mat-card-content>
+			<mat-card-content><h1>No payments</h1></mat-card-content>
 		</mat-card>
 	</div>
 </ng-template>

--- a/app/mikane/src/app/pages/payment-structure/payment-structure.component.scss
+++ b/app/mikane/src/app/pages/payment-structure/payment-structure.component.scss
@@ -5,25 +5,45 @@
 	margin-top: 2em;
 }
 
-.amount-cell {
-	width: 50%;
+.payments-list-mobile {
+	padding: 0;
 }
 
-.user {
+.payments-header {
 	display: flex;
+	justify-content: space-between;
 	align-items: center;
-	height: inherit;
+	padding: 10px 0;
+	padding-left: 22px;
+	margin: 20px 0;
+	background-color: #1c1c1c;
+	border-radius: 4px;
 
-	.avatar {
-		position: relative;
-		width: 24px;
-		height: 24px;
-		margin-right: 16px;
-		border-radius: 50%;
-		object-fit: cover;
+	&.no-payments {
+		padding-top: 14px;
+		padding-bottom: 14px;
+	}
+
+	.payments-title {
+		margin: 0;
+	}
+
+	.collapse-button {
+		margin-right: 10px;
 	}
 }
 
-.payments-list-mobile {
-	padding: 0;
+.no-payments-text {
+	margin-left: 24px;
+}
+
+.title-mobile {
+	display: flex;
+	align-items: center;
+	height: 40px;
+	padding-left: 16px;
+	background-color: rgba(24, 24, 24, 1);
+	border-top: 1px solid #333333;
+	stroke: #333333;
+	color: #b4b4b4;
 }


### PR DESCRIPTION
Split the payments list into 2 separate lists, one for the user's own payments (both as sender and receiver), and another for other payments. The list of user's payments will start expanded, while the latter list will start collapsed. 

Closes #250 