### PR TITLE
feat: Event settings page

### DIFF
--- a/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.html
+++ b/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.html
@@ -4,10 +4,10 @@
 		*ngFor="let link of mobileLinks"
 		[routerLink]="link.location"
 		(click)="activeLink = link.location"
-		[ngClass]="{ 'active': activeLink === link.location, 'nav-back-button': link.location== './events' }"
+		[ngClass]="{ 'active': activeLink === link.location, 'nav-back-button': link.location== '/events' }"
 		matRipple
 	>
-		<mat-icon [ngClass]="{ 'back-icon': link.location === './events' }">{{ link.icon }}</mat-icon>
+		<mat-icon [ngClass]="{ 'back-icon': link.location === '/events' }">{{ link.icon }}</mat-icon>
 		<div>{{ link.name }}</div>
 	</a>
 </div>

--- a/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.ts
+++ b/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.ts
@@ -31,7 +31,7 @@ export class MobileEventNavbarComponent {
 			{
 				name: '',
 				icon: 'arrow_back_ios',
-				location: './events',
+				location: '/events',
 			},
 			...this.links
 		];

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.html
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.html
@@ -1,0 +1,159 @@
+<div *ngIf="(loading | async) === false; else loadingSpinner">
+	<div *ngIf="(breakpointService.isMobile() | async) === false; else mobileView" class="settings">
+		<mat-card class="card">
+			<mat-card-header>
+				<div mat-card-avatar>
+					<mat-icon>settings</mat-icon>
+				</div>
+				<mat-card-title>Event settings</mat-card-title>
+			</mat-card-header>
+			<mat-card-content>
+				<div class="header">Edit event</div>
+				<div>
+					<ng-container *ngTemplateOutlet="formContent"></ng-container>
+				</div>
+				<div class="header">Archive event</div>
+				<div class="event-settings-content archive">
+					<ng-container *ngTemplateOutlet="archiveContent"></ng-container>
+				</div>
+				<div class="header">Manage admins</div>
+				<div class="event-settings-content admins">
+					<ng-container *ngTemplateOutlet="adminsContent"></ng-container>
+				</div>
+				<div class="header">Delete event</div>
+				<div class="event-settings-content delete">
+					<div class="event-settings-text">
+						Warning: Deleting this event will remove the event in its entirety, along with all categories and expenses.
+						This action is irreversible.
+					</div>
+					<button mat-raised-button color="warn" (click)="deleteEvent()" [disabled]="!event.active">
+						{{ event.active ? 'Delete event' : 'Archived events cannot be deleted' }}
+					</button>
+				</div>
+			</mat-card-content>
+		</mat-card>
+	</div>
+</div>
+
+<ng-template #mobileView>
+	<div class="header-mobile">Edit event</div>
+	<ng-container *ngTemplateOutlet="formContent"></ng-container>
+	<div class="header-mobile">Archive event</div>
+	<div class="event-settings-content archive">
+		<ng-container *ngTemplateOutlet="archiveContent"></ng-container>
+	</div>
+	<div class="header-mobile admins">Manage admins</div>
+	<div class="admins">
+		<ng-container *ngTemplateOutlet="adminsContent"></ng-container>
+	</div>
+	<div class="header-mobile">Delete event</div>
+	<div class="event-settings-content delete-mobile">
+		<ng-container *ngTemplateOutlet="deleteContent"></ng-container>
+	</div>
+</ng-template>
+
+<ng-template #formContent>
+	<form (ngSubmit)="editEvent()" class="event-settings-content form">
+		<mat-form-field appearance="fill">
+			<mat-label>Event Name</mat-label>
+			<input matInput name="name" [(ngModel)]="eventData.name" required [eventName]="eventData.id" #name="ngModel" />
+			<mat-error *ngIf="name.errors?.['required']">Event name is required</mat-error>
+			<mat-error *ngIf="name.errors?.['duplicate']">Event name already exists</mat-error>
+			<mat-error *ngIf="name.errors?.['invalid']">Invalid event name</mat-error>
+		</mat-form-field>
+		<mat-form-field appearance="fill">
+			<mat-label>Event Description</mat-label>
+			<input matInput name="description" [(ngModel)]="eventData.description" />
+		</mat-form-field>
+		<button mat-raised-button color="primary" type="submit" [disabled]="name.invalid || name.pending" [ngClass]="(breakpointService.isMobile() | async) ? 'save-button-mobile' : 'save-button-pc'">
+			Save
+		</button>
+	</form>
+</ng-template>
+
+<ng-template #archiveContent>
+	<div *ngIf="event?.active; else activate">
+		<div class="event-settings-text">
+			This event is currently active.
+			By archiving the event any further editing by any participants will not be possible.
+		</div>
+		<button mat-raised-button color="primary" (click)="archiveEvent(true)">
+			Archive event
+		</button>
+	</div>
+	<ng-template #activate>
+		<div class="event-settings-text">
+			This event is currently archived.
+			By setting this event as active participants can start editing the event again.
+		</div>
+		<button mat-raised-button color="accent" (click)="archiveEvent(false)">
+			Set event as active
+		</button>
+	</ng-template>
+</ng-template>
+
+<ng-template #adminsContent>
+	<div class="admins-content" [ngClass]="{ 'full-view': (breakpointService.isMobile() | async) }">
+		<mat-nav-list>
+			<mat-list-item *ngFor="let admin of adminsInEvent">
+				<div class="admin">
+					<div class="name">
+						<img [src]="admin.avatarURL" class="avatar" />
+						{{ admin.name }}
+					</div>
+					<button mat-icon-button (click)="removeAdmin(admin.id)">
+						<mat-icon>remove</mat-icon>
+					</button>
+				</div>
+			</mat-list-item>
+		</mat-nav-list>
+		<div class="add-admin" [ngClass]="{ 'mobile': breakpointService.isMobile() | async }">
+			<mat-form-field *ngIf="otherUsersInEvent.length !== 0; else allUsersAdded">
+				<mat-select
+					[formControl]="addAdminForm.get('userId') | formControl"
+					name="userId"
+					placeholder="Add admins"
+					required
+				>
+					<mat-option *ngFor="let user of otherUsersInEvent" [value]="user.id">
+						<span class="name">
+							<img [src]="user.avatarURL" class="avatar" />
+							{{ user.name }}
+						</span>
+					</mat-option>
+				</mat-select>
+			</mat-form-field>
+			<ng-template #allUsersAdded>
+				<div class="all-users-admins">
+					All users in this event are admins
+				</div>
+			</ng-template>
+			<button
+				mat-icon-button
+				type="button"
+				(click)="addAdmin()"
+				[disabled]="
+					addAdminForm.get('userId')?.invalid ||
+					!addAdminForm.get('userId')?.dirty
+				"
+				class="add-admin-button"
+			>
+				<mat-icon>add_circle</mat-icon>
+			</button>
+		</div>
+	</div>
+</ng-template>
+
+<ng-template #deleteContent>
+	<div class="event-settings-text">
+		Warning: Deleting this event will remove the event in its entirety, along with all categories and expenses.
+		This action is irreversible.
+	</div>
+	<button mat-raised-button color="warn" (click)="deleteEvent()" [disabled]="!event.active">
+		{{ event.active ? 'Delete event' : 'Archived events cannot be deleted' }}
+	</button>
+</ng-template>
+
+<ng-template #loadingSpinner>
+	<loading-spinner></loading-spinner>
+</ng-template>

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.scss
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.scss
@@ -1,0 +1,128 @@
+.settings {
+	display: flex;
+	align-items: center;
+	flex-direction: column;
+	margin-top: 2em;
+
+	.card {
+		width: 40vw;
+		min-width: 30em;
+
+		.header {
+			padding: 12px 16px;
+			margin-bottom: 18px;
+			font-size: 16px;
+			background-color: rgba(33, 33, 33, 0.8);
+		}
+	}
+}
+
+.event-settings-content {
+	padding-left: 16px;
+	padding-right: 16px;
+
+	&.archive {
+		margin-bottom: 40px;
+	}
+
+	&.admins {
+		margin-bottom: 20px;
+	}
+
+	&.delete {
+		margin-bottom: 30px !important;
+	}
+
+	&.delete-mobile {
+		margin-bottom: 90px !important;
+	}
+}
+
+.form {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: 40px;
+
+	.save-button-pc {
+		max-width: 140px;
+	}
+
+	.save-button-mobile {
+		max-width: 100%;
+	}
+}
+
+.admins-content {
+	&.full-view {
+		width: 360px;
+	}
+
+	.admin {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.add-admin {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-top: 10px;
+
+		&.mobile {
+			margin-left: 16px;
+		}
+
+		mat-form-field {
+			width: 280px;
+		}
+
+		.all-users-admins {
+			color: rgba(255, 255, 255, 0.7);
+			margin-bottom: 18px;
+		}
+
+		.add-admin-button {
+			margin-bottom: 22px;
+			margin-left: 20px;
+			margin-right: 16px;
+		}
+	}
+}
+
+.name {
+	display: flex;
+	align-items: center;
+
+	.avatar {
+		position: relative;
+		width: 24px;
+		height: 24px;
+		margin-right: 16px;
+		border-radius: 50%;
+		object-fit: cover;
+	}
+}
+
+.header-mobile {
+	display: flex;
+	align-items: center;
+	height: 50px;
+	margin-bottom: 20px;
+	padding-left: 16px;
+	background-color: rgba(24, 24, 24, 1);
+	border-top: 1px solid #333333;
+	stroke: #333333;
+
+	&.admins {
+		margin-bottom: 0;
+	}
+}
+
+.event-settings-text {
+	margin-bottom: 20px;
+}
+
+mat-card-content {
+	padding: 0 !important;
+}

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.ts
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.ts
@@ -95,8 +95,8 @@ export class EventSettingsComponent {
 				},
 				error: (err: ApiError) => {
 					this.loading.next(false);
-					this.messageService.showError('Error loading data');
-					console.error('Something went wrong while data', err?.error?.message);
+					this.messageService.showError('Error loading event settings');
+					console.error('Something went wrong while loading event settings data', err?.error?.message);
 				},
 			});
 	};
