### PR TITLE
feat: Event "ready to settle" status

### DIFF
--- a/app/mikane/.eslintrc.json
+++ b/app/mikane/.eslintrc.json
@@ -33,7 +33,10 @@
 			"files": ["*.html"],
 			"parser": "@angular-eslint/template-parser",
 			"extends": ["plugin:@angular-eslint/template/recommended", "plugin:@angular-eslint/template/accessibility"],
-			"rules": {}
+			"rules": {
+				"@angular-eslint/template/click-events-have-key-events": "off",
+				"@angular-eslint/template/interactive-supports-focus": "off"
+			}
 		},
 		{
 			"files": [".ts", ".tsx", ".js", ".jsx"],

--- a/app/mikane/src/app/features/mobile/event-item/event-item.component.html
+++ b/app/mikane/src/app/features/mobile/event-item/event-item.component.html
@@ -1,4 +1,4 @@
-<mat-list-item class="wrapper">
+<mat-list-item class="wrapper" [ngClass]="{ 'ready-to-settle': event.status.id === EventStatusType.READY_TO_SETTLE}">
 	<div class="event-title">
 		<span class="title-text">{{ event.name }}</span>
 		<mat-icon
@@ -19,6 +19,6 @@
 		</span>
 	</div>
 	<div *ngIf="event.description" class="description">
-		{{ event.description }}
+		{{ event.status.id === EventStatusType.READY_TO_SETTLE ? 'READY TO SETTLE' : event.description }}
 	</div>
 </mat-list-item>

--- a/app/mikane/src/app/features/mobile/event-item/event-item.component.scss
+++ b/app/mikane/src/app/features/mobile/event-item/event-item.component.scss
@@ -3,6 +3,10 @@
 	padding-top: 18px;
 	padding-bottom: 18px;
 	border-bottom: 1px solid rgba(181, 181, 181, 0.1);
+
+	&.ready-to-settle {
+		background-color: #534149;
+	}
 }
 
 .event-title {

--- a/app/mikane/src/app/features/mobile/event-item/event-item.component.ts
+++ b/app/mikane/src/app/features/mobile/event-item/event-item.component.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { PuddingEvent } from 'src/app/services/event/event.service';
+import { EventStatusType, PuddingEvent } from 'src/app/services/event/event.service';
 
 @Component({
 	selector: 'app-event-item',
@@ -14,4 +14,5 @@ import { PuddingEvent } from 'src/app/services/event/event.service';
 })
 export class EventItemComponent {
 	@Input() event: PuddingEvent;
+	readonly EventStatusType = EventStatusType;
 }

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.html
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.html
@@ -12,9 +12,9 @@
 				<div>
 					<ng-container *ngTemplateOutlet="formContent"></ng-container>
 				</div>
-				<div class="header">Archive event</div>
+				<div class="header">Change status</div>
 				<div class="event-settings-content archive">
-					<ng-container *ngTemplateOutlet="archiveContent"></ng-container>
+					<ng-container *ngTemplateOutlet="statusContent"></ng-container>
 				</div>
 				<div class="header">Manage admins</div>
 				<div class="event-settings-content admins">
@@ -32,9 +32,9 @@
 <ng-template #mobileView>
 	<div class="header-mobile">Edit event</div>
 	<ng-container *ngTemplateOutlet="formContent"></ng-container>
-	<div class="header-mobile">Archive event</div>
+	<div class="header-mobile">Change status</div>
 	<div class="event-settings-content archive">
-		<ng-container *ngTemplateOutlet="archiveContent"></ng-container>
+		<ng-container *ngTemplateOutlet="statusContent"></ng-container>
 	</div>
 	<div class="header-mobile admins">Manage admins</div>
 	<div class="admins">
@@ -71,18 +71,27 @@
 	</form>
 </ng-template>
 
-<ng-template #archiveContent>
-	<div *ngIf="event?.status.id === EventStatusType.ACTIVE else setActive">
+<ng-template #statusContent>
+	<div *ngIf="event?.status.id === EventStatusType.ACTIVE else notActive">
 		<div class="event-settings-text">
-			This event is currently active. By archiving the event any further editing by any participants will not be possible.
+			This event is currently <b>active</b>. By setting the event as 'ready to settle' any further editing by any participants will not be possible, and participants will be urged to settle their payments.
 		</div>
-		<button mat-raised-button color="primary" (click)="archiveEvent(EventStatusType.ARCHIVED)">Archive event</button>
+		<button mat-raised-button color="primary" (click)="setStatus(EventStatusType.READY_TO_SETTLE)">Set event as ready to settle</button>
 	</div>
-	<ng-template #setActive>
-		<div class="event-settings-text">
-			This event is currently archived. By setting this event as active participants can start editing the event again.
+	<ng-template #notActive>
+		<div *ngIf="event?.status.id === EventStatusType.READY_TO_SETTLE else archived">
+			<div class="event-settings-text">
+				This event is currently <b>ready to settle</b>. When all participants have settled their payments the event should be archived. Should any changes be neccessary, set the event as active again.
+			</div>
+			<button mat-raised-button color="primary" (click)="setStatus(EventStatusType.ARCHIVED)" class="status-button">Archive event</button>
+			<button mat-raised-button color="accent" (click)="setStatus(EventStatusType.ACTIVE)">Set event as active</button>
 		</div>
-		<button mat-raised-button color="accent" (click)="archiveEvent(EventStatusType.ACTIVE)">Set event as active</button>
+		<ng-template #archived>
+			<div class="event-settings-text">
+				This event is currently <b>archived</b>. By setting this event as active participants can start editing the event again.
+			</div>
+			<button mat-raised-button color="accent" (click)="setStatus(EventStatusType.ACTIVE)">Set event as active</button>
+		</ng-template>
 	</ng-template>
 </ng-template>
 

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.scss
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.scss
@@ -124,6 +124,10 @@
 	margin-bottom: 20px;
 }
 
