### PR TITLE
fix: Edit category and expense issues

### DIFF
--- a/app/mikane/src/app/features/mobile/category-item/category-item.component.html
+++ b/app/mikane/src/app/features/mobile/category-item/category-item.component.html
@@ -21,7 +21,7 @@
 			</span>
 		</div>
 		<mat-list-item *ngFor="let user of category.users">
-			<div class="user">
+			<div class="user data">
 				<span class="name">
 					<img [src]="user.avatarURL" class="avatar" />
 					{{ user.name }}

--- a/app/mikane/src/app/features/mobile/category-item/category-item.component.scss
+++ b/app/mikane/src/app/features/mobile/category-item/category-item.component.scss
@@ -46,6 +46,10 @@
 			background-color: #1c1c1c;
 		}
 
+		&.data {
+			min-height: 40px;
+		}
+
 		.name {
 			width: 50%;
 			display: flex;

--- a/app/mikane/src/app/pages/category/category-dialog/category-dialog.component.html
+++ b/app/mikane/src/app/pages/category/category-dialog/category-dialog.component.html
@@ -1,4 +1,4 @@
-<h1 mat-dialog-title>{{ data.icon ? "Edit Expense Category" : "Add Expense Category" }}</h1>
+<h1 mat-dialog-title>{{ data.name ? "Edit Expense Category" : "Add Expense Category" }}</h1>
 <div mat-dialog-content>
 	<form [formGroup]="addCategoryForm">
 		<mat-form-field appearance="fill">
@@ -18,7 +18,7 @@
 			<mat-error *ngIf="addCategoryForm?.get('categoryName')?.errors?.['duplicate']">Category already exists</mat-error>
 			<mat-error *ngIf="addCategoryForm?.get('categoryName')?.errors?.['invalid']">Invalid category name</mat-error>
 		</mat-form-field>
-		<div *ngIf="!data.icon">
+		<div *ngIf="!data.name">
 			<mat-checkbox name="weighted" formControlName="weighted">Weighted</mat-checkbox>
 		</div>
 	</form>

--- a/app/mikane/src/app/pages/category/category-dialog/category-dialog.component.ts
+++ b/app/mikane/src/app/pages/category/category-dialog/category-dialog.component.ts
@@ -57,10 +57,12 @@ export class CategoryDialogComponent implements OnInit {
 	) {}
 
 	ngOnInit(): void {
-		if (this.data.icon) {
+		if (this.data.name) {
 			// Category is being edited
 			this.addCategoryForm.get('categoryName').patchValue(this.data.name);
-			this.addCategoryForm.get('selectedIcon').patchValue(this.data.icon);
+			if (this.data.icon) {
+				this.addCategoryForm.get('selectedIcon').patchValue(this.data.icon);
+			}
 			this.addCategoryForm.markAsDirty();
 		}
 	}

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.ts
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.ts
@@ -81,7 +81,7 @@ export class EventSettingsComponent {
 					this.eventData.name = event.name;
 					this.eventData.description = event.description;
 					return combineLatest([
-						this.userService.loadUsersByEvent(event.id),
+						this.userService.loadUsersByEvent(event.id, true),
 						this.authService.getCurrentUser(),
 					]);
 				})

--- a/app/mikane/src/app/pages/expenditures/expenditure-dialog/expenditure-dialog.component.html
+++ b/app/mikane/src/app/pages/expenditures/expenditure-dialog/expenditure-dialog.component.html
@@ -1,4 +1,4 @@
-<h1 mat-dialog-title>Add Expense</h1>
+<h1 mat-dialog-title>{{ edit ? 'Edit Expense' : 'Add Expense' }}</h1>
 <div mat-dialog-content>
 	<form [formGroup]="addExpenseForm" autocomplete="off">
 		<mat-form-field appearance="fill">

--- a/app/mikane/src/app/pages/expenditures/expenditure-dialog/expenditure-dialog.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expenditure-dialog/expenditure-dialog.component.ts
@@ -40,6 +40,7 @@ import { CategoryIcon } from 'src/app/types/enums';
 })
 export class ExpenditureDialogComponent implements OnInit {
 	isOpen: boolean = false;
+	edit: boolean = false;
 	categoryIcons = CategoryIcon;
 
 	categories: Category[] = [];
@@ -79,6 +80,7 @@ export class ExpenditureDialogComponent implements OnInit {
 
 		if (this.data.expense) {
 			// Expense is being edited
+			this.edit = true;
 			this.addExpenseForm.get('name').patchValue(this.data.expense.name);
 			this.addExpenseForm.get('description').patchValue(this.data.expense.description);
 			this.addExpenseForm.get('category').patchValue(this.data.expense.categoryInfo.name);


### PR DESCRIPTION
Changelog:
- Fix bug where edit expense dialog had wrong title
- Fix bug where edit category dialog appeared as new category if category had no set icon
- Fix bug where guests would be loaded as potential admins
- Fix height of the user list in a category for archived events, when in mobile view

Closes #267, closes #268 