@@ -152,6 +152,10 @@ export class EventSettingsComponent {
 				next: () => {
 					this.messageService.showSuccess('Event deleted successfully');
 					this.router.navigate(['/events']);
+				},
+				error: (err: ApiError) => {
+					this.messageService.showError('Failed to delete event');
+					console.error('Something went wrong while deleting event', err?.error?.message);
 				},
 			});
 	}

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.ts
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.ts
@@ -1,0 +1,237 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { BehaviorSubject, NEVER, Subscription, combineLatest, filter, switchMap } from 'rxjs';
+import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.service';
+import { EventService, PuddingEvent } from 'src/app/services/event/event.service';
+import { User, UserService } from 'src/app/services/user/user.service';
+import { AuthService } from 'src/app/services/auth/auth.service';
+import { MessageService } from 'src/app/services/message/message.service';
+import { ProgressSpinnerComponent } from "../../shared/progress-spinner/progress-spinner.component";
+import { ApiError } from 'src/app/types/apiError.type';
+import { EventNameValidatorDirective } from 'src/app/shared/forms/validators/async-event-name.validator';
+import { ConfirmDialogComponent } from 'src/app/features/confirm-dialog/confirm-dialog.component';
+import { FormControlPipe } from "../../shared/forms/form-control.pipe";
+
+@Component({
+    selector: 'event-settings',
+    templateUrl: 'event-settings.component.html',
+    styleUrls: ['./event-settings.component.scss'],
+    standalone: true,
+    imports: [
+        CommonModule,
+        MatButtonModule,
+        MatCardModule,
+        MatDialogModule,
+        MatIconModule,
+        MatListModule,
+        MatInputModule,
+        MatSelectModule,
+        MatFormFieldModule,
+        FormsModule,
+        ReactiveFormsModule,
+        ProgressSpinnerComponent,
+        EventNameValidatorDirective,
+        FormControlPipe
+    ]
+})
+export class EventSettingsComponent {
+	@Input() $event: BehaviorSubject<PuddingEvent>;
+	event: PuddingEvent;
+	loading: BehaviorSubject<boolean> = new BehaviorSubject(false);
+	eventData: { id?: string; name: string; description: string } = { name: '', description: '' };
+	adminsInEvent: User[];
+	otherUsersInEvent: User[];
+	currentUser: User;
+
+	addAdminForm = new FormGroup({
+		userId: new FormControl('', [Validators.required]),
+	}) as FormGroup;
+
+	private eventSubscription: Subscription;
+	private deleteSubscription: Subscription;
+	
+	constructor(
+		private router: Router,
+		private eventService: EventService,
+		private userService: UserService,
+		private authService: AuthService,
+		public breakpointService: BreakpointService,
+		private messageService: MessageService,
+		public dialog: MatDialog,
+	) {}
+
+	ngOnInit(): void {
+		this.loading.next(true);
+		this.eventSubscription = this.$event
+			.pipe(
+				filter((event) => event?.id !== undefined),
+				switchMap((event) => {
+					this.event = event;
+					this.eventData.id = event.id;
+					this.eventData.name = event.name;
+					this.eventData.description = event.description;
+					return combineLatest([
+						this.userService.loadUsersByEvent(event.id),
+						this.authService.getCurrentUser()
+					]);
+				})
+			)
+			.subscribe({
+				next: ([users, currentUser]) => {
+					this.adminsInEvent = users.filter(user => user.eventInfo.isAdmin);
+					this.otherUsersInEvent = users.filter(user => !user.eventInfo.isAdmin);
+					this.currentUser = currentUser;
+					this.loading.next(false);
+				},
+				error: (err: ApiError) => {
+					this.loading.next(false);
+					this.messageService.showError('Error loading data');
+					console.error('Something went wrong while data', err?.error?.message);
+				},
+			});
+	};
+
+	editEvent() {
+		this.eventService.editEvent({ id: this.event.id, name: this.eventData.name, description: this.eventData.description }).subscribe({
+			next: (event) => {
+				this.event = event;
+				this.messageService.showSuccess('Event successfully edited');
+			},
+			error: (err: ApiError) => {
+				this.messageService.showError('Failed to edit event');
+				console.error('Something went wrong while editing event', err?.error?.message);
+			},
+		});
+	}
+
+	archiveEvent(archive: boolean) {
+		this.eventService.editEvent({ id: this.event.id, active: !archive }).subscribe({
+			next: (event) => {
+				this.event = event;
+				this.messageService.showSuccess(archive ? 'Event successfully archived' : 'Event successfully set as active');
+			},
+			error: (err: ApiError) => {
+				this.messageService.showError('Failed to archive event');
+				console.error('Something went wrong while archiving event', err?.error?.message);
+			},
+		});
+	}
+
+	deleteEvent() {
+		const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+			width: '350px',
+			data: {
+				title: 'Delete event',
+				content: 'Are you sure you want to delete this event? This cannot be undone.',
+				confirm: 'Yes, I am sure',
+			},
+		});
+
+		this.deleteSubscription = dialogRef
+			.afterClosed()
+			.pipe(
+				switchMap((confirm) => {
+					if (confirm) {
+						return this.eventService.deleteEvent(this.event.id);
+					} else {
+						return NEVER;
+					}
+				})
+			)
+			.subscribe({
+				next: () => {
+					this.messageService.showSuccess('Event deleted successfully');
+					this.router.navigate(['/events']);
+				},
+			});
+	}
+
+	addAdmin() {
+		const newAdminId = this.addAdminForm.value.userId;
+		if (newAdminId) {
+			this.eventService.setUserAsAdmin(this.event.id, newAdminId).subscribe({
+				next: (res) => {
+					this.event = res;
+					const newAdmin = this.otherUsersInEvent.find((user) => user.id === newAdminId && res.adminIds.includes(newAdminId));
+					const index = this.otherUsersInEvent.findIndex((user) => user.id === newAdminId && res.adminIds.includes(newAdminId));
+					this.adminsInEvent.push(newAdmin);
+					this.otherUsersInEvent.splice(index, 1);
+
+					this.addAdminForm.get('userId')?.setValue('');
+					this.addAdminForm.get('userId')?.markAsUntouched();
+					this.messageService.showSuccess('Admin added successfully');
+				},
+				error: (err: ApiError) => {
+					this.messageService.showError('Failed to add admin');
+					console.error('Something went wrong while setting admin for event', err?.error?.message);
+				}
+			})
+		}
+	}
+
+	removeAdmin(userId: string) {
+		if (userId === this.currentUser.id) {
+			const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+				width: '350px',
+				data: {
+					title: 'Remove yourself as admin?',
+					content: 'Are you sure you want to remove yourself as admin for this event? This means you will lose access to this page, and cannot edit this event anymore.',
+					confirm: 'Yes, I am sure',
+				},
+			});
+
+			dialogRef
+				.afterClosed()
+				.pipe(
+					switchMap((confirm) => {
+						if (confirm) {
+							return this.eventService.removeUserAsAdmin(this.event.id, userId);
+						} else {
+							return NEVER;
+						}
+					})
+				)
+				.subscribe({
+					next: () => {
+						this.messageService.showSuccess('Admin removed successfully');
+						this.router.navigate(['/events']);
+					},
+					error: (err: ApiError) => {
+						this.messageService.showError('Failed to remove admin');
+						console.error('Something went wrong while removing admin from event', err?.error?.message);
+					}
+				});
+		}
+		else {
+			this.eventService.removeUserAsAdmin(this.event.id, userId).subscribe({
+				next: (res) => {
+					this.event = res;
+					const index = this.adminsInEvent.findIndex((user) => user.id === userId && !res.adminIds.includes(userId));
+					const user = this.adminsInEvent.find((user) => user.id === userId && !res.adminIds.includes(userId));
+					this.adminsInEvent.splice(index, 1);
+					this.otherUsersInEvent.push(user);
+					this.messageService.showSuccess('Admin removed successfully');
+				},
+				error: (err: ApiError) => {
+					this.messageService.showError('Failed to remove admin');
+					console.error('Something went wrong while removing admin from event', err?.error?.message);
+				}
+			});
+		}
+	}
+
+	ngOnDestroy(): void {
+		this.eventSubscription?.unsubscribe();
+		this.deleteSubscription?.unsubscribe();
+	}
+}

