### PR TITLE
feat: Split events into active and archived sections

### DIFF
--- a/app/mikane/src/app/pages/events/events.component.html
+++ b/app/mikane/src/app/pages/events/events.component.html
@@ -9,51 +9,96 @@
 <div *ngIf="(loading | async) === false; else loadingSpinner">
 	<div *ngIf="(breakpointService.isMobile() | async) === false; else mobileView" class="events-container">
 		<mat-card class="event-card">
-			<mat-card-header id="header">
-				<mat-card-title> Events </mat-card-title>
-			</mat-card-header>
 			<mat-card-content class="card-content">
-				<mat-card *ngFor="let event of pagedEvents" class="event-item">
-					<mat-card-header class="event-header clickable" (click)="clickEvent(event)">
-						<mat-card-title class="event-title">
-							<span class="event-name">
-								<span class="name-text">{{ event.name }}</span>
-								<mat-icon
-									*ngIf="event.userInfo.inEvent"
-									matTooltip="You are in this event"
-									[matTooltipShowDelay]="200"
-									class="joined-icon"
-								>
-									how_to_reg
-								</mat-icon>
-								<span
-									*ngIf="event.userInfo.isAdmin"
-									matTooltip="You are an admin for this event"
-									[matTooltipShowDelay]="200"
-									class="admin-icon"
-								>
-									A
+				<div class="header">Active Events</div>
+				<div *ngIf="pagedEventsActive().length > 0; else noActiveEvents">
+					<mat-card *ngFor="let event of pagedEventsActive()" class="event-item">
+						<mat-card-header class="event-header clickable" (click)="clickEvent(event)">
+							<mat-card-title class="event-title">
+								<span class="event-name">
+									<span class="name-text">{{ event.name }}</span>
+									<mat-icon
+										*ngIf="event.userInfo.inEvent"
+										matTooltip="You are in this event"
+										[matTooltipShowDelay]="200"
+										class="joined-icon"
+									>
+										how_to_reg
+									</mat-icon>
+									<span
+										*ngIf="event.userInfo.isAdmin"
+										matTooltip="You are an admin for this event"
+										[matTooltipShowDelay]="200"
+										class="admin-icon"
+									>
+										A
+									</span>
 								</span>
+							</mat-card-title>
+							<mat-card-subtitle>
+								{{ event.description }}
+							</mat-card-subtitle>
+							<span *ngIf="event.userInfo.isAdmin" class="event-actions">
+								<button mat-icon-button (click)="editEvent(event); $event.stopPropagation()">
+									<mat-icon>edit</mat-icon>
+								</button>
 							</span>
-						</mat-card-title>
-						<mat-card-subtitle>
-							{{ event.description }}
-						</mat-card-subtitle>
-						<span *ngIf="event.userInfo.isAdmin" class="event-actions">
-							<button mat-icon-button (click)="editEvent(event); $event.stopPropagation()">
-								<mat-icon>edit</mat-icon>
-							</button>
-						</span>
-					</mat-card-header>
-				</mat-card>
-				<mat-paginator
-					[length]="length"
-					[pageSize]="pageSize"
-					[pageSizeOptions]="pageSizeOptions"
-					(page)="onPageChange($event)"
-					class="events-paginator"
-				>
-				</mat-paginator>
+						</mat-card-header>
+					</mat-card>
+					<mat-paginator
+						[length]="lengthActive()"
+						[pageSize]="pageSizeActive()"
+						[pageSizeOptions]="pageSizeOptions"
+						(page)="onPageChange($event, 'active')"
+						class="events-paginator"
+					>
+					</mat-paginator>
+				</div>
+				<ng-template #noActiveEvents>
+					<div class="no-events">There are currently no active events</div>
+				</ng-template>
+				<div class="header archived-events">Archived events</div>
+				<div *ngIf="pagedEventsArchived().length > 0; else noArchivedEvents">
+					<mat-card *ngFor="let event of pagedEventsArchived()" class="event-item">
+						<mat-card-header class="event-header clickable" (click)="clickEvent(event)">
+							<mat-card-title class="event-title">
+								<span class="event-name">
+									<span class="name-text">{{ event.name }}</span>
+									<mat-icon
+										*ngIf="event.userInfo.inEvent"
+										matTooltip="You are in this event"
+										[matTooltipShowDelay]="200"
+										class="joined-icon"
+									>
+										how_to_reg
+									</mat-icon>
+									<span
+										*ngIf="event.userInfo.isAdmin"
+										matTooltip="You are an admin for this event"
+										[matTooltipShowDelay]="200"
+										class="admin-icon"
+									>
+										A
+									</span>
+								</span>
+							</mat-card-title>
+							<mat-card-subtitle>
+								{{ event.description }}
+							</mat-card-subtitle>
+						</mat-card-header>
+					</mat-card>
+					<mat-paginator
+						[length]="lengthArchived()"
+						[pageSize]="pageSizeArchived()"
+						[pageSizeOptions]="pageSizeOptions"
+						(page)="onPageChange($event, 'archived')"
+						class="events-paginator"
+					>
+					</mat-paginator>
+				</div>
+				<ng-template #noArchivedEvents>
+					<div class="no-events">There are currently no archived events</div>
+				</ng-template>
 			</mat-card-content>
 			<mat-card-actions>
 				<div class="add-button">
