### PR TITLE
feat: Expense page (mobile)

### DIFF
--- a/app/mikane/src/app/features/mobile/expense-item/expense-item.component.html
+++ b/app/mikane/src/app/features/mobile/expense-item/expense-item.component.html
@@ -1,4 +1,4 @@
-<mat-list-item class="wrapper">
+<mat-list-item class="wrapper" (click)="gotoExpense()">
 	<mat-icon matListItemIcon class="expense-icon">{{ expense.categoryInfo.icon ?? 'shopping_cart' }}</mat-icon>
 	<div class="price-category">
 		<span class="amount-color-darker">{{ expense.amount | currency : "" : "" : "1.2-2" : "no" }} kr</span>

--- a/app/mikane/src/app/features/mobile/expense-item/expense-item.component.scss
+++ b/app/mikane/src/app/features/mobile/expense-item/expense-item.component.scss
@@ -34,18 +34,18 @@
 	color: rgba(255, 255, 255, 0.7);
 	font-size: 0.9em;
 	margin-top: 4px;
-}
 
-.payer-avatar {
-	position: relative;
-	width: 16px;
-	height: 16px;
-	margin-right: 6px;
-	border-radius: 50%;
-	object-fit: cover;
-}
-
-.payer-name {
-	position: relative;
-	top: 1px;
+	.payer-avatar {
+		position: relative;
+		width: 16px;
+		height: 16px;
+		margin-right: 6px;
+		border-radius: 50%;
+		object-fit: cover;
+	}
+	
+	.payer-name {
+		position: relative;
+		top: 1px;
+	}
 }

--- a/app/mikane/src/app/features/mobile/expense-item/expense-item.component.ts
+++ b/app/mikane/src/app/features/mobile/expense-item/expense-item.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { CurrencyPipe } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Expense } from 'src/app/services/expense/expense.service';
 import { MatListModule } from '@angular/material/list';
 
@@ -13,4 +14,10 @@ import { MatListModule } from '@angular/material/list';
 })
 export class ExpenseItemComponent {
 	@Input('expense') expense: Expense;
+
+	constructor(private router: Router, private route: ActivatedRoute) {};
+
+	gotoExpense() {
+		this.router.navigate([this.expense.id], { relativeTo: this.route });
+	}
 }