--- a/app/mikane/src/app/pages/event-settings/event-settings.guard.ts
+++ b/app/mikane/src/app/pages/event-settings/event-settings.guard.ts
@@ -1,0 +1,19 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { EventService } from 'src/app/services/event/event.service';
+import { map } from 'rxjs';
+
+export const eventSettingsGuard: CanActivateFn = (route, state) => {
+	const router = inject(Router);
+	const eventService = inject(EventService);
+	const eventId = route.parent.paramMap.get('eventId');
+	return eventService.getEvent(eventId).pipe(
+		map((event) => {
+			if (event.userInfo.isAdmin) {
+				return true;
+			} else {
+				return router.parseUrl(`/events/${eventId}/participants`);
+			}
+		})
+	);
+};

--- a/app/mikane/src/app/pages/event-settings/event-settings.routes.ts
+++ b/app/mikane/src/app/pages/event-settings/event-settings.routes.ts
@@ -1,0 +1,4 @@
+import { Route } from '@angular/router';
+import { EventSettingsComponent  } from './event-settings.component';
+
+export default [{ path: '', component: EventSettingsComponent }] as Route[];

--- a/app/mikane/src/app/pages/events/event/event.component.html
+++ b/app/mikane/src/app/pages/events/event/event.component.html
@@ -10,6 +10,9 @@
 	</div>
 	<div class="name">
 		{{ event.name }}
