### PR TITLE
feat: Expenses info on category + prevent deletion of categories with expenses

### DIFF
--- a/app/mikane/src/app/features/mobile/category-item/category-item.component.html
+++ b/app/mikane/src/app/features/mobile/category-item/category-item.component.html
@@ -1,16 +1,22 @@
 <div class="wrapper">
 	<mat-list-item (click)="toggleDropdown()">
 		<div class="upper">
-			<mat-icon matListItemIcon class="category-icon">{{ category.icon ?? "shopping_cart" }}</mat-icon>
-			<mat-icon matListItemIcon class="dropdown-arrow">
-				{{ dropdownOpen ? "arrow_drop_up" : "arrow_drop_down" }}
-			</mat-icon>
-			<div>
-				<div class="number-of-participants">Number of participants: {{ category.users.length }}</div>
-				<div class="name">
-					{{ category.name }}
+			<div class="leftside">
+				<mat-icon matListItemIcon class="category-icon">{{ category.icon ?? "shopping_cart" }}</mat-icon>
+				<mat-icon matListItemIcon class="dropdown-arrow">
+					{{ dropdownOpen ? "arrow_drop_up" : "arrow_drop_down" }}
+				</mat-icon>
+				<div>
+					<div class="number-of-participants">Number of participants: {{ category.users.length }}</div>
+					<div class="name">
+						{{ category.name }}
+					</div>
 				</div>
 			</div>
+			<button	mat-icon-button class="expenses-button" [disabled]="category.numberOfExpenses === 0" (click)="gotoExpenses(); $event.stopPropagation()">
+				<div class="count">{{ category.numberOfExpenses }}</div>
+				<mat-icon class="icon">payment</mat-icon>
+			</button>
 		</div>
 	</mat-list-item>
 	<div #lower class="lower" [style.height.px]="lowerHeight">
@@ -102,7 +108,7 @@
 				<button mat-icon-button (click)="openEdit(category.id, category.name, category.icon)">
 					<mat-icon>edit</mat-icon>
 				</button>
-				<button mat-icon-button color="warn" (click)="deleteCategory(category.id)">
+				<button mat-icon-button [disabled]="category.numberOfExpenses !== 0" color="warn" (click)="deleteCategory(category.id)">
 					<mat-icon>delete</mat-icon>
 				</button>
 			</div>

