### PR TITLE
feat: Filtering for mobile

### DIFF
--- a/app/mikane/src/app/pages/expenditures/expenditures.component.html
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.html
@@ -129,6 +129,55 @@
 </div>
 
 <ng-template #mobileView>
+	<mat-chip-set class="mobile-filters">
+		<mat-chip (click)="openFilterSearchBottomSheet()" [ngClass]="{ 'selected-chip': filterValue().length > 0 }">
+			<div class="filter-chip">
+				<div *ngIf="filterValue().length > 0; else noSearchFilter" class="filter-one-element-text">
+					{{ filterValue() }}
+				</div>
+				<ng-template #noSearchFilter>
+					Filter
+				</ng-template>
+				<mat-icon>keyboard_arrow_down</mat-icon>
+			</div>
+		</mat-chip>
+		<mat-chip (click)="openFilterPayerBottomSheet()" [ngClass]="{ 'selected-chip': payersFilter().length > 0 }">
+			<div class="filter-chip">
+				<div *ngIf="payersFilter().length > 1; else onePayer">
+					<span class="elements-circle">{{ payersFilter().length }}</span>
+					Payers
+				</div>
+				<ng-template #onePayer>
+					<div *ngIf="payersFilter().length === 1; else noPayerFilter" class="filter-one-element-text">
+						<img [src]="filteredPayer().avatarURL" alt="User avatar" class="filter-icon payer" />
+						{{ filteredPayer().name }}
+					</div>
+					<ng-template #noPayerFilter>
+						Payer
+					</ng-template>
+				</ng-template>
+				<mat-icon>keyboard_arrow_down</mat-icon>
+			</div>
+		</mat-chip>
+		<mat-chip (click)="openFilterCategoryBottomSheet()" [ngClass]="{ 'selected-chip': categoriesFilter().length > 0 }">
+			<div class="filter-chip">
+				<div *ngIf="categoriesFilter().length > 1; else oneCategory">
+					<span class="elements-circle">{{ categoriesFilter().length }}</span>
+					Categories
+				</div>
+				<ng-template #oneCategory>
+					<div *ngIf="categoriesFilter().length === 1; else noCategoryFilter" class="filter-one-element-text">
+						<mat-icon class="filter-icon">{{ filteredCategory().icon }}</mat-icon>
+						{{ filteredCategory().name }}
+					</div>
+					<ng-template #noCategoryFilter>
+						Category
+					</ng-template>
+				</ng-template>
+				<mat-icon>keyboard_arrow_down</mat-icon>
+			</div>
+		</mat-chip>
+	</mat-chip-set>
 	<mat-nav-list #expensesList *ngIf="filteredExpenses().length > 0; else noExpensesMobile" class="expenses-list-mobile">
 		<app-expense-item *ngFor="let expense of filteredExpenses()" [expense]="expense"></app-expense-item>
 	</mat-nav-list>

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.scss
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.scss
@@ -56,3 +56,55 @@
 	margin-right: 20px;
 	width: 280px;
 }
