### PR TITLE
feat: Super-admins - restrictions on managing guests

### DIFF
--- a/app/mikane/src/app/pages/guests/guest-dialog/guest-dialog.component.html
+++ b/app/mikane/src/app/pages/guests/guest-dialog/guest-dialog.component.html
@@ -1,5 +1,10 @@
 <h1 mat-dialog-title>
-	{{ data?.edit ? (delete ? "Delete " + guest.firstName + " " + guest.lastName + "?" : "Edit guest") : "Create guest" }}
+	@if (data?.edit) {
+		{{ delete ? "Delete " + guest.firstName + (guest.lastName ? " " + guest.lastName : "") + "?" : "Edit guest" }}
+	}
+	@else {
+		Create guest
+	}
 </h1>
 <div *ngIf="!delete; else deleteContent">
 	<div mat-dialog-content>

--- a/app/mikane/src/app/pages/guests/guests.component.html
+++ b/app/mikane/src/app/pages/guests/guests.component.html
@@ -39,9 +39,11 @@
 						<img [src]="guest.avatarURL" alt="Guest user avatar" class="avatar" />
 						{{ guest.name }}
 					</div>
-					<button mat-icon-button (click)="editGuest(guest)">
-						<mat-icon>edit</mat-icon>
-					</button>
+					@if (currentUser.superAdmin || guest.guestCreatedBy === currentUser.id) {
+						<button mat-icon-button (click)="editGuest(guest)">
+							<mat-icon>edit</mat-icon>
+						</button>
+					}
 				</div>
 			</mat-list-item>
 		</mat-nav-list>