+.status-button {
+	margin-right: 20px;
+}
+
 .list-item {
 	cursor: default !important;
 }

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.spec.ts
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.spec.ts
@@ -255,7 +255,7 @@ describe('EventSettingsComponent', () => {
 			);
 			tick();
 			fixture.detectChanges();
-			component.archiveEvent(EventStatusType.ARCHIVED);
+			component.setStatus(EventStatusType.ARCHIVED);
 
 			tick();
 
@@ -286,7 +286,7 @@ describe('EventSettingsComponent', () => {
 			);
 			tick();
 			fixture.detectChanges();
-			component.archiveEvent(EventStatusType.ACTIVE);
+			component.setStatus(EventStatusType.ACTIVE);
 
 			tick();
 
@@ -319,7 +319,7 @@ describe('EventSettingsComponent', () => {
 				})
 			);
 			fixture.detectChanges();
-			component.archiveEvent(EventStatusType.ARCHIVED);
+			component.setStatus(EventStatusType.ARCHIVED);
 
 			expect(messageService.showError).toHaveBeenCalledWith('Failed to archive event');
 		});

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.ts
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.ts
@@ -116,11 +116,19 @@ export class EventSettingsComponent implements OnInit, OnDestroy {
 		});
 	}
 
-	archiveEvent(status: EventStatusType) {
+	setStatus(status: EventStatusType) {
 		this.eventService.editEvent({ id: this.event.id, status: status }).subscribe({
 			next: (event) => {
 				this.event = event;
-				this.messageService.showSuccess(status === EventStatusType.ARCHIVED ? 'Event successfully archived' : 'Event successfully set as active');
+				if (status === EventStatusType.ACTIVE) {
+					this.messageService.showSuccess('Event successfully set as active');
+				}
+				else if (status === EventStatusType.READY_TO_SETTLE) {
+					this.messageService.showSuccess('Event successfully ready to be settled');
+				}
+				else if (status === EventStatusType.ARCHIVED) {
+					this.messageService.showSuccess('Event successfully archived');
+				}
 
 				// Reload to refresh now archived event
 				this.router.navigateByUrl('/', { skipLocationChange: true }).then(() => {

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.ts
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.ts
@@ -130,14 +130,14 @@ export class EventSettingsComponent implements OnInit, OnDestroy {
 					this.messageService.showSuccess('Event successfully archived');
 				}
 
-				// Reload to refresh now archived event
+				// Reload to refresh event
 				this.router.navigateByUrl('/', { skipLocationChange: true }).then(() => {
 					this.router.navigate(['events', this.event.id, 'settings']);
 				});
 			},
 			error: (err: ApiError) => {
-				this.messageService.showError('Failed to archive event');
-				console.error('Something went wrong while archiving event', err?.error?.message);
+				this.messageService.showError('Failed to change event status');
+				console.error('Something went wrong while changing event status', err?.error?.message);
 			},
 		});
 	}

--- a/app/mikane/src/app/pages/events/event/event.component.html
+++ b/app/mikane/src/app/pages/events/event/event.component.html
@@ -10,8 +10,8 @@
 	</div>
 	<div class="name">
 		{{ event.name }}
-		<button *ngIf="event.status?.id !== EventStatusType.ACTIVE && (breakpointService.isMobile() | async) === false" mat-stroked-button disabled>
-			Archived
+		<button *ngIf="event.status?.id !== EventStatusType.ACTIVE && (breakpointService.isMobile() | async) === false" mat-stroked-button disabled [ngClass]="{ 'ready-to-settle': event.status?.id === EventStatusType.READY_TO_SETTLE}">
+			{{ event.status?.id === EventStatusType.READY_TO_SETTLE ? 'Ready to settle' : 'Archived' }}
 		</button>
 	</div>
 	<span class="toolbar-spacer"></span>

--- a/app/mikane/src/app/pages/events/event/event.component.scss
+++ b/app/mikane/src/app/pages/events/event/event.component.scss
@@ -30,3 +30,7 @@ mat-toolbar button {
 	max-width: 10px;
 	background-color: #161616;
 }
+
+.ready-to-settle {
+	background-color: rgb(87 59 70 / 20%);
+}

--- a/app/mikane/src/app/pages/events/events.component.html
+++ b/app/mikane/src/app/pages/events/events.component.html
@@ -12,7 +12,7 @@
 			<mat-card-content class="card-content">
 				<div class="header">Active Events</div>
 				<div *ngIf="pagedEventsActive().length > 0; else noActiveEvents">
-					<mat-card *ngFor="let event of pagedEventsActive()" class="event-item">
+					<mat-card *ngFor="let event of pagedEventsActive()" class="event-item" [ngClass]="{ 'ready-to-settle': event.status.id === EventStatusType.READY_TO_SETTLE}">
 						<mat-card-header class="event-header clickable" (click)="clickEvent(event)">
 							<mat-card-title class="event-title">
 								<span class="event-name">
@@ -36,7 +36,7 @@
 								</span>
 							</mat-card-title>
 							<mat-card-subtitle>
-								{{ event.description }}
+								{{ event.status.id === EventStatusType.READY_TO_SETTLE ? 'READY TO SETTLE' : event.description }}
 							</mat-card-subtitle>
 							<span *ngIf="event.userInfo.isAdmin" class="event-actions">
 								<button mat-icon-button (click)="editEvent(event); $event.stopPropagation()">

--- a/app/mikane/src/app/pages/events/events.component.scss
+++ b/app/mikane/src/app/pages/events/events.component.scss
@@ -48,6 +48,14 @@ mat-toolbar button {
 	margin-right: 16px;
 	margin-bottom: 0.4em;
 
+	&.ready-to-settle {
+		background-color: #4b3a41;
+
+		.clickable:hover {
+			background-image: linear-gradient(#705963, #705963, #705963);
+		}
+	}
+
 	.event-header {
 		min-height: 48px;
 		align-items: center;

--- a/app/mikane/src/app/pages/events/events.component.ts
+++ b/app/mikane/src/app/pages/events/events.component.ts
@@ -46,10 +46,10 @@ import { EventDialogComponent } from './event-dialog/event-dialog.component';
 export class EventsComponent implements OnInit, OnDestroy {
 	events: WritableSignal<PuddingEvent[]> = signal([]);
 	eventsActive = computed(() => {
-		return this.events().filter((event) => event.status.id === EventStatusType.ACTIVE);
+		return this.events().filter((event) => event.status.id !== EventStatusType.ARCHIVED);
 	});
 	eventsArchived = computed(() => {
-		return this.events().filter((event) => event.status.id !== EventStatusType.ACTIVE);
+		return this.events().filter((event) => event.status.id === EventStatusType.ARCHIVED);
 	});
 	pagedEventsActive = computed(() => {
 		return this.eventsActive().slice(this.startIndexActive(), this.endIndexActive());
@@ -61,6 +61,7 @@ export class EventsComponent implements OnInit, OnDestroy {
 	selectedEvent!: PuddingEvent;
 	loading: BehaviorSubject<boolean> = new BehaviorSubject(false);
 	editSubscription: Subscription;
+	readonly EventStatusType = EventStatusType;
 
 	// Paginator
 	lengthActive = computed(() => {

--- a/app/mikane/src/app/pages/login/login.component.scss
+++ b/app/mikane/src/app/pages/login/login.component.scss
@@ -94,3 +94,7 @@
 .mat-spinner::ng-deep circle{
 	stroke: #FFFFFF !important;
 }
+
+mat-card-title {
+	padding-left: 0 !important;
+}

--- a/app/mikane/src/app/pages/participant/participant.component.html
+++ b/app/mikane/src/app/pages/participant/participant.component.html
@@ -19,6 +19,13 @@
 			</ng-template>
 		</div>
 
+		<div *ngIf="event?.status.id === EventStatusType.READY_TO_SETTLE" class="ready-to-settle-box" (click)="gotoPayments()">
+			<div class="info">
+				<mat-icon class="info-icon">info</mat-icon>
+				This event is ready for settlement. Go to the payments page to find your pending payments.
+			</div>
+		</div>
+
 		<mat-accordion class="user-list" *ngIf="usersWithBalance.length > 0; else noUsers" #accordion>
 			<!-- HEADER ROW -->
 			<table mat-table matSort (matSortChange)="sortData($event)" class="participants-header">
@@ -166,6 +173,12 @@
 				<mat-icon>info</mat-icon>
 			</button>
 		</ng-template>
+	</div>
+	<div *ngIf="event?.status.id === EventStatusType.READY_TO_SETTLE" class="ready-to-settle-box-mobile" (click)="gotoPayments()">
+		<div class="info">
+			<mat-icon class="info-icon">info</mat-icon>
+			This event is ready for settlement. Go to the payments page to find your pending payments.
+		</div>
 	</div>
 	<mat-nav-list class="userbalances-list-mobile">
 		<app-participant-item

--- a/app/mikane/src/app/pages/participant/participant.component.scss
+++ b/app/mikane/src/app/pages/participant/participant.component.scss
@@ -110,3 +110,52 @@
 		padding-right: 28px;
 	}
 }
+
+.ready-to-settle-box {
+	display: flex;
+	width: 100%;
+	height: 70px;
+	background-color: #5f5f5f;
+	margin-bottom: 20px;
+	border-radius: 4px;
+
+	.info {
+		display: flex;
+		align-items: center;
+		margin-left: 20px;
+
+		.info-icon {
+			margin-right: 10px;
+		}
+	}
+
+	&:hover {
+		background-color: #6d6d6d;
+		cursor: pointer;
+	}
+}
+
+.ready-to-settle-box-mobile {
+	display: flex;
+	width: 100%;
+	padding-top: 18px;
+	padding-bottom: 18px;
+	background-color: #5f5f5f;
+
+	.info {
+		display: flex;
+		align-items: center;
+		margin: 0 16px;
+		font-size: 13px;
+
+		.info-icon {
+			margin-right: 10px;
+			min-width: 28px;
+		}
+	}
+
+	&:hover {
+		background-color: #6d6d6d;
+		cursor: pointer;
+	}
+}

--- a/app/mikane/src/app/pages/participant/participant.component.ts
+++ b/app/mikane/src/app/pages/participant/participant.component.ts
@@ -396,6 +396,10 @@ export class ParticipantComponent implements OnInit, OnDestroy {
 		});
 	}
 
+	gotoPayments() {
+		this.router.navigate(['events', this.event.id, 'payment']);
+	}
+
 	private compare(a: string | number, b: string | number, isAsc: boolean) {
 		if (a === b) return 0;
 		return (a < b ? -1 : 1) * (isAsc ? 1 : -1);

--- a/app/mikane/src/app/services/event/event.service.spec.ts
+++ b/app/mikane/src/app/services/event/event.service.spec.ts
@@ -160,7 +160,7 @@ describe('EventService', () => {
 			const req = httpTestingController.expectOne('http://localhost:3002/api/events/eventId');
 
 			expect(req.request.method).toEqual('PUT');
-			expect(req.request.body).toEqual({ name: 'name', description: 'description', private: false, status: EventStatusType.ACTIVE });
+			expect(req.request.body).toEqual({ name: 'name', description: 'description', status: EventStatusType.ACTIVE });
 
 			req.flush(mockEvent);
 		});

--- a/app/mikane/src/app/services/event/event.service.ts
+++ b/app/mikane/src/app/services/event/event.service.ts
@@ -64,7 +64,7 @@ export class EventService {
 	}
 
 	editEvent({ id, name, description, status }: { id: string; name?: string; description?: string; status?: EventStatusType }): Observable<PuddingEvent> {
-		return this.httpClient.put<PuddingEvent>(this.apiUrl + `/${id}`, { name, description, private: false, status });
+		return this.httpClient.put<PuddingEvent>(this.apiUrl + `/${id}`, { name, description, status });
 	}
 
 	deleteEvent(eventId: string): Observable<void> {

--- a/server/db_scripts/edit_event.sql
+++ b/server/db_scripts/edit_event.sql
@@ -34,8 +34,14 @@ begin
     raise exception 'Only event admins can edit event' using errcode = 'P0087';
   end if;
 
-  if exists (select 1 from "event" e where e.id = ip_event_id and e.status != 1) and (ip_status != 1 or ip_status is null) then
+  if exists (select 1 from "event" e where e.id = ip_event_id and e.status != 1) and (
+    ip_name is not null or ip_description is not null or ip_private is not null
+  ) then
     raise exception 'Only active events can be edited' using errcode = 'P0118';
+  end if;
+
+  if ip_status is not null and not exists (select 1 from event_status_type est where est.id = ip_status) then
+    raise exception 'Not a valid event status type' using errcode = 'P0128';
   end if;
 
   if exists (select 1 from "event" e where e.name ilike ip_name and e.id != ip_event_id) then

--- a/server/src/db/dbEvents.ts
+++ b/server/src/db/dbEvents.ts
@@ -413,6 +413,8 @@ export const editEvent = async (eventId: string, userId: string, name?: string, 
         throw new ErrorExt(ec.PUD087, err);
       else if (err.code === "P0118")
         throw new ErrorExt(ec.PUD118, err);
+      else if (err.code === "P0128")
+        throw new ErrorExt(ec.PUD128, err);
       else
         throw new ErrorExt(ec.PUD044, err);
     });

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -1208,3 +1208,12 @@ export const PUD127: ErrorCode = {
   status: 500,
   log: true
 };
+
+/**
+ * PUD-128: Not a valid event status type (400)
+ */
+export const PUD128: ErrorCode = {
+  code: "PUD-128",
+  message: "Not a valid event status type",
+  status: 400
+};

--- a/server/tests/categories.test.ts
+++ b/server/tests/categories.test.ts
@@ -144,19 +144,19 @@ describe("categories", async () => {
       expect(res.body.code).toEqual(ec.PUD096.code);
     });
 
-    test("should set event as archived", async () => {
+    test("should set event as ready to settle", async () => {
       const res = await request(app)
         .put("/api/events/" + event.id)
         .set("Cookie", authToken)
         .send({
-          status: EventStatusType.ARCHIVED
+          status: EventStatusType.READY_TO_SETTLE
         });
 
       expect(res.status).toEqual(200);
-      expect(res.body.status.id).toEqual(EventStatusType.ARCHIVED);
+      expect(res.body.status.id).toEqual(EventStatusType.READY_TO_SETTLE);
     });
 
-    test("fail creating category in archived event", async () => {
+    test("fail creating category in event with status 'ready to settle'", async () => {
       const res = await request(app)
         .post("/api/categories")
         .set("Cookie", authToken)

--- a/server/tests/events.test.ts
+++ b/server/tests/events.test.ts
@@ -249,6 +249,30 @@ describe("events", async () => {
       expect(res.body.code).toEqual(ec.PUD053.code);
     });
 
+    test("should set event as ready to settle", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          status: EventStatusType.READY_TO_SETTLE
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.status.id).toEqual(EventStatusType.READY_TO_SETTLE);
+    });
+
+    test("fail editing event with status 'ready to settle'", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          name: "New name"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD118.code);
+    });
+
     test("should set event as archived", async () => {
       const res = await request(app)
         .put("/api/events/" + event.id)
@@ -284,6 +308,18 @@ describe("events", async () => {
       expect(res.status).toEqual(200);
       expect(res.body.status.id).toEqual(EventStatusType.ACTIVE);
     });
+
+    test("fail setting event status as invalid type", async () => {
+      const res = await request(app)
+        .put("/api/events/" + event.id)
+        .set("Cookie", authToken)
+        .send({
+          status: 9
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD128.code);
+    });
   });
 
   /* ----------------------------- */
@@ -301,19 +337,19 @@ describe("events", async () => {
       expect(res.body.length).toEqual(1);
     });
 
-    test("should set event as archived", async () => {
+    test("should set event as ready to settle", async () => {
       const res = await request(app)
         .put("/api/events/" + event.id)
         .set("Cookie", authToken)
         .send({
-          status: EventStatusType.ARCHIVED
+          status: EventStatusType.READY_TO_SETTLE
         });
 
       expect(res.status).toEqual(200);
-      expect(res.body.status.id).toEqual(EventStatusType.ARCHIVED);
+      expect(res.body.status.id).toEqual(EventStatusType.READY_TO_SETTLE);
     });
 
-    test("fail adding user2 to archived event", async () => {
+    test("fail adding user2 to 'ready to settle' event", async () => {
       const res = await request(app)
         .post(`/api/events/${event.id}/user/${user2.id}`)
         .set("Cookie", authToken);

--- a/server/tests/expenses.test.ts
+++ b/server/tests/expenses.test.ts
@@ -190,19 +190,19 @@ describe("expenses", async () => {
       expect(res.body.code).toEqual(ec.PUD062.code);
     });
 
-    test("should set event as archived", async () => {
+    test("should set event as ready to settle", async () => {
       const res = await request(app)
         .put("/api/events/" + event.id)
         .set("Cookie", authToken)
         .send({
-          status: EventStatusType.ARCHIVED
+          status: EventStatusType.READY_TO_SETTLE
         });
 
       expect(res.status).toEqual(200);
-      expect(res.body.status.id).toEqual(EventStatusType.ARCHIVED);
+      expect(res.body.status.id).toEqual(EventStatusType.READY_TO_SETTLE);
     });
 
-    test("fail create expense in archived event", async () => {
+    test("fail create expense in event with status 'ready to settle'", async () => {
       const res = await request(app)
         .post("/api/expenses")
         .set("Cookie", authToken)


### PR DESCRIPTION
Add a 'ready to settle' status for events. When an event is in this status, participants can no longer edit the event and will be urged to settle their payments.

Features:
- The event settings page has been updated to allow setting the new event statuses. The flow is as follows:
  - Active <-> Ready to settle -> Archived -> Active
- Events with the 'ready to settle' status will show up in the active events list, but will be identifiable as ready for settlement
  - Currently this identifier is a different background color and the text READY TO SETTLE instead of the event's description
- On the participants page, if an event is set as ready to settle, there is now an info box above the table informing users the event is ready to be settled (which can be clicked to go directly to the payments page)

Sidenote: Changing the background color for events ready to be settled in the event list is not the prettiest solution for identifying these events, so if a better way to visualize these events comes up, do not hesistate to change it.

Closes #309 