--- a/app/mikane/src/app/pages/events/event/event.component.ts
+++ b/app/mikane/src/app/pages/events/event/event.component.ts
@@ -110,7 +110,7 @@ export class EventComponent implements OnInit {
 
 	ngOnInit() {
 		// Set active link based on current URL
-		this.activeLink = './' + window.location.href.substring(window.location.href.lastIndexOf('/') + 1);
+		this.activeLink = this.getActiveLinkFromUrl(window.location.href);
 
 		this.router.events.subscribe((event) => {
 			if (event instanceof NavigationEnd) {
@@ -142,5 +142,19 @@ export class EventComponent implements OnInit {
 					this.messageService.showError('Error loading events');
 				},
 			});
+	}
+
+	getActiveLinkFromUrl(url: string) {
+		const lastSegment = url.substring(url.lastIndexOf('/') + 1);
+		if (this.isUUID(lastSegment)) {
+			return `.${url.substring(url.lastIndexOf('/'), url.lastIndexOf('/', url.lastIndexOf('/') - 1))}`;
+		}
+
+		return `./${lastSegment}`;
+	}
+
+	isUUID(text: string) {
+		const regex = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
+		return regex.test(text);
 	}
 }

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.html
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.html
@@ -40,7 +40,7 @@
 
 			<!-- Payer Column -->
 			<ng-container matColumnDef="payer">
-				<th mat-header-cell *matHeaderCellDef mat-sort-header>Payer</th>
+				<th mat-header-cell *matHeaderCellDef mat-sort-header>Paid by</th>
 				<td mat-cell *matCellDef="let expense">
 					<div class="payer">
 						<img [src]="expense.payer.avatarURL" class="payer-avatar" />

--- a/app/mikane/src/app/pages/expenditures/expenditures.routes.ts
+++ b/app/mikane/src/app/pages/expenditures/expenditures.routes.ts
@@ -1,4 +1,8 @@
 import { Route } from '@angular/router';
 import { ExpendituresComponent } from './expenditures.component';
+import { ExpenseComponent } from './expense/expense.component';
 
-export default [{ path: '', component: ExpendituresComponent }] as Route[];
+export default [
+  { path: '', component: ExpendituresComponent },
+  { path: ':id', component: ExpenseComponent},
+] as Route[];

--- a/app/mikane/src/app/pages/expenditures/expense/expense.component.html
+++ b/app/mikane/src/app/pages/expenditures/expense/expense.component.html
@@ -1,0 +1,54 @@
+<div *ngIf="loading === false; else loadingSpinner" class="expense-content">
+	<div>
+		<div class="title">
+			<div class="header expense-title">Expense</div>
+			<div class="name">
+				{{ expense.name }}
+			</div>
+		</div>
+		<div class="title">
+			<div class="header">Category</div>
+			<div class="category">
+				<mat-icon class="icon">{{ expense.categoryInfo.icon ?? "shopping_cart" }}</mat-icon>
+				<span>{{ expense.categoryInfo.name }}</span>
+			</div>
+		</div>
+		<div class="title">
+			<div class="header">Amount</div>
+			<div class="amount">
+				<span class="amount-color-darker">{{ expense.amount | currency : "" : "" : "1.2-2" : "no" }} kr</span>
+			</div>
+		</div>
+		<div class="title">
+			<div class="header">Paid by</div>
+			<div class="payer">
+				<img [src]="expense.payer.avatarURL" class="payer-avatar" />
+				<div id="payer-name">{{ expense.payer.name }}</div>
+			</div>
+		</div>
+		<div *ngIf="expense.description" class="title">
+			<div class="header">Description</div>
+			<div>{{ expense.description }}</div>
+		</div>
+	</div>
+	<div class="buttons">
+		<div>
+			<button mat-button (click)="goBack()">
+				<mat-icon class="back">arrow_back</mat-icon>
+				<span class="back">Back</span>
+			</button>
+		</div>
+		<div>
+			<button mat-icon-button *ngIf="expense.payer.id === currentUserId || event?.userInfo?.isAdmin" (click)="editExpense()">
+				<mat-icon>edit</mat-icon>
+			</button>
+			<button mat-icon-button *ngIf="expense.payer.id === currentUserId || event?.userInfo?.isAdmin" color="warn" (click)="removeExpense()">
+				<mat-icon>delete</mat-icon>
+			</button>
+		</div>
+	</div>
+</div>
+
+<ng-template #loadingSpinner>
+	<loading-spinner></loading-spinner>
+</ng-template>

--- a/app/mikane/src/app/pages/expenditures/expense/expense.component.html
+++ b/app/mikane/src/app/pages/expenditures/expense/expense.component.html
@@ -38,11 +38,11 @@
 				<span class="back">Back</span>
 			</button>
 		</div>
-		<div>
-			<button mat-icon-button *ngIf="expense.payer.id === currentUserId || event?.userInfo?.isAdmin" (click)="editExpense()">
+		<div *ngIf="event.active && (expense.payer.id === currentUserId || event.userInfo?.isAdmin)">
+			<button mat-icon-button (click)="editExpense()">
 				<mat-icon>edit</mat-icon>
 			</button>
-			<button mat-icon-button *ngIf="expense.payer.id === currentUserId || event?.userInfo?.isAdmin" color="warn" (click)="removeExpense()">
+			<button mat-icon-button color="warn" (click)="removeExpense()">
 				<mat-icon>delete</mat-icon>
 			</button>
 		</div>

--- a/app/mikane/src/app/pages/expenditures/expense/expense.component.scss
+++ b/app/mikane/src/app/pages/expenditures/expense/expense.component.scss
@@ -1,0 +1,70 @@
+.expense-content {
+	margin-left: 8vw;
+	margin-right: 8vw;
+	margin-top: 30px;
+}
+
+.header {
+	color: rgba(255, 255, 255, 0.7);
+	margin-bottom: 6px;
+
+	&.expense-title {
+		margin-bottom: 10px;
+	}
+}
+
+.title {
+	margin-bottom: 30px;
+}
+
+.name {
+	font-size: 1.6em;
+}
+
+.category {
+	display: flex;
+	align-items: center;
+	font-size: 1.2em;
+
+	.icon {
+		margin-right: 8px;
+	}
+}
+
+.amount {
+	display: flex;
+	font-size: 1.2em;
+}
+
+.payer {
+	display: flex;
+	align-items: center;
+
+	font-size: 1.2em;
+	margin-top: 4px;
+
+	.payer-avatar {
+		position: relative;
+		width: 24px;
+		height: 24px;
+		margin-right: 6px;
+		border-radius: 50%;
+		object-fit: cover;
+		margin-right: 10px;
+	}
+	
+	.payer-name {
+		position: relative;
+		top: 1px;
+	}
+}
+
+.buttons {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+
+	.back {
+		color: rgba(255, 255, 255, 0.7);
+	}
+}

--- a/app/mikane/src/app/pages/expenditures/expense/expense.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expense/expense.component.ts
@@ -6,7 +6,7 @@ import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { Subject, Subscription, filter, switchMap, takeUntil } from 'rxjs';
+import { Subject, filter, switchMap, takeUntil } from 'rxjs';
 import { MenuComponent } from 'src/app/features/menu/menu.component';
 import { Category, CategoryService } from 'src/app/services/category/category.service';
 import { ConfirmDialogComponent } from 'src/app/features/confirm-dialog/confirm-dialog.component';

--- a/app/mikane/src/app/pages/expenditures/expense/expense.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expense/expense.component.ts
@@ -1,0 +1,179 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { Subject, Subscription, filter, switchMap, takeUntil } from 'rxjs';
+import { MenuComponent } from 'src/app/features/menu/menu.component';
+import { Category, CategoryService } from 'src/app/services/category/category.service';
+import { ConfirmDialogComponent } from 'src/app/features/confirm-dialog/confirm-dialog.component';
+import { ExpenditureDialogComponent } from '../expenditure-dialog/expenditure-dialog.component';
+import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.service';
+import { AuthService } from 'src/app/services/auth/auth.service';
+import { Expense, ExpenseService } from 'src/app/services/expense/expense.service';
+import { EventService, PuddingEvent } from 'src/app/services/event/event.service';
+import { MessageService } from 'src/app/services/message/message.service';
+import { ProgressSpinnerComponent } from 'src/app/shared/progress-spinner/progress-spinner.component';
+import { ApiError } from 'src/app/types/apiError.type';
+
+@Component({
+	templateUrl: 'expense.component.html',
+	styleUrls: ['./expense.component.scss'],
+	standalone: true,
+	imports: [
+		CommonModule,
+		MatCardModule,
+		ProgressSpinnerComponent,
+		MenuComponent,
+		MatDialogModule,
+		MatIconModule,
+		RouterLink,
+		MatButtonModule,
+		MatToolbarModule,
+	],
+})
+export class ExpenseComponent implements OnInit, OnDestroy {
+	protected loading: boolean = true;
+	expense: Expense;
+	event: PuddingEvent;
+	currentUserId: string;
+
+	private expenseSubscription: Subscription;
+	private authSubscription: Subscription;
+	cancel$: Subject<void> = new Subject();
+	destroy$: Subject<void> = new Subject();
+
+	constructor(
+		public breakpointService: BreakpointService,
+		private authService: AuthService,
+		private eventService: EventService,
+		private expenseService: ExpenseService,
+		private categoryService: CategoryService,
+		private messageService: MessageService,
+		public dialog: MatDialog,
+		private router: Router,
+		private route: ActivatedRoute,
+	) {}
+
+	ngOnInit() {
+		this.loading = true;
+		const eventId = this.route.parent.parent.snapshot.paramMap.get('eventId');
+		const expenseId = this.route.snapshot.paramMap.get('id');
+
+		this.expenseSubscription = this.eventService.getEvent(eventId).pipe(
+			switchMap((event) => {
+				this.event = event;
+				return this.expenseService.getExpense(expenseId)
+			})
+		)
+		.subscribe({
+			next: (expense) => {
+				this.expense = expense;
+				this.loading = false;
+			},
+			error: (err: ApiError) => {
+				this.loading = false;
+				this.messageService.showError('Error loading expense');
+				console.error('Something went wrong while loading expense', err?.error?.message);
+			},
+		});
+
+		this.authService.getCurrentUser().subscribe({
+			next: (user) => {
+				this.currentUserId = user.id;
+			},
+			error: (err: ApiError) => {
+				this.messageService.showError('Failed to get user');
+				console.error('Something went wrong getting signed in user', err?.error?.message);
+			},
+		});
+	}
+
+	editExpense() {
+		let newExpense: Expense;
+
+		this.dialog
+			.open(ExpenditureDialogComponent, {
+				width: '350px',
+				data: {
+					eventId: this.event.id,
+					userId: this.currentUserId,
+					expense: this.expense,
+				},
+			})
+			.afterClosed()
+			.pipe(
+				switchMap((expense) => {
+					if (!expense) {
+						this.cancel$.next();
+					}
+					newExpense = expense;
+					return this.categoryService.findOrCreate(this.event.id, expense?.category);
+				}),
+				takeUntil(this.cancel$)
+			)
+			.pipe(
+				switchMap((category: Category) => {
+					return this.expenseService.editExpense(
+						this.expense.id,
+						newExpense.name,
+						newExpense.description ?? undefined,
+						newExpense.amount,
+						category.id,
+						newExpense.payer as unknown as string
+					);
+				}),
+				takeUntil(this.destroy$)
+			)
+			.subscribe({
+				next: (newExpense) => {
+					this.expense = newExpense;
+					this.messageService.showSuccess('Expense edited');
+				},
+				error: (err: ApiError) => {
+					this.messageService.showError('Failed to edit expense');
+					console.error('Something went wrong while editing expense', err);
+				},
+			});
+	}
+
+	removeExpense() {
+		const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+			width: '350px',
+			data: {
+				title: 'Delete expense',
+				content: 'Are you sure you want to delete this expense? This cannot be undone.',
+				confirm: 'I am sure',
+			},
+		});
+
+		dialogRef.afterClosed().pipe(
+			filter(confirm => confirm),
+			switchMap(() => this.expenseService.deleteExpense(this.expense.id))
+		)
+		.subscribe({
+			next: () => {
+				this.router.navigate(['events', this.event.id, 'expenses']);
+				this.messageService.showSuccess('Expense successfully deleted');
+			},
+			error: (err: ApiError) => {
+				this.messageService.showError('Failed to delete expense');
+				console.error('Something went wrong while deleting expense', err?.error?.message);
+			},
+		});
+	}
+
+	goBack() {
+		this.router.navigate(['events', this.event.id, 'expenses']);
+	}
+
+	ngOnDestroy(): void {
+		this.expenseSubscription?.unsubscribe();
+		this.authSubscription?.unsubscribe();
+		this.destroy$.next();
+		this.destroy$.complete();
+	}
+}

--- a/app/mikane/src/app/services/expense/expense.service.ts
+++ b/app/mikane/src/app/services/expense/expense.service.ts
@@ -31,6 +31,10 @@ export class ExpenseService {
 		return this.httpClient.get<Expense[]>(this.apiUrl + `?eventId=${eventId}`);
 	}
 
+	getExpense(id: string): Observable<Expense> {
+		return this.httpClient.get<Expense>(`${this.apiUrl}/${id}`)
+	}
+
 	createExpense(
 		expenseName: string,
 		expenseDescription: string,


### PR DESCRIPTION
Adds an expense page, primarily for mobile use, where users can see more details about an expense, as well as edit/delete the expense if they are the payer or an event admin. This page can be accessed by clicking on an expense while in mobile view. In full view, the page is accessible via URL and technically works, but there is no button that will ever take a user there.

Also improves the method of getting the active link in event. Now it correctly gets the ./expenses link even if there is a UUID following it. However, there is an issue remaining where the navbar's active link is not set correctly upon entering the expense page, though it works again after a refresh.

Closes #257, closes #252 