--- a/app/mikane/src/app/services/user/user.service.ts
+++ b/app/mikane/src/app/services/user/user.service.ts
@@ -16,6 +16,8 @@ export interface User {
 	phone?: string;
 	created?: Date;
 	guest: boolean;
+	guestCreatedBy?: string;
+	superAdmin?: boolean;
 	avatarURL?: string;
 	eventInfo?: {
 		id: string;

--- a/server/db_scripts/convert_guest_to_user.sql
+++ b/server/db_scripts/convert_guest_to_user.sql
@@ -17,7 +17,9 @@ returns table (
   phone_number varchar(20),
   "password" varchar(255),
   created timestamp,
-  guest boolean
+  guest boolean,
+  guest_created_by uuid,
+  super_admin boolean
 ) as
 $$
 declare tmp_user_id uuid;
@@ -48,7 +50,8 @@ begin
     phone_number = nullif(ip_phone_number, ''),
     "password" = ip_password,
     created = CURRENT_TIMESTAMP,
-    guest = false
+    guest = false,
+    guest_created_by = null
   where
     u.id = ip_guest_id and
     u.guest = true and

--- a/server/db_scripts/delete_user.sql
+++ b/server/db_scripts/delete_user.sql
@@ -37,6 +37,7 @@ begin
     email = null,
     phone_number = null,
     "password" = '22',
+    super_admin = false,
     deleted = true
   where
     u.id = ip_user_id;

--- a/server/db_scripts/edit_user.sql
+++ b/server/db_scripts/edit_user.sql
@@ -16,7 +16,9 @@ returns table (
   phone_number varchar(20),
   "password" varchar(255),
   created timestamp,
-  guest boolean
+  guest boolean,
+  guest_created_by uuid,
+  super_admin boolean
 ) as
 $$
 begin

--- a/server/db_scripts/get_user.sql
+++ b/server/db_scripts/get_user.sql
@@ -13,14 +13,16 @@ returns table (
   phone_number varchar(20),
   "password" varchar(255),
   created timestamp,
-  guest boolean
+  guest boolean,
+  guest_created_by uuid,
+  super_admin boolean
 ) as
 $$
 begin
   if (ip_user_id is not null) then
     return query
     select
-      u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.password, u.created, u.guest
+      u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.password, u.created, u.guest, u.guest_created_by, u.super_admin
     from
       "user" u
     where
@@ -30,7 +32,7 @@ begin
   elsif (ip_username is not null) then
     return query
     select
-      u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.password, u.created, u.guest
+      u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.password, u.created, u.guest, u.guest_created_by, u.super_admin
     from
       "user" u
     where

--- a/server/db_scripts/get_users.sql
+++ b/server/db_scripts/get_users.sql
@@ -13,6 +13,8 @@ returns table (
   phone_number varchar(20),
   created timestamp,
   guest boolean,
+  guest_created_by uuid,
+  super_admin boolean,
   deleted boolean,
   event_id uuid,
   is_event_admin boolean,
@@ -25,7 +27,7 @@ begin
   begin
     return query
     select
-      u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.created, u.guest, u.deleted,
+      u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.created, u.guest, u.guest_created_by, u.super_admin, u.deleted,
       null::uuid as event_id,
       null::boolean as is_event_admin,
       null::timestamp as event_joined_time
@@ -49,7 +51,7 @@ begin
 
     return query
     select
-      u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.created, u.guest, u.deleted,
+      u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.created, u.guest, u.guest_created_by, u.super_admin, u.deleted,
       e.id as event_id, ue.admin as is_event_admin, ue.joined_time as event_joined_time
     from
       "user" u

--- a/server/db_scripts/new_guest_user.sql
+++ b/server/db_scripts/new_guest_user.sql
@@ -2,7 +2,8 @@ drop function if exists new_guest_user;
 create or replace function new_guest_user(
   ip_id uuid,
   ip_first_name varchar(255),
-  ip_last_name varchar(255)
+  ip_last_name varchar(255),
+  ip_by_user_id uuid
 )
 returns table (
   id uuid,
@@ -13,13 +14,19 @@ returns table (
   phone_number varchar(20),
   "password" varchar(255),
   created timestamp,
-  guest boolean
+  guest boolean,
+  guest_created_by uuid,
+  super_admin boolean
 ) as
 $$
 begin
 
-  insert into "user"(id, username, first_name, last_name, email, phone_number, "password", created, guest, deleted)
-    values (ip_id, ip_id, ip_first_name, nullif(ip_last_name, ''), null, null, '1', CURRENT_TIMESTAMP, true, false);
+  if not exists (select 1 from "user" u where u.id = ip_by_user_id) then
+    raise exception 'User not found' using errcode = 'P0008';
+  end if;
+
+  insert into "user"(id, username, first_name, last_name, email, phone_number, "password", created, guest, guest_created_by, super_admin, deleted)
+    values (ip_id, ip_id, ip_first_name, nullif(ip_last_name, ''), null, null, '1', CURRENT_TIMESTAMP, true, ip_by_user_id, false, false);
 
   return query
   select * from get_user(ip_id, null, true);

--- a/server/db_scripts/new_user.sql
+++ b/server/db_scripts/new_user.sql
@@ -16,7 +16,9 @@ returns table (
   phone_number varchar(20),
   "password" varchar(255),
   created timestamp,
-  guest boolean
+  guest boolean,
+  guest_created_by uuid,
+  super_admin boolean
 ) as
 $$
 declare tmp_user_id uuid;
@@ -33,8 +35,8 @@ begin
     raise exception 'Phone number already taken' using errcode = 'P0019';
   end if;
 
-  insert into "user"(username, first_name, last_name, email, phone_number, "password", created, guest, deleted)
-    values (ip_username, ip_first_name, nullif(ip_last_name, ''), nullif(ip_email, ''), nullif(ip_phone_number, ''), ip_password, CURRENT_TIMESTAMP, false, false)
+  insert into "user"(username, first_name, last_name, email, phone_number, "password", created, guest, super_admin, deleted)
+    values (ip_username, ip_first_name, nullif(ip_last_name, ''), nullif(ip_email, ''), nullif(ip_phone_number, ''), ip_password, CURRENT_TIMESTAMP, false, false, false)
     returning "user".id into tmp_user_id;
 
   return query

--- a/server/db_scripts/schema/2.1-2.2_migrations.sql
+++ b/server/db_scripts/schema/2.1-2.2_migrations.sql
@@ -11,3 +11,7 @@ ADD status int not null references "event_status_type"(id) on delete restrict de
 
 ALTER TABLE "event"
 DROP COLUMN active;
+
+ALTER TABLE "user"
+ADD super_admin boolean not null default false,
+ADD guest_created_by uuid;

--- a/server/db_scripts/schema/db_schema.sql
+++ b/server/db_scripts/schema/db_schema.sql
@@ -13,6 +13,8 @@ create table "user" (
   "password" varchar(255) not null,
   created timestamp not null,
   guest boolean not null,
+  guest_created_by uuid,
+  super_admin boolean not null,
   deleted boolean not null
 );
 

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -953,7 +953,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/User"
+                    "$ref": "#/components/schemas/Guest"
                   }
                 }
               }
@@ -997,7 +997,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserDetailed"
+                  "$ref": "#/components/schemas/Guest"
                 }
               }
             }
@@ -1064,7 +1064,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserDetailed"
+                  "$ref": "#/components/schemas/Guest"
                 }
               }
             }
@@ -3724,6 +3724,10 @@
           "avatarURL": {
             "type": "string",
             "example": "https://gravatar.com/avatar/aaaa"
+          },
+          "superAdmin": {
+            "type": "boolean",
+            "example": "false"
           }
         }
       },