+		<button *ngIf="event.active === false && (breakpointService.isMobile() | async) === false" mat-stroked-button disabled>
+			Archived
+		</button>
 	</div>
 	<span class="toolbar-spacer"></span>
 	<menu [ngClass]="{ 'mobile-menu': breakpointService.isMobile() | async }"></menu>
@@ -21,8 +24,13 @@
 		[routerLink]="link.location"
 		(click)="activeLink = link.location"
 		[active]="activeLink == link.location"
-		>{{ link.name }}</a
+		[ngClass]="{ 'settings-tab': link.name === 'Settings' }"
 	>
+		<mat-icon *ngIf="link.name === 'Settings'; else name">settings</mat-icon>
+		<ng-template #name>
+			{{ link.name }}
+		</ng-template>
+	</a>
 </nav>
 <mat-tab-nav-panel #tabPanel></mat-tab-nav-panel>
 <ng-template #mobileNavbar>

--- a/app/mikane/src/app/pages/events/event/event.component.scss
+++ b/app/mikane/src/app/pages/events/event/event.component.scss
@@ -25,3 +25,8 @@ mat-toolbar button {
 	-webkit-line-clamp: 1;
 	-webkit-box-orient: vertical;
 }
+
+.settings-tab {
+	max-width: 10px;
+	background-color: #161616;
+}

