### PR TITLE
Archive events - backend

### DIFF
--- a/server/db_scripts/add_user_as_event_admin.sql
+++ b/server/db_scripts/add_user_as_event_admin.sql
@@ -10,6 +10,7 @@ returns table (
   "description" varchar(255),
   created timestamp,
   "private" boolean,
+  active boolean,
   admin_ids jsonb,
   user_id uuid,
   user_in_event boolean,
@@ -44,7 +45,7 @@ begin
   update user_event ue set "admin" = true where ue.event_id = ip_event_id and ue.user_id = ip_user_id;
 
   return query
-  select * from get_events(ip_event_id, null);
+  select * from get_events(ip_event_id, null, false);
 
 end;
 $$

--- a/server/db_scripts/add_user_to_category.sql
+++ b/server/db_scripts/add_user_to_category.sql
@@ -30,6 +30,10 @@ begin
     raise exception 'User not found' using errcode = 'P0008';
   end if;
 
+  if exists (select 1 from "event" e inner join category c on c.event_id = e.id where c.id = ip_category_id and e.active = false) then
+    raise exception 'Archived events cannot be edited' using errcode = 'P0118';
+  end if;
+
   if not exists (select 1 from user_event ue where ue.event_id = tmp_event_id and ue.user_id = ip_user_id) then
     raise exception 'User not in event, cannot be added to category' using errcode = 'P0010';
   end if;

--- a/server/db_scripts/add_user_to_event.sql
+++ b/server/db_scripts/add_user_to_event.sql
@@ -10,6 +10,7 @@ returns table (
   "description" varchar(255),
   created timestamp,
   "private" boolean,
+  active boolean,
   admin_ids jsonb,
   user_id uuid,
   user_in_event boolean,
@@ -26,6 +27,10 @@ begin
     raise exception 'User not found' using errcode = 'P0008';
   end if;
 
+  if exists (select 1 from "event" e where e.id = ip_event_id and e.active = false) then
+    raise exception 'Archived events cannot be edited' using errcode = 'P0118';
+  end if;
+
   if exists (select 1 from user_event ue where ue.event_id = ip_event_id and ue.user_id = ip_user_id) then
     raise exception 'User is already in this event' using errcode = 'P0009';
   end if;
@@ -34,7 +39,7 @@ begin
     values (ip_user_id, ip_event_id, CURRENT_TIMESTAMP, ip_admin);
 
   return query
-  select * from get_events(ip_event_id, null);
+  select * from get_events(ip_event_id, null, false);
 
 end;
 $$

--- a/server/db_scripts/delete_category.sql
+++ b/server/db_scripts/delete_category.sql
@@ -10,6 +10,10 @@ begin
     raise exception 'Category not found' using errcode = 'P0007';
   end if;
 
+  if exists (select 1 from "event" e inner join category c on c.event_id = e.id where c.id = ip_category_id and e.active = false) then
+    raise exception 'Archived events cannot be edited' using errcode = 'P0118';
+  end if;
+
   delete from category c where c.id = ip_category_id;
 
 end;

--- a/server/db_scripts/delete_expense.sql
+++ b/server/db_scripts/delete_expense.sql
@@ -11,6 +11,10 @@ begin
     raise exception 'Expense not found' using errcode = 'P0084';
   end if;
 
+  if exists (select 1 from "event" e inner join category c on c.event_id = e.id inner join expense ex on ex.category_id = c.id where ex.id = ip_expense_id and e.active = false) then
+    raise exception 'Archived events cannot be edited' using errcode = 'P0118';
+  end if;
+
   if not exists (select 1 from expense ex
                   inner join category c on c.id = ex.category_id
                   inner join user_event ue on ue.event_id = c.event_id

--- a/server/db_scripts/edit_category.sql
+++ b/server/db_scripts/edit_category.sql
@@ -20,6 +20,10 @@ begin
     raise exception 'Category not found' using errcode = 'P0007';
   end if;
 
+  if exists (select 1 from "event" e inner join category c on c.event_id = e.id where c.id = ip_category_id and e.active = false) then
+    raise exception 'Archived events cannot be edited' using errcode = 'P0118';
+  end if;
+
   update
     category c
   set

--- a/server/db_scripts/edit_category_weighted_status.sql
+++ b/server/db_scripts/edit_category_weighted_status.sql
@@ -19,6 +19,10 @@ begin
     raise exception 'Category not found' using errcode = 'P0007';
   end if;
 
+  if exists (select 1 from "event" e inner join category c on c.event_id = e.id where c.id = ip_category_id and e.active = false) then
+    raise exception 'Archived events cannot be edited' using errcode = 'P0118';
+  end if;
+
   update category c set weighted = ip_weighted where c.id = ip_category_id;
 
   if (ip_weighted = true) then

--- a/server/db_scripts/edit_expense.sql
+++ b/server/db_scripts/edit_expense.sql
@@ -38,6 +38,10 @@ begin
     raise exception 'User not found' using errcode = 'P0008';
   end if;
 
+  if exists (select 1 from "event" e inner join category c on c.event_id = e.id inner join expense ex on ex.category_id = c.id where ex.id = ip_expense_id and e.active = false) then
+    raise exception 'Archived events cannot be edited' using errcode = 'P0118';
+  end if;
+
   if ip_payer_id is not null and not exists (select ue.user_id from user_event ue inner join category c on ue.event_id = c.event_id where c.id = coalesce(ip_category_id, c.id) and ue.user_id = ip_payer_id) then
     raise exception 'User cannot pay for expense as user is not in event' using errcode = 'P0062';
   end if;

--- a/server/db_scripts/edit_user_weight.sql
+++ b/server/db_scripts/edit_user_weight.sql
@@ -20,6 +20,10 @@ begin
     raise exception 'Category not found' using errcode = 'P0007';
   end if;
 
+  if exists (select 1 from "event" e inner join category c on c.event_id = e.id where c.id = ip_category_id and e.active = false) then
+    raise exception 'Archived events cannot be edited' using errcode = 'P0118';
+  end if;
+
   update
     user_category uc
   set

--- a/server/db_scripts/get_event_by_name.sql
+++ b/server/db_scripts/get_event_by_name.sql
@@ -9,6 +9,7 @@ returns table (
   "description" varchar(255),
   created timestamp,
   "private" boolean,
+  active boolean,
   admin_ids jsonb,
   user_id uuid,
   user_in_event boolean,
@@ -26,7 +27,7 @@ begin
   end if;
 
   return query
-  select * from get_events(tmp_event_id, ip_user_id);
+  select * from get_events(tmp_event_id, ip_user_id, false);
   
 end;
 $$

--- a/server/db_scripts/get_users.sql
+++ b/server/db_scripts/get_users.sql
@@ -35,7 +35,8 @@ begin
       (ip_exclude_user_id is null and u.id = u.id)) and
       u.deleted = coalesce(ip_deleted, u.deleted)
     order by
-      u.first_name asc;
+      u.first_name asc,
+      u.last_name asc;
   end;
 
   else
@@ -59,7 +60,8 @@ begin
       (ip_exclude_user_id is null and u.id = u.id)) and
       u.deleted = coalesce(ip_deleted, u.deleted)
     order by
-      ue.joined_time asc;
+      u.first_name asc,
+      u.last_name asc;
   end;
 
   end if;

--- a/server/db_scripts/new_category.sql
+++ b/server/db_scripts/new_category.sql
@@ -23,6 +23,10 @@ begin
     raise exception 'Event not found' using errcode = 'P0006';
   end if;
 
+  if exists (select 1 from "event" e where e.id = ip_event_id and e.active = false) then
+    raise exception 'Archived events cannot be edited' using errcode = 'P0118';
+  end if;
+
   if exists (select 1 from category c where c.name ilike ip_name and c.event_id = ip_event_id) then
     raise exception 'Another category in this event already has this name' using errcode = 'P0097';
   end if;

--- a/server/db_scripts/new_event.sql
+++ b/server/db_scripts/new_event.sql
@@ -13,6 +13,7 @@ returns table (
   "description" varchar(255),
   created timestamp,
   "private" boolean,
+  active boolean,
   admin_ids jsonb,
   user_id uuid,
   user_in_event boolean,

--- a/server/db_scripts/new_expense.sql
+++ b/server/db_scripts/new_expense.sql
@@ -35,6 +35,10 @@ begin
     raise exception 'User not found' using errcode = 'P0008';
   end if;
 
+  if exists (select 1 from "event" e inner join category c on c.event_id = e.id where c.id = ip_category_id and e.active = false) then
+    raise exception 'Archived events cannot be edited' using errcode = 'P0118';
+  end if;
+
   if not exists (select ue.user_id from user_event ue inner join category c on ue.event_id = c.event_id where c.id = ip_category_id and ue.user_id = ip_payer_id) then
     raise exception 'User cannot pay for expense as user is not in event' using errcode = 'P0062';
   end if;

--- a/server/db_scripts/remove_user_as_event_admin.sql
+++ b/server/db_scripts/remove_user_as_event_admin.sql
@@ -10,6 +10,7 @@ returns table (
   "description" varchar(255),
   created timestamp,
   "private" boolean,
+  active boolean,
   admin_ids jsonb,
   user_id uuid,
   user_in_event boolean,
@@ -47,7 +48,7 @@ begin
   update user_event ue set "admin" = false where ue.event_id = ip_event_id and ue.user_id = ip_user_id;
 
   return query
-  select * from get_events(ip_event_id, null);
+  select * from get_events(ip_event_id, null, false);
 
 end;
 $$

--- a/server/db_scripts/remove_user_from_category.sql
+++ b/server/db_scripts/remove_user_from_category.sql
@@ -23,6 +23,10 @@ begin
     raise exception 'User not found' using errcode = 'P0008';
   end if;
 
+  if exists (select 1 from "event" e inner join category c on c.event_id = e.id where c.id = ip_category_id and e.active = false) then
+    raise exception 'Archived events cannot be edited' using errcode = 'P0118';
+  end if;
+
   delete from user_category uc where uc.category_id = ip_category_id and uc.user_id = ip_user_id;
 
   return query

--- a/server/db_scripts/remove_user_from_event.sql
+++ b/server/db_scripts/remove_user_from_event.sql
@@ -9,6 +9,7 @@ returns table (
   "description" varchar(255),
   created timestamp,
   "private" boolean,
+  active boolean,
   admin_ids jsonb,
   user_id uuid,
   user_in_event boolean,
@@ -25,6 +26,10 @@ begin
 
   if not exists (select 1 from "user" u where u.id = ip_user_id) then
     raise exception 'User not found' using errcode = 'P0008';
+  end if;
+
+  if exists (select 1 from "event" e where e.id = ip_event_id and e.active = false) then
+    raise exception 'Archived events cannot be edited' using errcode = 'P0118';
   end if;
 
   if exists (select 1 from expense ex inner join category c on ex.category_id = c.id where c.event_id = ip_event_id and ex.payer_id = ip_user_id) then
@@ -54,7 +59,7 @@ begin
   );
 
   return query
-  select * from get_events(ip_event_id, null);
+  select * from get_events(ip_event_id, null, false);
 
 end;
 $$

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -1150,8 +1150,12 @@
                     "example": "New event description"
                   },
                   "private": {
-                    "type": "integer",
-                    "example": 1
+                    "type": "boolean",
+                    "example": true
+                  },
+                  "active": {
+                    "type": "boolean",
+                    "example": true
                   }
                 }
               }
@@ -3624,6 +3628,10 @@
           "private": {
             "type": "boolean",
             "example": false
+          },
+          "active": {
+            "type": "boolean",
+            "example": true
           }
         }
       },
