### PR TITLE
feat: User deletion improvements

### DIFF
--- a/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.html
+++ b/app/mikane/src/app/pages/account/danger-zone/danger-zone.component.html
@@ -22,11 +22,11 @@
 		<h2>Delete your account</h2>
 	</div>
 	<div class="delete-account-text">
-		When the deletion process is initiated by clicking the button below you will get a confirmation email with the deletion link. Think
-		hard before you press this link!
+		When you initiate the deletion process by clicking the button below, you will receive a confirmation email containing the deletion link.
+		Take a moment to consider your decision before proceeding with this link.
 		<br /><br />
-		If you decide to proceed, you should know: once an account has been deleted you cannot go back. There is no undo button. The data is
-		gone permanently and no one can get it back for you.
+		If you decide to proceed, here's what you should know: Your contributions to active events will be removed completely. For events that have been archived,
+		to maintain the event's integrity, your contributions will be anonymized. This means that there won't be any identifiable connection back to your account.
 	</div>
 	<mat-card-actions>
 		<button type="button" [class.spinner]="loading" [disabled]="loading" mat-stroked-button color="warn" (click)="deleteUser()">

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.html
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.html
@@ -22,13 +22,7 @@
 				</div>
 				<div class="header">Delete event</div>
 				<div class="event-settings-content delete">
-					<div class="event-settings-text">
-						Warning: Deleting this event will remove the event in its entirety, along with all categories and expenses.
-						This action is irreversible.
-					</div>
-					<button mat-raised-button color="warn" (click)="deleteEvent()" [disabled]="!event.active">
-						{{ event.active ? 'Delete event' : 'Archived events cannot be deleted' }}
-					</button>
+					<ng-container *ngTemplateOutlet="deleteContent"></ng-container>
 				</div>
 			</mat-card-content>
 		</mat-card>

--- a/server/db_scripts/delete_event.sql
+++ b/server/db_scripts/delete_event.sql
@@ -18,6 +18,10 @@ begin
     raise exception 'Only event admins can delete event' using errcode = 'P0085';
   end if;
 
+  if exists (select 1 from "event" e where e.id = ip_event_id and e.active = false) then
+    raise exception 'Archived events cannot be deleted' using errcode = 'P0119';
+  end if;
+
   delete from "event" e where e.id = ip_event_id;
 
 end;

--- a/server/db_scripts/delete_user_from_event.sql
+++ b/server/db_scripts/delete_user_from_event.sql
@@ -1,0 +1,40 @@
+drop function if exists delete_user_from_event;
+create or replace function delete_user_from_event(
+  ip_user_id uuid,
+  ip_event_id uuid
+)
+returns void as
+$$
+begin
+
+  if exists (select 1 from "event" e where e.id = ip_event_id and e.active = false) then
+    raise exception 'Cannot delete user from archived event' using errcode = 'P0120';
+  end if;
+
+  delete from
+    expense ex
+  using
+    category c
+  where
+    ex.category_id = c.id and
+    c.event_id  = ip_event_id and
+    ex.payer_id = ip_user_id;
+  
+  delete from
+    user_category uc
+  using
+    category c
+  where
+    c.id = uc.category_id and
+    uc.user_id = ip_user_id and
+    c.event_id = ip_event_id;
+
+  delete from
+    user_event ue
+  where
+    ue.user_id = ip_user_id and
+    ue.event_id = ip_event_id;
+
+end;
+$$
+language plpgsql;

--- a/server/db_scripts/get_user.sql
+++ b/server/db_scripts/get_user.sql
@@ -31,7 +31,7 @@ begin
     from
       "user" u
     where
-      u.username = ip_username and
+      u.username ilike ip_username and
       u.deleted = false;
   end if;
 end;