@@ -3753,6 +3757,10 @@
           "avatarURL": {
             "type": "string",
             "example": "https://gravatar.com/avatar/aaaa"
+          },
+          "superAdmin": {
+            "type": "boolean",
+            "example": "false"
           },
           "eventInfo": {
             "type": "object",
@@ -3818,6 +3826,10 @@
           "avatarURL": {
             "type": "string",
             "example": "https://gravatar.com/avatar/aaaa"
+          },
+          "superAdmin": {
+            "type": "boolean",
+            "example": "false"
           }
         }
       },
@@ -3859,6 +3871,47 @@
           "avatarURL": {
             "type": "string",
             "example": "https://gravatar.com/avatar/aaaa"
+          },
+          "superAdmin": {
+            "type": "boolean",
+            "example": "false"
+          }
+        }
+      },
+      "Guest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
+          },
+          "username": {
+            "type": "string",
+            "example": "testuser"
+          },
+          "name": {
+            "type": "string",
+            "example": "Test"
+          },
+          "email": {
+            "type": "string",
+            "example": "test@user.com"
+          },
+          "created": {
+            "type": "date-time",
+            "example": "2023-01-20T18:00:00"
+          },
+          "avatarURL": {
+            "type": "string",
+            "example": "https://gravatar.com/avatar/aaaa"
+          },
+          "superAdmin": {
+            "type": "boolean",
+            "example": "false"
+          },
+          "guestCreatedBy": {
+            "type": "string",
+            "example": "13b96dad-e95a-4794-9dea-25fd2bbd21a1"
           }
         }
       },