--- a/app/mikane/src/app/pages/events/events.component.html
+++ b/app/mikane/src/app/pages/events/events.component.html
@@ -114,14 +114,14 @@
 </div>
 
 <ng-template #mobileView>
-	<div class="title-mobile">ACTIVE EVENTS</div>
+	<div class="title-mobile">Active events</div>
 	<mat-nav-list *ngIf="pagedEventsActive().length > 0; else noActiveEvents" class="events-list-mobile">
 		<event-item *ngFor="let event of eventsActive()" [event]="event" (click)="clickEvent(event)"></event-item>
 	</mat-nav-list>
 	<ng-template #noActiveEvents>
 		<div class="no-events-mobile">There are currently no active events</div>
 	</ng-template>
-	<div class="title-mobile">ARCHIVED EVENTS</div>
+	<div class="title-mobile">Archived events</div>
 	<mat-nav-list *ngIf="pagedEventsArchived().length > 0; else noArchivedEvents" class="events-list-mobile">
 		<event-item *ngFor="let event of eventsArchived()" [event]="event" (click)="clickEvent(event)"></event-item>
 	</mat-nav-list>

--- a/app/mikane/src/app/pages/events/events.component.ts
+++ b/app/mikane/src/app/pages/events/events.component.ts
@@ -9,8 +9,7 @@ import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { BehaviorSubject, NEVER, Subscription, switchMap } from 'rxjs';
-import { ConfirmDialogComponent } from 'src/app/features/confirm-dialog/confirm-dialog.component';
+import { BehaviorSubject, Subscription } from 'rxjs';
 import { MenuComponent } from 'src/app/features/menu/menu.component';
 import { EventItemComponent } from 'src/app/features/mobile/event-item/event-item.component';
 import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.service';