--- a/server/db_scripts/schema/db_schema.sql
+++ b/server/db_scripts/schema/db_schema.sql
@@ -22,8 +22,8 @@ create table "event" (
 create index idx_event_created on "event"(created);
 
 create table user_event (
-  user_id uuid references "user"(id) on delete cascade,
-  event_id uuid references "event"(id) on delete cascade,
+  user_id uuid not null references "user"(id) on delete cascade,
+  event_id uuid not null references "event"(id) on delete cascade,
   joined_time timestamp not null,
   "admin" boolean not null,
   primary key (user_id, event_id)
@@ -34,14 +34,14 @@ create table category (
   "name" varchar(255) not null,
   icon varchar(255),
   weighted boolean not null,
-  event_id uuid references "event"(id) on delete cascade,
+  event_id uuid not null references "event"(id) on delete cascade,
   created timestamp not null
 );
 create index idx_category_created on category(created);
 
 create table user_category (
-  user_id uuid references "user"(id) on delete cascade,
-  category_id uuid references category(id) on delete cascade,
+  user_id uuid not null references "user"(id) on delete cascade,
+  category_id uuid not null references category(id) on delete cascade,
   "weight" numeric(14),
    joined_time timestamp not null,
   primary key (user_id, category_id)
@@ -52,7 +52,7 @@ create table expense (
   "name" varchar(255) not null,
   "description" varchar(255),
   amount numeric(16, 2) not null,
-  category_id uuid references category(id) on delete cascade,
+  category_id uuid not null references category(id) on delete cascade,
   payer_id uuid references "user"(id) on delete cascade,
   created timestamp not null
 );
@@ -62,7 +62,7 @@ create table "session" (
   "sid" varchar(255) not null primary key,
   "session" json not null,
   expires timestamp not null,
-  user_id uuid references "user"(id) on delete cascade
+  user_id uuid not null references "user"(id) on delete cascade
 );
 
 create table api_key (
@@ -77,20 +77,21 @@ create table api_key (
 create table register_account_key (
   "key" varchar(255) primary key,
   email varchar(255) not null,
+  user_id uuid references "user"(id) on delete cascade,
   used boolean not null,
   expires timestamp not null
 );
 
 create table delete_account_key (
   "key" varchar(255) primary key,
-  user_id uuid references "user"(id) on delete set null,
+  user_id uuid not null references "user"(id) on delete set null,
   used boolean not null,
   expires timestamp not null
 );
 
 create table password_reset_key (
   "key" varchar(255) primary key,
-  user_id uuid references "user"(id) on delete cascade,
+  user_id uuid not null references "user"(id) on delete cascade,
   used boolean not null,
   expires timestamp not null
 );

--- a/server/src/api/expenses.ts
+++ b/server/src/api/expenses.ts
@@ -59,7 +59,7 @@ router.get("/expenses/:id", authCheck, async (req, res, next) => {
 */
 router.post("/expenses", authCheck, async (req, res, next) => {
   try {
-    if (!req.body.name || !req.body.amount || !req.body.categoryId || !req.body.payerId) {
+    if (!req.body.name || [null, undefined].includes(req.body.amount) || !req.body.categoryId || !req.body.payerId) {
       throw new ErrorExt(ec.PUD057);
     }
 

--- a/server/src/api/users.ts
+++ b/server/src/api/users.ts
@@ -345,16 +345,12 @@ router.delete("/users/:id", authCheck, async (req, res, next) => {
 
     const success = await db.deleteUser(userId, key);
 
-    // Delete current session if deleted user is logged in
-    if (req.session.authenticated && req.session.userId === userId) {
-      const username = req.session.username;
-      req.session.destroy(err => {
-        if (err) {
-          throw new ErrorExt(ec.PUD060, err);
-        }
-        console.log(`User ${username} successfully signed out`);
-      });
-    }
+    // Destroy all sessions for this user
+    req.sessionStore.destroyAll(userId, err => {
+      if (err) {
+        throw new ErrorExt(ec.PUD083);
+      }
+    });
 
     res.status(200).send({ success: success });
   }

--- a/server/src/db/dbEvents.ts
+++ b/server/src/db/dbEvents.ts
@@ -246,6 +246,8 @@ export const deleteEvent = async (id: string, userId: string) => {
         throw new ErrorExt(ec.PUD006, err);
       else if (err.code === "P0085")
         throw new ErrorExt(ec.PUD085, err);
+      else if (err.code === "P0119")
+        throw new ErrorExt(ec.PUD119, err);
       else
         throw new ErrorExt(ec.PUD023, err);
     });

--- a/server/src/db/dbUsers.ts
+++ b/server/src/db/dbUsers.ts
@@ -58,9 +58,10 @@ export const getUserID = async (email: string) => {
  * @returns List of users
  */
 export const getUsers = async (filter?: { eventId?: string, excludeUserId?: string }) => {
+  const withDeleted = filter?.eventId ? null : false;
   const query = {
-    text: "SELECT * FROM get_users($1, $2, false)",
-    values: [filter?.eventId, filter?.excludeUserId]
+    text: "SELECT * FROM get_users($1, $2, $3)",
+    values: [filter?.eventId, filter?.excludeUserId, withDeleted]
   };
   const users: User[] = await pool.query(query)
     .then(data => {
@@ -185,6 +186,8 @@ export const deleteUser = async (userId: string, key: string) => {
         throw new ErrorExt(ec.PUD008, err);
       else if (err.code === "P0108")
         throw new ErrorExt(ec.PUD108, err);
+      else if (err.code === "P0120")
+        throw new ErrorExt(ec.PUD120, err);
       else
         throw new ErrorExt(ec.PUD025, err);
     });

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -1122,3 +1122,22 @@ export const PUD118: ErrorCode = {
   message: "Archived events cannot be edited",
   status: 400
 };
+
+/**
+ * PUD-119: Archived events cannot be deleted
+ */
+export const PUD119: ErrorCode = {
+  code: "PUD-119",
+  message: "Archived events cannot be deleted",
+  status: 400
+};
+
+/**
+ * PUD-120: Cannot delete user from archived event (500)
+ */
+export const PUD120: ErrorCode = {
+  code: "PUD-120",
+  message: "Cannot delete user from archived event",
+  status: 500,
+  log: true
+};

--- a/server/tests/events.test.ts
+++ b/server/tests/events.test.ts
@@ -622,5 +622,47 @@ describe("events", async () => {
       expect(res.status).toEqual(403);
       expect(res.body.code).toEqual(ec.PUD085.code);
     });
+
+    test("should set event as archived", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: false
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(false);
+    });
+
+    test("fail delete archived event", async () => {
+      const res = await request(app)
+        .delete("/api/events/" + event.id)
+        .set("Cookie", authToken);
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD119.code);
+    });
+
+    test("should set event as active", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          active: true
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.active).toEqual(true);
+    });
+
+    test("should delete event", async () => {
+      const res = await request(app)
+        .delete("/api/events/" + event.id)
+        .set("Cookie", authToken);
+
+      expect(res.status).toEqual(200);
+      expect(res.body.success).toEqual(true);
+    });
   });
 });

--- a/server/tests/users.test.ts
+++ b/server/tests/users.test.ts
@@ -3,7 +3,7 @@ import request from "supertest";
 import nodemailerMock from "nodemailer-mock";
 import app from "./setup";
 import * as ec from "../src/types/errorCodes";
-import { User } from "../src/types/types";
+import { Category, Event, User } from "../src/types/types";
 
 // Mock nodemailer
 vi.mock("nodemailer", () => nodemailerMock);
@@ -288,6 +288,108 @@ describe("users", async () => {
   /* DELETE /users/:id */
   /* ----------------- */
   describe("DELETE /users/:id", async () => {
+
+    let event1: Event;
+    let event2: Event;
+
+    test("create 2 events, add users to both, create category/expense, then archive one event", async () => {
+      event1 = (await request(app)
+        .post("/api/events")
+        .set("Cookie", authToken)
+        .send({
+          name: "Event1",
+          private: false
+        })).body;
+
+      event2 = (await request(app)
+        .post("/api/events")
+        .set("Cookie", authToken)
+        .send({
+          name: "Event2",
+          private: false
+        })).body;
+
+      await request(app)
+        .post(`/api/events/${event1.id}/user/${user2.id}`)
+        .set("Cookie", authToken);
+      await request(app)
+        .post(`/api/events/${event2.id}/user/${user2.id}`)
+        .set("Cookie", authToken);
+
+      const category1: Category = (await request(app)
+        .post("/api/categories")
+        .set("Cookie", authToken)
+        .send({
+          name: "Category1",
+          icon: "shopping_cart",
+          weighted: false,
+          eventId: event1.id
+        })).body;
+
+      const category2: Category = (await request(app)
+        .post("/api/categories")
+        .set("Cookie", authToken)
+        .send({
+          name: "Category2",
+          icon: "shopping_cart",
+          weighted: false,
+          eventId: event2.id
+        })).body;
+
+      await request(app)
+        .post(`/api/categories/${category1.id}/user/${user.id}`)
+        .set("Cookie", authToken);
+      await request(app)
+        .post(`/api/categories/${category1.id}/user/${user2.id}`)
+        .set("Cookie", authToken);
+      await request(app)
+        .post(`/api/categories/${category2.id}/user/${user.id}`)
+        .set("Cookie", authToken);
+      await request(app)
+        .post(`/api/categories/${category2.id}/user/${user2.id}`)
+        .set("Cookie", authToken);
+
+      await request(app)
+        .post("/api/expenses")
+        .set("Cookie", authToken)
+        .send({
+          name: "Expense1",
+          amount: "100",
+          categoryId: category1.id,
+          payerId: user2.id
+        });
+
+      await request(app)
+        .post("/api/expenses")
+        .set("Cookie", authToken)
+        .send({
+          name: "Expense2",
+          amount: "200",
+          categoryId: category2.id,
+          payerId: user2.id
+        });
+
+      await request(app)
+        .put("/api/events/" + event1.id)
+        .set("Cookie", authToken)
+        .send({
+          active: false
+        });
+
+      const finalEvent1: Event = (await request(app)
+        .get("/api/events/" + event1.id)
+        .set("Cookie", authToken2)).body;
+      const finalEvent2: Event = (await request(app)
+        .get("/api/events/" + event2.id)
+        .set("Cookie", authToken2)).body;
+
+      expect(finalEvent1.active).toEqual(false);
+      expect(finalEvent1.userInfo?.inEvent).toEqual(true);
+
+      expect(finalEvent2.active).toEqual(true);
+      expect(finalEvent2.userInfo?.inEvent).toEqual(true);
+    });
+
     test("fail delete user without delete account key", async () => {
       const res = await request(app)
         .delete("/api/users/" + user2.id)
@@ -328,6 +430,26 @@ describe("users", async () => {
 
       expect(res.status).toEqual(404);
       expect(res.body.code).toEqual(ec.PUD008.code);
+    });
+
+    test("confirm user2 is deleted from active event", async () => {
+      const res = await request(app)
+        .get("/api/users")
+        .set("Cookie", authToken)
+        .query("eventId=" + event2.id);
+
+      expect(res.body.length).toEqual(1);
+      expect(res.body).not.toContainEqual(expect.objectContaining({ id: user2.id }));
+    });
+
+    test("confirm user2 (as deleted user) is still in archived event", async () => {
+      const res = await request(app)
+        .get("/api/users")
+        .set("Cookie", authToken)
+        .query("eventId=" + event1.id);
+
+      expect(res.body.length).toEqual(2);
+      expect(res.body).toContainEqual(expect.objectContaining({ id: user2.id, name: "Deleted user" }));
     });
   });
 


### PR DESCRIPTION
When a user account is deleted the user will now be removed from all active events, while their anonymized data will still be retained in archived events.

Other changes:
- Update frontend account page to accomodate for this account deletion change
- Fix bug where expenses with amount zero were not allowed
- Add better constraints on certain foreign keys in the database
- Prevent archived events from being deleted (this means an event will need to be set active before deletion)
- Fix bug with getting user by username
- Add tests related to event archival and user deletion

Closes #265 