@@ -68,10 +113,20 @@
 </div>
 
 <ng-template #mobileView>
-	<div class="title-mobile">EVENTS</div>
-	<mat-nav-list #eventsList class="events-list-mobile">
-		<event-item *ngFor="let event of events" [event]="event" (click)="clickEvent(event)"></event-item>
+	<div class="title-mobile">ACTIVE EVENTS</div>
+	<mat-nav-list *ngIf="pagedEventsActive().length > 0; else noActiveEvents" class="events-list-mobile">
+		<event-item *ngFor="let event of eventsActive()" [event]="event" (click)="clickEvent(event)"></event-item>
 	</mat-nav-list>
+	<ng-template #noActiveEvents>
+		<div class="no-events-mobile">There are currently no active events</div>
+	</ng-template>
+	<div class="title-mobile">ARCHIVED EVENTS</div>
+	<mat-nav-list *ngIf="pagedEventsArchived().length > 0; else noArchivedEvents" class="events-list-mobile">
+		<event-item *ngFor="let event of eventsArchived()" [event]="event" (click)="clickEvent(event)"></event-item>
+	</mat-nav-list>
+	<ng-template #noArchivedEvents>
+		<div class="no-events-mobile">There are currently no archived events</div>
+	</ng-template>
 	<button mat-fab color="primary" class="add-event-button-mobile" (click)="openDialog()">
 		<mat-icon>edit_calendar</mat-icon>
 	</button>

--- a/app/mikane/src/app/pages/events/events.component.scss
+++ b/app/mikane/src/app/pages/events/events.component.scss
@@ -10,9 +10,14 @@ mat-toolbar button {
 	margin-left: 1em;
 }
 
-#header {
-	padding: 16px;
-	margin-bottom: 10px;
+.archived-events {
+	margin-top: 30px;
+}
+
+.header {
+	padding: 20px 16px 20px;
+	margin-bottom: 18px;
+	font-size: 20px;
 	background-color: rgba(33, 33, 33, 0.8);
 }
 
@@ -24,14 +29,23 @@ mat-toolbar button {
 	margin-top: 2em;
 
 	.event-card {
+		margin-bottom: 28px;
 		min-width: 34em;
 		max-width: 54em;
 		width: 70vw;
 		background-color: #3d3d3d;
 	}
+
+	.no-events {
+		margin-top: 28px;
+		margin-left: 16px;
+		color: rgba(255, 255, 255, 0.6);
+	}
 }
 
 .event-item {
+	margin-left: 16px;
+	margin-right: 16px;
 	margin-bottom: 0.4em;
 
 	.event-header {
@@ -91,8 +105,19 @@ mat-toolbar button {
 	stroke: #333333;
 }
 
+.no-events-mobile {
+	margin-top: 20px;
+	margin-bottom: 20px;
+	margin-left: 16px;
+	color: rgba(255, 255, 255, 0.6);
+}
+
 .mat-mdc-card-header-text::ng-deep {
 	color: red !important;
+}
+
+mat-card-content {
+	padding: 0 !important;
 }
 
 .add-event-button-mobile {

--- a/app/mikane/src/app/services/event/event.service.ts
+++ b/app/mikane/src/app/services/event/event.service.ts
@@ -12,6 +12,7 @@ export interface PuddingEvent {
 	created: Date;
 	adminIds: string[];
 	private: boolean;
+	active: boolean;
 	userInfo?: {
 		id: string;
 		inEvent: boolean;


### PR DESCRIPTION
Split the events in the events page into 2 sections - one for active events, and one for archived events

Closes #255 