@@ -60,11 +59,8 @@ export class EventsComponent implements OnInit, OnDestroy {
 	});
 
 	selectedEvent!: PuddingEvent;
-
 	loading: BehaviorSubject<boolean> = new BehaviorSubject(false);
-
 	editSubscription: Subscription;
-	deleteSubscription: Subscription;
 
 	// Paginator
 	lengthActive = computed(() => {
@@ -142,38 +138,6 @@ export class EventsComponent implements OnInit, OnDestroy {
 		});
 	}
 
-	deleteEvent(deleteEvent: PuddingEvent) {
-		const dialogRef = this.dialog.open(ConfirmDialogComponent, {
-			width: '350px',
-			data: {
-				title: 'Delete event',
-				content: 'Are you sure you want to delete this event? This can not be undone.',
-				confirm: 'Yes, I am sure',
-			},
-		});
-
-		this.deleteSubscription = dialogRef
-			.afterClosed()
-			.pipe(
-				switchMap((confirm) => {
-					if (confirm) {
-						return this.eventService.deleteEvent(deleteEvent.id);
-					} else {
-						return NEVER;
-					}
-				})
-			)
-			.subscribe({
-				next: () => {
-					this.messageService.showSuccess('Event deleted successfully');
-					const index = this.events().indexOf(this.events().find((event) => event.id === deleteEvent.id));
-					if (~index) {
-						this.events().splice(index, 1);
-					}
-				},
-			});
-	}
-
 	openDialog() {
 		const dialogRef = this.dialog.open(EventDialogComponent, {
 			width: '350px',
@@ -186,11 +150,6 @@ export class EventsComponent implements OnInit, OnDestroy {
 						this.events.mutate(events => events.unshift(event));
 						this.startIndexActive.set(0);
 						this.endIndexActive.set(this.pageSizeActive());
-
-						this.router.navigate([event.id, 'users'], {
-							relativeTo: this.route,
-							state: { event: event },
-						});
 					},
 					error: (err: ApiError) => {
 						this.messageService.showError('Failed to create event');
@@ -224,6 +183,5 @@ export class EventsComponent implements OnInit, OnDestroy {
 
 	ngOnDestroy(): void {
 		this.editSubscription?.unsubscribe();
-		this.deleteSubscription?.unsubscribe();
 	}
 }

--- a/app/mikane/src/app/pages/events/events.routes.ts
+++ b/app/mikane/src/app/pages/events/events.routes.ts
@@ -2,6 +2,7 @@ import { Route } from '@angular/router';
 import { authGuard } from 'src/app/services/auth/auth.guard';
 import { EventComponent } from './event/event.component';
 import { EventsComponent } from './events.component';
+import { eventSettingsGuard } from '../event-settings/event-settings.guard';
 
 export default [
 	{ path: '', component: EventsComponent },
@@ -26,6 +27,12 @@ export default [
 				path: 'payment',
 				loadChildren: () => import('../payment-structure/payment-structure.routes'),
 			},
+			{
+				path: 'settings',
+				canActivate: [eventSettingsGuard],
+				loadChildren: () => import('../event-settings/event-settings.routes'),
+			},
+			{ path: '**', redirectTo: 'participants' },
 		],
 	},
 ] as Route[];

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.ts
@@ -39,9 +39,9 @@ import { ExpenditureDialogComponent } from './expenditure-dialog/expenditure-dia
 	],
 })
 export class ExpendituresComponent implements OnInit, OnDestroy {
-	event!: PuddingEvent;
-
 	@Input() $event: BehaviorSubject<PuddingEvent>;
+	
+	event!: PuddingEvent;
 	private eventSubscription: Subscription;
 
 	loading: BehaviorSubject<boolean> = new BehaviorSubject(false);

--- a/app/mikane/src/app/pages/participant/participant.component.html
+++ b/app/mikane/src/app/pages/participant/participant.component.html
@@ -49,7 +49,7 @@
 							<img [src]="userWithBalance.user.avatarURL" class="avatar" />
 							{{ userWithBalance.user.name }}
 						</div>
-						<div class="count">{{ userWithBalance.expensesCount }}</div>
+						<div class="count" [ngClass]="{ 'no-expenses': userWithBalance.expensesCount === 0 }">{{ userWithBalance.expensesCount }}</div>
 						<div>{{ userWithBalance.spending | currency : "" : "" : "1.2-2" : "no" }} kr</div>
 						<div>{{ userWithBalance.expenses | currency : "" : "" : "1.2-2" : "no" }} kr</div>
 						<div class="amount-color">{{ userWithBalance.balance | currency : "" : "" : "1.2-2" : "no" }} kr</div>
@@ -148,6 +148,9 @@
 			{{ isAdmin ? "You are an admin in this event" : "You are in this event" }}
 			<mat-icon>{{ isAdmin ? "star" : "check" }}</mat-icon>
 		</span>
+		<button mat-icon-button *ngIf="isAdmin" (click)="gotoSettings()">
+			<mat-icon>settings</mat-icon>
+		</button>
 		<ng-template #notInEvent>
 			<span class="not-in-event">You are not in this event</span>
 		</ng-template>

--- a/app/mikane/src/app/pages/participant/participant.component.scss
+++ b/app/mikane/src/app/pages/participant/participant.component.scss
@@ -30,10 +30,15 @@
 .count {
 	width: 20%;
 	text-align: left;
+
+	&.no-expenses {
+		color: rgba(255, 255, 255, 0.3);
+	}
 }
 
 .header-mobile {
 	display: flex;
+	justify-content: space-between;
 	align-items: center;
 	height: 40px;
 	padding-left: 16px;

--- a/app/mikane/src/app/pages/participant/participant.component.ts
+++ b/app/mikane/src/app/pages/participant/participant.component.ts
@@ -10,7 +10,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSortModule, Sort } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, Observable, Subject, Subscription, combineLatest, forkJoin, map, of, switchMap, takeUntil } from 'rxjs';
 import { ConfirmDialogComponent } from 'src/app/features/confirm-dialog/confirm-dialog.component';
 import { ParticipantItemComponent } from 'src/app/features/mobile/participant-item/participant-item.component';