--- a/server/src/api/authentication.ts
+++ b/server/src/api/authentication.ts
@@ -27,7 +27,8 @@ router.get("/login", (req, res, next) => {
       authenticated: req.session.authenticated,
       id: req.session.userId,
       username: req.session.username,
-      avatarURL: req.session.avatarURL
+      avatarURL: req.session.avatarURL,
+      superAdmin: req.session.superAdmin
     });
   }
   catch (err) {
@@ -96,6 +97,7 @@ router.post("/login", async (req, res, next) => {
     req.session.userId = user.id;
     req.session.username = user.username;
     req.session.avatarURL = user.avatarURL;
+    req.session.superAdmin = user.superAdmin;
     console.log(`User ${user.username} signing in...`, req.sessionID);
     res.status(200).json({
       authenticated: req.session.authenticated,

--- a/server/src/api/guestUsers.ts
+++ b/server/src/api/guestUsers.ts
@@ -38,11 +38,16 @@ router.post("/guests", authCheck, async (req, res, next) => {
     const lastName: string = req.body.lastName;
     const id = randomUUID();
 
+    const byUserId = req.session.userId;
+    if (!byUserId) {
+      throw new ErrorExt(ec.PUD055);
+    }
+
     if (!firstName || firstName.trim() === "") {
       throw new ErrorExt(ec.PUD121);
     }
 
-    const guestUser: Guest = await db.createGuestUser(id, firstName, lastName);
+    const guestUser: Guest = await db.createGuestUser(id, firstName, lastName, byUserId);
     res.status(200).json(guestUser);
   }
   catch (err) {
@@ -63,6 +68,10 @@ router.put("/guests/:id", authCheck, async (req, res, next) => {
     if (!isUUID(guestId)) {
       throw new ErrorExt(ec.PUD016);
     }
+    const byUserId = req.session.userId;
+    if (!byUserId) {
+      throw new ErrorExt(ec.PUD055);
+    }
 
     const firstName: string | undefined = req.body.firstName;
     const lastName: string | undefined = req.body.lastName;
@@ -79,7 +88,7 @@ router.put("/guests/:id", authCheck, async (req, res, next) => {
       lastName: lastName
     };
 
-    const guestUser = await db.editGuestUser(guestId, data);
+    const guestUser = await db.editGuestUser(guestId, data, byUserId);
     if (!guestUser) {
       throw new ErrorExt(ec.PUD122);
     }
@@ -103,8 +112,12 @@ router.delete("/guests/:id", authCheck, async (req, res, next) => {
     if (!isUUID(guestId)) {
       throw new ErrorExt(ec.PUD016);
     }
+    const byUserId = req.session.userId;
+    if (!byUserId) {
+      throw new ErrorExt(ec.PUD055);
+    }
 
-    const success = await db.deleteGuestUser(guestId);
+    const success = await db.deleteGuestUser(guestId, byUserId);
     res.status(200).send({ success: success });
   }
   catch (err) {

--- a/server/src/parsers/parseUsers.ts
+++ b/server/src/parsers/parseUsers.ts
@@ -22,7 +22,8 @@ export const parseUsers = (usersInput: UserDB[], withEventData: boolean, exclude
         username: "Deleted user",
         name: "Deleted user",
         avatarURL: getGravatarURL("", { size: avatarSize ?? 200, default: "mp" }),
-        guest: userObj.guest
+        guest: userObj.guest,
+        superAdmin: userObj.super_admin
       };
       allUsers.push(user);
       if (!excludeGuests || (excludeGuests && !user.guest)) {
@@ -41,6 +42,7 @@ export const parseUsers = (usersInput: UserDB[], withEventData: boolean, exclude
       created: userObj.created,
       avatarURL: getGravatarURL(userObj.email ?? "", { size: avatarSize ?? 200, default: userObj.guest ? "mp" : "identicon" }),
       guest: userObj.guest,
+      superAdmin: userObj.super_admin,
       eventInfo: withEventData && userObj.event_id && userObj.event_joined_time ? {
         id: userObj.event_id,
         isAdmin: userObj.is_event_admin ?? false,
@@ -94,8 +96,9 @@ export const parseGuestUsers = (usersInput: UserDB[], avatarSize?: number): Gues
       name: userObj.first_name,
       firstName: userObj.first_name,
       lastName: userObj.last_name,
+      avatarURL: getGravatarURL(userObj.email ?? "", { size: avatarSize ?? 200, default: "mp" }),
       guest: userObj.guest,
-      avatarURL: getGravatarURL(userObj.email ?? "", { size: avatarSize ?? 200, default: "mp" })
+      guestCreatedBy: userObj.guest_created_by
     };
     guests.push(user);
   });
@@ -126,7 +129,8 @@ export const parseUser = (userObj: UserDB, avatarSize?: number): User => {
     phone: userObj.phone_number,
     created: userObj.created,
     avatarURL: getGravatarURL(userObj.email ?? "", { size: avatarSize ?? 200, default: userObj.guest ? "mp" : "identicon" }),
-    guest: userObj.guest
+    guest: userObj.guest,
+    superAdmin: userObj.super_admin
   };
 };
 
@@ -143,6 +147,7 @@ export const parseGuestUser = (userObj: UserDB, avatarSize?: number): Guest => {
     firstName: userObj.first_name,
     lastName: userObj.last_name,
     avatarURL: getGravatarURL(userObj.email ?? "", { size: avatarSize ?? 200, default: "mp" }),
-    guest: userObj.guest
+    guest: userObj.guest,
+    guestCreatedBy: userObj.guest_created_by
   };
 };

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -1217,3 +1217,21 @@ export const PUD128: ErrorCode = {
   message: "Not a valid event status type",
   status: 400
 };
+
+/**
+ * PUD-129: Only super-admins and guest's creator can delete guest users (403)
+ */
+export const PUD129: ErrorCode = {
+  code: "PUD-129",
+  message: "Only super-admins and guest's creator can delete guest users",
+  status: 403
+};
+
+/**
+ * PUD-130: Only super-admins and guest's creator can edit guest users (403)
+ */
+export const PUD130: ErrorCode = {
+  code: "PUD-130",
+  message: "Only super-admins and guest's creator can edit guest users",
+  status: 403
+};

--- a/server/src/types/express-session.d.ts
+++ b/server/src/types/express-session.d.ts
@@ -6,6 +6,7 @@ declare module "express-session" {
     userId: string;
     username: string;
     avatarURL: string;
+    superAdmin: boolean;
   }
   export interface Store {
     destroyExpired(): void;

--- a/server/src/types/types.ts
+++ b/server/src/types/types.ts
@@ -11,6 +11,7 @@ export type User = {
   created?: Date;
   avatarURL?: string;
   guest: boolean;
+  superAdmin?: boolean;
   eventInfo?: {
     id: string;
     isAdmin: boolean;
@@ -25,6 +26,7 @@ export type Guest = {
   avatarURL: string;
   firstName: string;
   lastName: string;
+  guestCreatedBy?: string;
 }
 
 export type Event = {

--- a/server/src/types/typesDB.ts
+++ b/server/src/types/typesDB.ts
@@ -7,6 +7,8 @@ export type UserDB = {
   phone_number: string,
   created: Date,
   guest: boolean,
+  guest_created_by: string;
+  super_admin: boolean,
   deleted: boolean,
   event_id?: string,
   is_event_admin?: boolean,


### PR DESCRIPTION
Implements super-admin role for users. This admin role is meant for administrating global application wide systems not related to any specific event.

Now guests can only be deleted/edited by super-admins, with both backend and frontend updated accordingly. For ease of use, note that the creator of a guest will still have delete/edit privileges for that specific guest.

Closes #317, closes #318