@@ -3657,6 +3665,10 @@
             "type": "boolean",
             "example": false
           },
+          "active": {
+            "type": "boolean",
+            "example": true
+          },
           "userInfo": {
             "type": "object",
             "properties": {
@@ -3681,7 +3693,8 @@
           "description",
           "created",
           "adminIds",
-          "private"
+          "private",
+          "active"
         ]
       },
       "Expense": {

--- a/server/src/api/events.ts
+++ b/server/src/api/events.ts
@@ -206,7 +206,7 @@ router.put("/events/:id", authCheck, async (req, res, next) => {
       throw new ErrorExt(ec.PUD055);
     }
 
-    const event = await db.editEvent(eventId, userId, req.body.name, req.body.description, req.body.private);
+    const event = await db.editEvent(eventId, userId, req.body.name, req.body.description, req.body.private, req.body.active);
     if (!event) {
       throw new ErrorExt(ec.PUD006);
     }

--- a/server/src/db/dbCategories.ts
+++ b/server/src/db/dbCategories.ts
@@ -86,6 +86,8 @@ export const createCategory = async (name: string, eventId: string, weighted: bo
         throw new ErrorExt(ec.PUD006, err);
       if (err.code === "P0097")
         throw new ErrorExt(ec.PUD097, err);
+      else if (err.code === "P0118")
+        throw new ErrorExt(ec.PUD118, err);
       else
         throw new ErrorExt(ec.PUD036, err);
     });
@@ -125,6 +127,8 @@ export const addUserToCategory = async (categoryId: string, userId: string, weig
         throw new ErrorExt(ec.PUD011, err);
       else if (err.code === "P0012")
         throw new ErrorExt(ec.PUD012, err);
+      else if (err.code === "P0118")
+        throw new ErrorExt(ec.PUD118, err);
       else
         throw new ErrorExt(ec.PUD020, err);
     });