+
+.mobile-filters {
+	padding: 10px 14px;
+	border-bottom: 1px solid rgba(181, 181, 181, 0.1);
+	white-space: nowrap;
+  overflow-x: auto;
+
+	mat-chip {
+		display: inline-block;
+		vertical-align: middle;
+	}
+}
+
+.filter-chip {
+	display: flex;
+	align-items: center;
+
+	.filter-one-element-text {
+		display: flex;
+		align-items: center;
+	}
+
+	.elements-circle {
+		display: inline-flex;
+		justify-content: center;
+		align-items: center;
+		width: 16px;
+		height: 16px;
+		border-radius: 50%;
+		background-color: white;
+		color: black;
+		font-size: 12px;
+		margin-right: 2px;
+	}
+
+	.filter-icon {
+		font-size: 14px;
+		width: 14px;
+		height: 14px;
+		margin-right: 4px;
+
+		&.payer {
+			border-radius: 50%;
+			object-fit: cover;
+			margin-right: 6px;
+		}
+	}
+}
+
+.selected-chip {
+	background-color: #1e1e1e !important;
+}

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.spec.ts
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { ActivatedRoute } from '@angular/router';
@@ -21,6 +22,7 @@ describe('ExpendituresComponent', () => {
 		await TestBed.configureTestingModule({
 			imports: [
 				HttpClientTestingModule,
+				MatBottomSheetModule,
 				MockModule(MatDialogModule),
 				MockModule(MatIconModule),
 				ExpendituresComponent,

--- a/app/mikane/src/app/pages/expenditures/expense-bottom-sheet/expense-bottom-sheet.component.html
+++ b/app/mikane/src/app/pages/expenditures/expense-bottom-sheet/expense-bottom-sheet.component.html
@@ -1,0 +1,46 @@
+<div *ngIf="data.type === 'search'; else payerCategoryTitle" class="title">
+	Filter
+</div>
+<ng-template #payerCategoryTitle>
+	<div class="title">
+		Filter by {{ data.type === 'payers' ? 'payer' : 'category' }}
+	</div>
+</ng-template>
+
+<div *ngIf="data.type === 'search'; else payerCategoryContent" class="search-container">
+	<mat-form-field class="search-input">
+		<mat-label>Search expenses</mat-label>
+		<input matInput [(ngModel)]="searchValue" (keyup)="applySearchFilter()" #input />
+		<button matSuffix *ngIf="input.value" mat-icon-button (click)="clearInput()">
+			<mat-icon>cancel</mat-icon>
+		</button>
+	</mat-form-field>
+</div>
+<ng-template #payerCategoryContent>
+	<ng-container *ngIf="data.type === 'payers'; else categoriesContent">
+		<mat-nav-list>
+			<mat-list-item *ngFor="let payer of payers" mat-list-item (click)="selectItem(payer.id)" class="wrapper">
+				<div class="payers">
+					<div class="name">
+						<img [src]="payer.avatarURL" alt="Payer avatar" class="avatar" />
+						{{ payer.name }}
+					</div>
+					<mat-icon *ngIf="selectedValues.includes(payer.id)" class="checkmark">check</mat-icon>
+				</div>
+			</mat-list-item>
+		</mat-nav-list>
+	</ng-container>
+	<ng-template #categoriesContent>
+		<mat-nav-list>
+			<mat-list-item *ngFor="let category of categories" mat-list-item (click)="selectItem(category.id)" class="wrapper">
+				<div class="categories">
+					<div class="name">
+						<mat-icon class="category-icon">{{ category.icon ?? "shopping_cart" }}</mat-icon>
+						{{ category.name }}
+					</div>
+					<mat-icon *ngIf="selectedValues.includes(category.id)" class="checkmark">check</mat-icon>
+				</div>
+			</mat-list-item>
+		</mat-nav-list>
+	</ng-template>	
+</ng-template>

--- a/app/mikane/src/app/pages/expenditures/expense-bottom-sheet/expense-bottom-sheet.component.scss
+++ b/app/mikane/src/app/pages/expenditures/expense-bottom-sheet/expense-bottom-sheet.component.scss
@@ -1,0 +1,58 @@
+.wrapper {
+	height: fit-content !important;
+	padding-top: 16px;
+	padding-bottom: 16px;
+}
+
+.title {
+	padding: 10px 20px;
+	font-size: 20px;
+	font-weight: 500;
+}
+
+.search-container {
+	padding: 10px 20px 0 20px;
+
+	.search-input {
+		width: 100%;
+	}
+}
+
+.payers {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+
+	.name {
+		display: flex;
+		align-items: center;
+		
+		.avatar {
+			position: relative;
+			width: 24px;
+			height: 24px;
+			margin-right: 12px;
+			border-radius: 50%;
+			object-fit: cover;
+		}
+	}
+
+	.checkmark {
+		margin-right: 10px;
+	}
+}
+
+.categories {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+
+	.name {
+		display: flex;
+		align-items: center;
+
+		.category-icon {
+			margin-right: 10px;
+		}
+	}
+}

--- a/app/mikane/src/app/pages/expenditures/expense-bottom-sheet/expense-bottom-sheet.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expense-bottom-sheet/expense-bottom-sheet.component.ts
@@ -1,0 +1,66 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Inject, Output } from "@angular/core";
+import { FormsModule } from '@angular/forms';
+import { MAT_BOTTOM_SHEET_DATA } from "@angular/material/bottom-sheet";
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatListModule } from "@angular/material/list";
+import { User } from 'src/app/services/user/user.service';
+
+type CategoryInfo = {
+	id: string;
+	name: string;
+	icon: string;
+};
+
+@Component({
+	selector: 'app-expense-bottom-sheet',
+	templateUrl: './expense-bottom-sheet.component.html',
+	styleUrls: ['./expense-bottom-sheet.component.scss'],
+	standalone: true,
+	imports: [CommonModule, MatListModule, MatButtonModule, MatIconModule, FormsModule, MatFormFieldModule, MatInputModule],
+})
+export class ExpenseBottomSheetComponent {
+	@Output() inputDataChange = new EventEmitter<string[]>();
+	protected selectedValues: string[];
+	protected searchValue = '';
+	protected payers: User[];
+	protected categories: CategoryInfo[];
+
+	constructor(
+		@Inject(MAT_BOTTOM_SHEET_DATA) public data: { type: 'search' | 'payers' | 'categories', filterData?: User[] | CategoryInfo[], currentFilter: string[] }
+	) {
+		this.selectedValues = data.currentFilter ?? [];
+		if (data.type === 'search') {
+			this.searchValue = data.currentFilter[0];
+		}
+		else if (data.type === 'payers') {
+			this.payers = (data.filterData ?? []) as User[];
+		}
+		else if (data.type === 'categories') {
+			this.categories = (data.filterData ?? []) as CategoryInfo[];
+		}
+	}
+
+	selectItem(value: string): void {
+		const indexToRemove = this.selectedValues.indexOf(value);
+		if (indexToRemove !== -1) {
+			this.selectedValues.splice(indexToRemove, 1);
+		}
+		else {
+			this.selectedValues.push(value);
+		}
+		this.inputDataChange.emit(this.selectedValues);
+	}
+
+	applySearchFilter() {
+		this.inputDataChange.emit([this.searchValue]);
+	}
+
+	clearInput() {
+		this.searchValue = '';
+		this.inputDataChange.emit([this.searchValue]);
+	}
+}

--- a/app/mikane/src/styles.scss
+++ b/app/mikane/src/styles.scss
@@ -221,6 +221,17 @@ input:-webkit-autofill:active {
 	overflow-y: initial;
 }
 
+// Remove left/right padding from bottom sheet
+.mat-bottom-sheet-container {
+  padding-left: 0 !important;
+	padding-right: 0 !important;
+}
+
+// Set display to allow horizontal scroll on filter chips
+.mobile-filters .mdc-evolution-chip-set__chips {
+	display: inline-block !important;
+}
+
 // Prevent hover-selection on tooltips
 mat-tooltip-component {
 	user-select: none;


### PR DESCRIPTION
Implement filtering for mobile view. On the expenses page there are now 3 chip buttons for filtering, each opening a bottom sheet where the user can search through the expenses, and/or filter by payer and category. Similar to full view filtering, active filters will be saved in the URL and the page can therefore be reloaded without losing the filter values.

Closes #304 