### PR TITLE
feat: Go to participant expenses (mobile)

### DIFF
--- a/app/mikane/src/app/features/mobile/expense-item/expense-item.component.spec.ts
+++ b/app/mikane/src/app/features/mobile/expense-item/expense-item.component.spec.ts
@@ -95,6 +95,6 @@ describe('ExpenseItemComponent', () => {
 	it('should navigate to expense details when gotoExpense is called', () => {
 		component.gotoExpense();
 
-		expect(routerSpy.navigate).toHaveBeenCalledWith([expense.id], { relativeTo: routeSpy });
+		expect(routerSpy.navigate).toHaveBeenCalledWith([expense.id], { relativeTo: routeSpy, queryParams: jasmine.any(Object) });
 	});
 });

--- a/app/mikane/src/app/features/mobile/expense-item/expense-item.component.ts
+++ b/app/mikane/src/app/features/mobile/expense-item/expense-item.component.ts
@@ -18,6 +18,9 @@ export class ExpenseItemComponent {
 	constructor(private router: Router, private route: ActivatedRoute) {}
 
 	gotoExpense() {
-		this.router.navigate([this.expense.id], { relativeTo: this.route });
+		this.router.navigate([this.expense.id], {
+			relativeTo: this.route,
+			queryParams: { ...this.route.snapshot.queryParams }
+		});
 	}
 }

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.html
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.html
@@ -167,7 +167,7 @@
 				</div>
 				<ng-template #oneCategory>
 					<div *ngIf="categoriesFilter().length === 1; else noCategoryFilter" class="filter-one-element-text">
-						<mat-icon class="filter-icon">{{ filteredCategory().icon }}</mat-icon>
+						<mat-icon class="filter-icon">{{ filteredCategory().icon ?? "shopping_cart" }}</mat-icon>
 						{{ filteredCategory().name }}
 					</div>
 					<ng-template #noCategoryFilter>

--- a/app/mikane/src/app/pages/expenditures/expense/expense.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expense/expense.component.ts
@@ -174,7 +174,9 @@ export class ExpenseComponent implements OnInit, OnDestroy {
 	}
 
 	goBack() {
-		this.router.navigate(['events', this.event.id, 'expenses']);
+		this.router.navigate(['events', this.event.id, 'expenses'], {
+			queryParams: { ...this.route.snapshot.queryParams }
+		});
 	}
 
 	ngOnDestroy(): void {

--- a/app/mikane/src/app/pages/participant/participant.component.html
+++ b/app/mikane/src/app/pages/participant/participant.component.html
@@ -171,6 +171,7 @@
 		<app-participant-item
 			*ngFor="let userWithBalance of usersWithBalance; let i = index"
 			[userBalance]="userWithBalance"
+			(click)="gotoUserExpenses(userWithBalance)"
 		></app-participant-item>
 	</mat-nav-list>
 	<button

--- a/app/mikane/src/app/pages/participant/participant.component.spec.ts
+++ b/app/mikane/src/app/pages/participant/participant.component.spec.ts
@@ -826,4 +826,26 @@ describe('ParticipantComponent', () => {
 			expect(routerStub.navigate).toHaveBeenCalledWith(['events', component.event.id, 'settings']);
 		});
 	});
+
+	describe('#gotoUserExpenses', () => {
+		beforeEach(() => {
+			(eventServiceStub.loadBalances as jasmine.Spy).and.returnValue(
+				of([
+					{ user: { id: '1', name: 'a' }, balance: 1, expensesCount: 1, spending: 1, expenses: 1  },
+					{ user: { id: '2', name: 'b' }, balance: 2, expensesCount: 2, spending: 2, expenses: 2 },
+				] as UserBalance[]),
+			);
+			(authServiceStub.getCurrentUser as jasmine.Spy).and.returnValue(of({ id: '1' }));
+		});
+
+		it('should navigate to expenses page, filtered by user', () => {
+			createComponent();
+
+			component.gotoUserExpenses(component.usersWithBalance[0]);
+
+			expect(routerStub.navigate).toHaveBeenCalledWith(['events', component.event.id, 'expenses'], {
+				queryParams: { payers: component.usersWithBalance[0].user.id }
+			});
+		});
+	});
 });

--- a/app/mikane/src/app/pages/participant/participant.component.ts
+++ b/app/mikane/src/app/pages/participant/participant.component.ts
@@ -386,6 +386,15 @@ export class ParticipantComponent implements OnInit, OnDestroy {
 		this.router.navigate(['events', this.event.id, 'settings']);
 	}
 
+	gotoUserExpenses(user: UserBalance) {
+		if (user.expensesCount < 1) {
+			return;
+		}
+		this.router.navigate(['events', this.event.id, 'expenses'], {
+			queryParams: { payers: user.user.id }
+		});
+	}
+
 	private compare(a: string | number, b: string | number, isAsc: boolean) {
 		if (a === b) return 0;
 		return (a < b ? -1 : 1) * (isAsc ? 1 : -1);


### PR DESCRIPTION
Changelog:
- When someone clicks on a user in the participants page, if the user has one or more expenses in the event, they will be taken to the expenses page filtered by that specific user
- When clicking on an expense and then clicking "go back" any active filters will be maintained on the expenses page
- Fix bug where filter icon for a category did not show if the category has no set icon

Closes #305 