@@ -75,6 +75,7 @@ export class ParticipantComponent implements OnInit, OnDestroy {
 		private userService: UserService,
 		private eventService: EventService,
 		private route: ActivatedRoute,
+		private router: Router,
 		public dialog: MatDialog,
 		private messageService: MessageService,
 		private expenseService: ExpenseService,
@@ -344,6 +345,10 @@ export class ParticipantComponent implements OnInit, OnDestroy {
 			}),
 		];
 		this.usersWithBalance$.next(this.usersWithBalance);
+	}
+
+	gotoSettings() {
+		this.router.navigate(['events', this.eventId, 'settings']);
 	}
 
 	private compare(a: string | number, b: string | number, isAsc: boolean) {

--- a/app/mikane/src/app/services/event/event.service.ts
+++ b/app/mikane/src/app/services/event/event.service.ts
@@ -46,12 +46,16 @@ export class EventService {
 		return this.httpClient.get<Payment[]>(this.apiUrl + `/${eventId}/payments`);
 	}
 
+	getEvent(eventId: string): Observable<PuddingEvent> {
+		return this.httpClient.get<PuddingEvent>(this.apiUrl + `/${eventId}`);
+	}
+
 	createEvent({ name, description }: { name: string; description: string }): Observable<PuddingEvent> {
 		return this.httpClient.post<PuddingEvent>(this.apiUrl, { name, description, private: false });
 	}
 
-	editEvent({ id, name, description }: { id: string; name: string; description: string }): Observable<PuddingEvent> {
-		return this.httpClient.put<PuddingEvent>(this.apiUrl + `/${id}`, { name, description, private: false });
+	editEvent({ id, name, description, active }: { id: string; name?: string; description?: string; active?: boolean }): Observable<PuddingEvent> {
+		return this.httpClient.put<PuddingEvent>(this.apiUrl + `/${id}`, { name, description, private: false, active });
 	}
 
 	deleteEvent(eventId: string): Observable<void> {
@@ -64,5 +68,13 @@ export class EventService {
 
 	removeUser(eventId: string, userId: string): Observable<PuddingEvent> {
 		return this.httpClient.delete<PuddingEvent>(this.apiUrl + `/${eventId}/user/${userId}`);
+	}
+
+	setUserAsAdmin(eventId: string, userId: string): Observable<PuddingEvent> {
+		return this.httpClient.post<PuddingEvent>(this.apiUrl + `/${eventId}/admin/${userId}`, {});
+	}
+
+	removeUserAsAdmin(eventId: string, userId: string): Observable<PuddingEvent> {
+		return this.httpClient.delete<PuddingEvent>(this.apiUrl + `/${eventId}/admin/${userId}`);
 	}
 }


### PR DESCRIPTION
Implement event settings page.

Changelog:
- Add event settings page with the following features:
  - Edit event name and description
  - Archive/set active event
  - Add and remove event admins
  - Delete event
- The event setting page is accesible only for admins, via a navigation tab in full view, and a cog icon in the header on the participants page in mobile view
- Archived tag by the event name in full view
- On the participants page, darken the color of the number of expenses if it is 0

Closes #88 