--- a/app/mikane/src/app/features/mobile/category-item/category-item.component.scss
+++ b/app/mikane/src/app/features/mobile/category-item/category-item.component.scss
@@ -10,22 +10,52 @@
 .upper {
 	display: flex;
 	align-items: center;
+	justify-content: space-between;
 	padding-top: 12px;
 	padding-bottom: 12px;
 	padding-left: 16px;
-	padding-right: 16px;
+	padding-right: 12px;
 
-	.category-icon {
-		margin-right: 2px !important;
+	.leftside {
+		display: flex;
+		align-items: center;
+
+		.category-icon {
+			margin-right: 2px !important;
+		}
+
+		.dropdown-arrow {
+			margin-right: 14px;
+		}
+
+		.number-of-participants {
+			font-size: 0.8em;
+			color: rgba(255, 255, 255, 0.7);
+		}
+
+		.name {
+			white-space: normal;
+			overflow: hidden;
+			display: -webkit-box;
+			-webkit-line-clamp: 1;
+			-webkit-box-orient: vertical;
+		}
 	}
 
-	.dropdown-arrow {
-		margin-right: 14px;
-	}
+	.expenses-button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-direction: column;
 
-	.number-of-participants {
-		font-size: 0.8em;
-		color: rgba(255, 255, 255, 0.7);
+		.count {
+			font-size: small;
+			color: rgba(255, 255, 255, 0.7);
+		}
+
+		.icon {
+			overflow: visible;
+		}
 	}
 }
 

--- a/app/mikane/src/app/features/mobile/category-item/category-item.component.spec.ts
+++ b/app/mikane/src/app/features/mobile/category-item/category-item.component.spec.ts
@@ -28,6 +28,7 @@ describe('CategoryItemComponent', () => {
 			icon: CategoryIcon.SHOPPING,
 			users: [user],
 			weighted: false,
+			numberOfExpenses: 0,
 			created: new Date(),
 		} as Category;
 		component.category = category;

--- a/app/mikane/src/app/features/mobile/category-item/category-item.component.ts
+++ b/app/mikane/src/app/features/mobile/category-item/category-item.component.ts
@@ -41,6 +41,7 @@ export class CategoryItemComponent {
 	@Output() openWeightEditDialog = new EventEmitter<{ categoryId: string; userId: string; weight: number }>();
 	@Output() toggleWeighted = new EventEmitter<{ categoryId: string; weighted: boolean }>();
 	@Output() deleteCategoryDialog = new EventEmitter<{ categoryId: string }>();
+	@Output() gotoCategoryExpenses = new EventEmitter<{ category: Category }>();
 
 	dropdownOpen = false;
 	lowerHeight = 0;
@@ -84,4 +85,8 @@ export class CategoryItemComponent {
 	deleteCategory = (categoryId: string) => {
 		this.deleteCategoryDialog.emit({ categoryId });
 	};
+
+	gotoExpenses = () => {
+		this.gotoCategoryExpenses.emit({ category: this.category });
+	}
 }

--- a/app/mikane/src/app/pages/category/category.component.html
+++ b/app/mikane/src/app/pages/category/category.component.html
@@ -15,9 +15,13 @@
 							{{ category.icon ?? "shopping_cart" }}
 						</mat-icon>
 						<span class="category-name">{{ category.name }}</span>
-						<span class="number-of-participants">
-							<span class="number">{{ category.users.length }}</span>
-							participants
+						<span class="number-of">
+							<span class="number" [ngClass]="{ 'zero': category.users.length === 0 }">{{ category.users.length }}</span>
+							{{ category.users.length === 1 ? 'participant' : 'participants' }}
+						</span>
+						<span class="number-of">
+							<span class="number" [ngClass]="{ 'zero': category.numberOfExpenses === 0 }">{{ category.numberOfExpenses }}</span>
+							{{ category.numberOfExpenses === 1 ? 'expense' : 'expenses' }}
 						</span>
 					</mat-panel-title>
 				</mat-expansion-panel-header>
@@ -136,6 +140,9 @@
 						</form>
 					</table>
 					<div id="category-actions" *ngIf="event?.status.id === EventStatusType.ACTIVE">
+						<button mat-stroked-button type="button" color="accent" class="goto-expenses-button" [disabled]="category.numberOfExpenses === 0" (click)="gotoCategoryExpenses(category)">
+							See expenses
+						</button>
 						<button
 							mat-raised-button
 							type="button"
@@ -148,11 +155,26 @@
 						<button mat-raised-button type="button" color="accent" (click)="toggleWeighted(category.id, category.weighted)">
 							Toggle weighted
 						</button>
-						<button mat-raised-button type="button" color="warn" (click)="deleteCategoryDialog(category.id)">
-							Delete category
-							<mat-icon>delete</mat-icon>
-						</button>
+						@if (category.numberOfExpenses === 0) {
+							<button mat-raised-button type="button" color="warn" (click)="deleteCategoryDialog(category.id)">
+								Delete category
+								<mat-icon>delete</mat-icon>
+							</button>
+						}
+						@else {
+							<span matTooltip="Cannot delete a category with expenses" style="padding: 8px 0">
+								<button mat-raised-button disabled>
+									Delete category
+									<mat-icon>delete</mat-icon>
+								</button>
+							</span>
+						}
 					</div>
+					@if (event?.status.id !== EventStatusType.ACTIVE && category.numberOfExpenses > 0) {
+						<button mat-stroked-button type="button" color="accent" class="goto-expenses-button" [disabled]="category.numberOfExpenses === 0" (click)="gotoCategoryExpenses(category)">
+							See expenses
+						</button>
+					}
 				</ng-template>
 			</mat-expansion-panel>
 		</mat-accordion>
@@ -173,6 +195,7 @@
 			(openEditCategoryDialog)="openEditCategoryDialog(category.id, category.name, category.icon)"
 			(toggleWeighted)="toggleWeighted($event.categoryId, $event.weighted)"
 			(deleteCategoryDialog)="deleteCategoryDialog($event.categoryId)"
+			(gotoCategoryExpenses)="gotoCategoryExpenses($event.category)"
 		>
 		</app-category-item>
 	</mat-nav-list>

--- a/app/mikane/src/app/pages/category/category.component.scss
+++ b/app/mikane/src/app/pages/category/category.component.scss
@@ -5,11 +5,18 @@
 		width: 20%;
 	}
 
-	.number-of-participants {
+	.number-of {
 		color: rgba(255, 255, 255, 0.45);
+		width: 15%;
+		min-width: 120px;
+
 		.number {
 			color: rgba(255, 255, 255, 0.8);
 			margin-right: 4px;
+
+			&.zero {
+				color: rgba(255, 255, 255, 0.3);
+			}
 		}
 	}
 }
@@ -86,6 +93,10 @@
 
 .extra-margin {
 	margin-top: 2em;
+}
+
+.goto-expenses-button {
+	margin: 1em;
 }
 
 .no-categories {

--- a/app/mikane/src/app/pages/category/category.component.spec.ts
+++ b/app/mikane/src/app/pages/category/category.component.spec.ts
@@ -908,7 +908,7 @@ describe('CategoryComponent', () => {
 				width: '350px',
 				data: {
 					title: 'Delete Category',
-					content: 'Are you sure you want to delete this category? All of its expenses will be permanently deleted!',
+					content: 'Are you sure you want to delete this category?',
 					confirm: 'I am sure',
 				},
 			});

--- a/app/mikane/src/app/pages/category/category.component.ts
+++ b/app/mikane/src/app/pages/category/category.component.ts
@@ -11,6 +11,8 @@ import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { Router } from '@angular/router';
 import { map } from 'lodash-es';
 import { BehaviorSubject, Subject, filter, of, switchMap, takeUntil } from 'rxjs';
 import { ConfirmDialogComponent } from 'src/app/features/confirm-dialog/confirm-dialog.component';
@@ -48,6 +50,7 @@ import { CategoryEditDialogComponent } from './category-edit-dialog/category-edi
 		MatInputModule,
 		ProgressSpinnerComponent,
 		MatCardModule,
+		MatTooltipModule,
 		AsyncPipe,
 		MatDialogModule,
 		FormControlPipe,
@@ -81,6 +84,7 @@ export class CategoryComponent implements OnInit, AfterViewChecked, OnDestroy {
 		private messageService: MessageService,
 		public breakpointService: BreakpointService,
 		public contextService: ContextService,
+		private router: Router
 	) {}
 
 	ngOnInit(): void {
@@ -364,7 +368,7 @@ export class CategoryComponent implements OnInit, AfterViewChecked, OnDestroy {
 			width: '350px',
 			data: {
 				title: 'Delete Category',
-				content: 'Are you sure you want to delete this category? All of its expenses will be permanently deleted!',
+				content: 'Are you sure you want to delete this category?',
 				confirm: 'I am sure',
 			},
 		});
@@ -391,6 +395,15 @@ export class CategoryComponent implements OnInit, AfterViewChecked, OnDestroy {
 					console.error('something went wrong while deleting category', err?.error?.message);
 				},
 			});
+	}
+
+	gotoCategoryExpenses(category: Category) {
+		if (category.numberOfExpenses < 1) {
+			return;
+		}
+		this.router.navigate(['events', this.event.id, 'expenses'], {
+			queryParams: { categories: category.id }
+		});
 	}
 
 	ngOnDestroy(): void {

--- a/app/mikane/src/app/pages/participant/participant.component.html
+++ b/app/mikane/src/app/pages/participant/participant.component.html
@@ -146,7 +146,7 @@
 						</button>
 						<ng-template #noRemoveButton>
 							<span matTooltip="Cannot remove a user with expenses" style="padding: 8px 0">
-								<button mat-stroked-button disabled>Remove User</button>
+								<button mat-raised-button disabled>Remove User</button>
 							</span>
 						</ng-template>
 					</div>

--- a/app/mikane/src/app/services/category/category.service.ts
+++ b/app/mikane/src/app/services/category/category.service.ts
@@ -11,6 +11,7 @@ export interface Category {
 	icon: CategoryIcon;
 	weighted: boolean;
 	created: Date;
+	numberOfExpenses: number;
 	users: Array<{
 		id: string;
 		name: string;

--- a/server/db_scripts/add_user_to_category.sql
+++ b/server/db_scripts/add_user_to_category.sql
@@ -11,6 +11,7 @@ returns table (
   weighted boolean,
   event_id uuid,
   created timestamp,
+  number_of_expenses int,
   user_weights jsonb
 ) as
 $$

--- a/server/db_scripts/delete_category.sql
+++ b/server/db_scripts/delete_category.sql
@@ -14,6 +14,10 @@ begin
     raise exception 'Only active events can be edited' using errcode = 'P0118';
   end if;
 
+  if exists (select 1 from expense ex inner join category c on ex.category_id = c.id where c.id = ip_category_id) then
+    raise exception 'Cannot delete category, as it has at least one expense associated with it' using errcode = 'P0131';
+  end if;
+
   delete from category c where c.id = ip_category_id;
 
 end;

--- a/server/db_scripts/edit_category.sql
+++ b/server/db_scripts/edit_category.sql
@@ -11,6 +11,7 @@ returns table (
   weighted boolean,
   event_id uuid,
   created timestamp,
+  number_of_expenses int,
   user_weights jsonb
 ) as
 $$

--- a/server/db_scripts/edit_category_weighted_status.sql
+++ b/server/db_scripts/edit_category_weighted_status.sql
@@ -10,6 +10,7 @@ returns table (
   weighted boolean,
   event_id uuid,
   created timestamp,
+  number_of_expenses int,
   user_weights jsonb
 ) as
 $$

--- a/server/db_scripts/edit_user_weight.sql
+++ b/server/db_scripts/edit_user_weight.sql
@@ -11,6 +11,7 @@ returns table (
   weighted boolean,
   event_id uuid,
   created timestamp,
+  number_of_expenses int,
   user_weights jsonb
 ) as
 $$

--- a/server/db_scripts/get_categories.sql
+++ b/server/db_scripts/get_categories.sql
@@ -10,6 +10,7 @@ returns table (
   weighted boolean,
   event_id uuid,
   created timestamp,
+  number_of_expenses int,
   user_weights jsonb
 ) as
 $$
@@ -47,6 +48,14 @@ begin
     c.weighted,
     e.id as event_id,
     c.created,
+    (
+      select
+        count(e.id)::int
+      from
+        expense e
+      where
+        e.category_id = c.id
+    ) as number_of_expenses,
     (
       select
         jsonb_agg(jsonb_build_object(

--- a/server/db_scripts/new_category.sql
+++ b/server/db_scripts/new_category.sql
@@ -12,6 +12,7 @@ returns table (
   weighted boolean,
   event_id uuid,
   created timestamp,
+  number_of_expenses int,
   user_weights jsonb
 ) as
 $$

--- a/server/db_scripts/remove_user_from_category.sql
+++ b/server/db_scripts/remove_user_from_category.sql
@@ -5,11 +5,12 @@ create or replace function remove_user_from_category(
 )
 returns table (
   id uuid,
-  name varchar(255),
+  "name" varchar(255),
   icon varchar(255),
   weighted boolean,
   event_id uuid,
   created timestamp,
+  number_of_expenses int,
   user_weights jsonb
 ) as
 $$

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mikane_server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mikane_server",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "cors": "^2.8.5",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mikane_server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "API server for Mikane",
   "scripts": {
     "build": "rimraf ./build && tsc && npm run copy && cd build && npm ci --omit=dev",

--- a/server/src/db/dbCategories.ts
+++ b/server/src/db/dbCategories.ts
@@ -241,6 +241,8 @@ export const deleteCategory = async (categoryId: string) => {
         throw new ErrorExt(ec.PUD007, err);
       else if (err.code === "P0118")
         throw new ErrorExt(ec.PUD118, err);
+      else if (err.code === "P0131")
+        throw new ErrorExt(ec.PUD131, err);
       else
         throw new ErrorExt(ec.PUD022, err);
     });

--- a/server/src/parsers/parseCategories.ts
+++ b/server/src/parsers/parseCategories.ts
@@ -26,7 +26,8 @@ export const parseCategories = (catInput: CategoryDB[], target: Target, usersInE
       name: catObj.name,
       icon: icon,
       weighted: catObj.weighted,
-      created: catObj.created
+      created: catObj.created,
+      numberOfExpenses: catObj.number_of_expenses
     };
 
     if (target === Target.CLIENT) {

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -1235,3 +1235,12 @@ export const PUD130: ErrorCode = {
   message: "Only super-admins and guest's creator can edit guest users",
   status: 403
 };
+
+/**
+ * PUD-131: Cannot delete category, as it has at least one expense associated with it (400)
+ */
+export const PUD131: ErrorCode = {
+  code: "PUD-131",
+  message: "Cannot delete category, as it has at least one expense associated with it",
+  status: 400
+};

--- a/server/src/types/types.ts
+++ b/server/src/types/types.ts
@@ -53,6 +53,7 @@ export type Category = {
   icon: CategoryIcon;
   weighted: boolean;
   created: Date;
+  numberOfExpenses: number;
   userWeights?: Map<string, number>;
   users?: {
     id: string;

--- a/server/src/types/typesDB.ts
+++ b/server/src/types/typesDB.ts
@@ -37,6 +37,7 @@ export type CategoryDB = {
   icon: string,
   weighted: boolean,
   created: Date,
+  number_of_expenses: number,
   user_weights: {
     user_id: string,
     guest: boolean,


### PR DESCRIPTION
### Expenses info on category
Added information about associated expenses when on the categories page. In full view, there is now a count of linked expenses next to the count of participants in said category. Inside the category dropdown there is also now a "see expenses" button that takes the user to the expenses page, filtered for the given category.

On mobile, there is instead an "expense-icon" button next to the category name, with a number above it counting the number of expenses. Clicking on this button also takes the user to the expenses page, filtered for the given category.

### Prevent deletion of categories with expenses
Previously it was too easy to accidently delete a bunch of expenses by deleting their associated category. Now only categories without any expenses can be deleted, meaning any existing expenses need to either change category or be deleted before the category can be deleted.

Closes #306, closes #323 