@@ -150,6 +154,8 @@ export const editCategory = async (categoryId: string, data: { name?: string, ic
     .catch(err => {
       if (err.code === "P0007")
         throw new ErrorExt(ec.PUD007, err);
+      else if (err.code === "P0118")
+        throw new ErrorExt(ec.PUD118, err);
       else
         throw new ErrorExt(ec.PUD041, err);
     });
@@ -175,6 +181,8 @@ export const editUserWeight = async (categoryId: string, userId: string, weight:
     .catch(err => {
       if (err.code === "P0007")
         throw new ErrorExt(ec.PUD007, err);
+      else if (err.code === "P0118")
+        throw new ErrorExt(ec.PUD118, err);
       else
         throw new ErrorExt(ec.PUD027, err);
     });
@@ -205,6 +213,8 @@ export const editWeightStatus = async (categoryId: string, weighted: boolean) =>
     .catch(err => {
       if (err.code === "P0007")
         throw new ErrorExt(ec.PUD007, err);
+      else if (err.code === "P0118")
+        throw new ErrorExt(ec.PUD118, err);
       else
         throw new ErrorExt(ec.PUD026, err);
     });
@@ -229,6 +239,8 @@ export const deleteCategory = async (categoryId: string) => {
     .catch(err => {
       if (err.code === "P0007")
         throw new ErrorExt(ec.PUD007, err);
+      else if (err.code === "P0118")
+        throw new ErrorExt(ec.PUD118, err);
       else
         throw new ErrorExt(ec.PUD022, err);
     });
@@ -261,6 +273,8 @@ export const removeUserFromCategory = async (categoryId: string, userId: string)
         throw new ErrorExt(ec.PUD007, err);
       else if (err.code === "P0008")
         throw new ErrorExt(ec.PUD008, err);
+      else if (err.code === "P0118")
+        throw new ErrorExt(ec.PUD118, err);
       else
         throw new ErrorExt(ec.PUD039, err);
     });

--- a/server/src/db/dbEvents.ts
+++ b/server/src/db/dbEvents.ts
@@ -16,7 +16,7 @@ import * as ec from "../types/errorCodes";
  */
 export const getEvents = async (userId?: string) => {
   const query = {
-    text: "SELECT * FROM get_events(null, $1);",
+    text: "SELECT * FROM get_events(null, $1, false);",
     values: [userId]
   };
   const events: Event[] = await pool.query(query)
@@ -41,7 +41,7 @@ export const getEvents = async (userId?: string) => {
  */
 export const getEvent = async (eventId: string, userId?: string) => {
   const query = {
-    text: "SELECT * FROM get_events($1, $2);",
+    text: "SELECT * FROM get_events($1, $2, false);",
     values: [eventId, userId]
   };
   const events: Event[] = await pool.query(query)
@@ -275,6 +275,8 @@ export const addUserToEvent = async (eventId: string, userId: string) => {
         throw new ErrorExt(ec.PUD008, err);
       else if (err.code === "P0009")
         throw new ErrorExt(ec.PUD009, err);
+      else if (err.code === "P0118")
+        throw new ErrorExt(ec.PUD118, err);
       else
         throw new ErrorExt(ec.PUD021, err);
     });
@@ -306,6 +308,8 @@ export const removeUserFromEvent = async (eventId: string, userId: string) => {
         throw new ErrorExt(ec.PUD098, err);
       else if (err.code === "P0114")
         throw new ErrorExt(ec.PUD114, err);
+      else if (err.code === "P0118")
+        throw new ErrorExt(ec.PUD118, err);
       else
         throw new ErrorExt(ec.PUD040, err);
     });
@@ -384,12 +388,13 @@ export const removeUserAsEventAdmin = async (eventId: string, userId: string, by
  * @param name New name
  * @param description New description
  * @param privateEvent Whether event should be open for all or invite only
+ * @param active Whether event should be active or not
  * @returns Edited event
  */
-export const editEvent = async (eventId: string, userId: string, name?: string, description?: string, privateEvent?: boolean) => {
+export const editEvent = async (eventId: string, userId: string, name?: string, description?: string, privateEvent?: boolean, active?: boolean) => {
   const query = {
-    text: "SELECT * FROM edit_event($1, $2, $3, $4, $5);",
-    values: [eventId, userId, name, description, privateEvent]
+    text: "SELECT * FROM edit_event($1, $2, $3, $4, $5, $6);",
+    values: [eventId, userId, name, description, privateEvent, active]
   };
   const events: Event[] = await pool.query(query)
     .then(data => {
@@ -402,6 +407,8 @@ export const editEvent = async (eventId: string, userId: string, name?: string, 
         throw new ErrorExt(ec.PUD005, err);
       else if (err.code === "P0087")
         throw new ErrorExt(ec.PUD087, err);
+      else if (err.code === "P0118")
+        throw new ErrorExt(ec.PUD118, err);
       else
         throw new ErrorExt(ec.PUD044, err);
     });

--- a/server/src/db/dbExpenses.ts
+++ b/server/src/db/dbExpenses.ts
@@ -93,6 +93,8 @@ export const createExpense = async (name: string, amount: number, categoryId: st
         throw new ErrorExt(ec.PUD008, err);
       else if (err.code === "P0062")
         throw new ErrorExt(ec.PUD062, err);
+      else if (err.code === "P0118")
+        throw new ErrorExt(ec.PUD118, err);
       else
         throw new ErrorExt(ec.PUD043, err);
     });
@@ -124,6 +126,8 @@ export const editExpense = async (expenseId: string, data: { name?: string, desc
         throw new ErrorExt(ec.PUD008, err);
       else if (err.code === "P0062")
         throw new ErrorExt(ec.PUD062, err);
+      else if (err.code === "P0118")
+        throw new ErrorExt(ec.PUD118, err);
       else
         throw new ErrorExt(ec.PUD117, err);
     });
@@ -150,6 +154,8 @@ export const deleteExpense = async (expenseId: string, userId: string) => {
         throw new ErrorExt(ec.PUD084, err);
       else if (err.code === "P0086")
         throw new ErrorExt(ec.PUD086, err);
+      else if (err.code === "P0118")
+        throw new ErrorExt(ec.PUD118, err);
       else
         throw new ErrorExt(ec.PUD024, err);
     });

--- a/server/src/parsers/parseEvents.ts
+++ b/server/src/parsers/parseEvents.ts
@@ -16,6 +16,7 @@ export const parseEvents = (eventsInput: EventDB[]) => {
       created: eventObj.created,
       adminIds: eventObj.admin_ids.map(admin => admin.user_id),
       private: eventObj.private,
+      active: eventObj.active,
       userInfo: eventObj.user_id && eventObj.user_in_event !== undefined && eventObj.user_is_admin !== undefined ? {
         id: eventObj.user_id,
         inEvent: eventObj.user_in_event,

--- a/server/src/parsers/parseEvents.ts
+++ b/server/src/parsers/parseEvents.ts
@@ -59,13 +59,5 @@ export const parseBalance = (balanceRes: BalanceCalculationResult, users: User[]
     });
   });
 
-  // Sort users by time joined event
-  balances.sort((a, b) => {
-    if (!a.user.eventInfo?.joinedTime || !b.user.eventInfo?.joinedTime) {
-      return 0;
-    }
-    return a.user.eventInfo?.joinedTime.getTime() - b.user.eventInfo?.joinedTime.getTime();
-  });
-
   return balances;
 };

--- a/server/src/parsers/parseUsers.ts
+++ b/server/src/parsers/parseUsers.ts
@@ -49,14 +49,6 @@ export const parseUsers = (usersInput: UserDB[], withEventData: boolean, avatarS
     delete user.lastName;
   }
 
-  // Sort users by time joined event
-  users.sort((a, b) => {
-    if (!a.eventInfo?.joinedTime || !b.eventInfo?.joinedTime) {
-      return 0;
-    }
-    return a.eventInfo?.joinedTime.getTime() - b.eventInfo?.joinedTime.getTime();
-  });
-
   return users;
 };
 

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -1113,3 +1113,12 @@ export const PUD117: ErrorCode = {
   status: 500,
   log: true
 };
+
+/**
+ * PUD-118: Archived events cannot be edited
+ */
+export const PUD118: ErrorCode = {
+  code: "PUD-118",
+  message: "Archived events cannot be edited",
+  status: 400
+};

--- a/server/src/types/types.ts
+++ b/server/src/types/types.ts
@@ -24,6 +24,7 @@ export type Event = {
   created: Date;
   adminIds: string[];
   private: boolean;
+  active: boolean;
   userInfo?: {
     id: string;
     inEvent: boolean;

--- a/server/src/types/typesDB.ts
+++ b/server/src/types/typesDB.ts
@@ -21,6 +21,7 @@ export type EventDB = {
     user_id: string
   }[],
   private: boolean,
+  active: boolean,
   user_id?: string,
   user_in_event?: boolean,
   user_is_admin?: boolean

--- a/server/tests/categories.test.ts
+++ b/server/tests/categories.test.ts
@@ -142,6 +142,45 @@ describe("categories", async () => {
       expect(res.status).toEqual(400);
       expect(res.body.code).toEqual(ec.PUD096.code);
     });
+
+    test("should set event as archived", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: false
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(false);
+    });
+
+    test("fail creating category in archived event", async () => {
+      const res = await request(app)
+        .post("/api/categories")
+        .set("Cookie", authToken)
+        .send({
+          name: "Another category",
+          icon: "shopping_cart",
+          weighted: false,
+          eventId: event.id
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD118.code);
+    });
+
+    test("should set event as active", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: true
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(true);
+    });
   });
 
   /* --------------- */

--- a/server/tests/events.test.ts
+++ b/server/tests/events.test.ts
@@ -247,6 +247,42 @@ describe("events", async () => {
       expect(res.status).toEqual(400);
       expect(res.body.code).toEqual(ec.PUD053.code);
     });
+
+    test("should set event as archived", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: false
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(false);
+    });
+
+    test("fail editing archived event", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          name: "New name"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD118.code);
+    });
+
+    test("should set event as active", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: true
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(true);
+    });
   });
 
   /* ----------------------------- */
@@ -262,6 +298,39 @@ describe("events", async () => {
 
       expect(res.status).toEqual(200);
       expect(res.body.length).toEqual(1);
+    });
+
+    test("should set event as archived", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: false
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(false);
+    });
+
+    test("fail adding user2 to archived event", async () => {
+      const res = await request(app)
+        .post(`/api/events/${event.id}/user/${user2.id}`)
+        .set("Cookie", authToken);
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD118.code);
+    });
+
+    test("should set event as active", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: true
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(true);
     });
 
     // Add user2 to event
@@ -300,13 +369,37 @@ describe("events", async () => {
       expect(res.body.adminIds[0]).toEqual(user.id);
     });
 
+    test("should set event as archived", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: false
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(false);
+    });
+
     // Add user2 as admin of event
-    test("should add user2 as event admin", async () => {
+    test("should add user2 as event admin, even if archived", async () => {
       const res = await request(app)
         .post(`/api/events/${event.id}/admin/${user2.id}`)
         .set("Cookie", authToken);
 
       expect(res.status).toEqual(200);
+    });
+
+    test("should set event as active", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: true
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(true);
     });
 
     // Check that user2 is also event admin
@@ -442,6 +535,39 @@ describe("events", async () => {
 
       expect(res.status).toEqual(200);
       expect(res.body.length).toEqual(2);
+    });
+
+    test("should set event as archived", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: false
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(false);
+    });
+
+    test("fail removal of user2 in archived event", async () => {
+      const res = await request(app)
+        .delete(`/api/events/${event.id}/user/${user2.id}`)
+        .set("Cookie", authToken);
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD118.code);
+    });
+
+    test("should set event as active", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: true
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(true);
     });
 
     // Remove user2 from event

--- a/server/tests/expenses.test.ts
+++ b/server/tests/expenses.test.ts
@@ -188,6 +188,46 @@ describe("expenses", async () => {
       expect(res.status).toEqual(400);
       expect(res.body.code).toEqual(ec.PUD062.code);
     });
+
+    test("should set event as archived", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: false
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(false);
+    });
+
+    test("fail create expense in archived event", async () => {
+      const res = await request(app)
+        .post("/api/expenses")
+        .set("Cookie", authToken)
+        .send({
+          name: "Test expense 2",
+          description: "This is test",
+          amount: 200,
+          categoryId: category.id,
+          payerId: user.id
+        });
+
+        expect(res.status).toEqual(400);
+        expect(res.body.code).toEqual(ec.PUD118.code);
+    });
+
+    test("should set event as active", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: true
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(true);
+    });
   });
 
   /* ------------- */


### PR DESCRIPTION
Implement backend functinoality for archiving events.

Changelog:
- Events can now be set as active/archived, through the edit event endpoint
- Archived events cannot be further edited in any way, except adding/removing event admins and setting event back to active
  - If an archived event is set to active alongside other changes in the edit event endpoint, those changes will also go through
- Add tests related to archival functionality

Closes #6 