### PR TITLE
feat: Scroll service, hide buttons when page is at bottom

### DIFF
--- a/app/mikane/src/app/pages/category/category.component.html
+++ b/app/mikane/src/app/pages/category/category.component.html
@@ -205,7 +205,7 @@
 		color="primary"
 		class="add-category-button-mobile"
 		(click)="openDialog()"
-		[ngClass]="{ iOS: contextService.isIos }"
+		[ngClass]="{ iOS: contextService.isIos, hidden: scrollService.isScrolledToBottom() | async }"
 	>
 		<mat-icon>post_add</mat-icon>
 	</button>

--- a/app/mikane/src/app/pages/category/category.component.scss
+++ b/app/mikane/src/app/pages/category/category.component.scss
@@ -81,6 +81,14 @@
 	bottom: 80px;
 	right: 20px;
 	z-index: 999;
+	opacity: 1;
+	transition: opacity 0.2s ease;
+
+	&.hidden {
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.2s ease;
+	}
 
 	&.iOS {
 		bottom: 110px;

--- a/app/mikane/src/app/pages/category/category.component.ts
+++ b/app/mikane/src/app/pages/category/category.component.ts
@@ -20,6 +20,7 @@ import { CategoryItemComponent } from 'src/app/features/mobile/category-item/cat
 import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.service';
 import { Category, CategoryService } from 'src/app/services/category/category.service';
 import { ContextService } from 'src/app/services/context/context.service';
+import { ScrollService } from 'src/app/services/scroll/scroll.service';
 import { PuddingEvent, EventStatusType } from 'src/app/services/event/event.service';
 import { MessageService } from 'src/app/services/message/message.service';
 import { User, UserService } from 'src/app/services/user/user.service';
@@ -84,6 +85,7 @@ export class CategoryComponent implements OnInit, AfterViewChecked, OnDestroy {
 		private messageService: MessageService,
 		public breakpointService: BreakpointService,
 		public contextService: ContextService,
+		public scrollService: ScrollService,
 		private router: Router
 	) {}
 

--- a/app/mikane/src/app/pages/events/events.component.html
+++ b/app/mikane/src/app/pages/events/events.component.html
@@ -132,7 +132,7 @@
 	<ng-template #noArchivedEvents>
 		<div class="no-events-mobile">There are currently no archived events</div>
 	</ng-template>
-	<button mat-fab color="primary" class="add-event-button-mobile" (click)="openDialog()">
+	<button mat-fab color="primary" class="add-event-button-mobile" (click)="openDialog()" [ngClass]="{ hidden: scrollService.isScrolledToBottom() | async }">
 		<mat-icon>edit_calendar</mat-icon>
 	</button>
 </ng-template>

--- a/app/mikane/src/app/pages/events/events.component.scss
+++ b/app/mikane/src/app/pages/events/events.component.scss
@@ -133,4 +133,12 @@ mat-card-content {
 	bottom: 50px;
 	right: 20px;
 	z-index: 9999;
+	opacity: 1;
+	transition: opacity 0.2s ease;
+
+	&.hidden {
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.2s ease;
+	}
 }

--- a/app/mikane/src/app/pages/events/events.component.ts
+++ b/app/mikane/src/app/pages/events/events.component.ts
@@ -15,6 +15,7 @@ import { EventItemComponent } from 'src/app/features/mobile/event-item/event-ite
 import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.service';
 import { EventService, EventStatusType, PuddingEvent } from 'src/app/services/event/event.service';
 import { MessageService } from 'src/app/services/message/message.service';
+import { ScrollService } from 'src/app/services/scroll/scroll.service';
 import { ApiError } from 'src/app/types/apiError.type';
 import { ProgressSpinnerComponent } from '../../shared/progress-spinner/progress-spinner.component';
 import { EventDialogComponent } from './event-dialog/event-dialog.component';
@@ -80,11 +81,12 @@ export class EventsComponent implements OnInit, OnDestroy {
 
 	constructor(
 		private eventService: EventService,
+		private messageService: MessageService,
 		private router: Router,
 		private route: ActivatedRoute,
 		public dialog: MatDialog,
-		private messageService: MessageService,
 		public breakpointService: BreakpointService,
+		public scrollService: ScrollService,
 	) {}
 
 	ngOnInit() {

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.html
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.html
@@ -187,7 +187,7 @@
 		color="primary"
 		class="add-expense-button-mobile"
 		(click)="openDialog()"
-		[ngClass]="{ iOS: contextService.isIos }"
+		[ngClass]="{ iOS: contextService.isIos, hidden: scrollService.isScrolledToBottom() | async }"
 	>
 		<mat-icon>add_shopping_cart</mat-icon>
 	</button>

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.scss
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.scss
@@ -7,6 +7,14 @@
 	bottom: 80px;
 	right: 20px;
 	z-index: 999;
+	opacity: 1;
+	transition: opacity 0.2s ease;
+
+	&.hidden {
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.2s ease;
+	}
 
 	&.iOS {
 		bottom: 110px;

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.ts
@@ -30,6 +30,7 @@ import { AuthService } from 'src/app/services/auth/auth.service';
 import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.service';
 import { Category, CategoryService } from 'src/app/services/category/category.service';
 import { ContextService } from 'src/app/services/context/context.service';
+import { ScrollService } from 'src/app/services/scroll/scroll.service';
 import { EventStatusType, PuddingEvent } from 'src/app/services/event/event.service';
 import { Expense, ExpenseService } from 'src/app/services/expense/expense.service';
 import { MessageService } from 'src/app/services/message/message.service';
@@ -120,6 +121,7 @@ export class ExpendituresComponent implements OnInit, OnDestroy {
 		private messageService: MessageService,
 		public breakpointService: BreakpointService,
 		public contextService: ContextService,
+		public scrollService: ScrollService,
 		private route: ActivatedRoute,
 		private router: Router,
 		private changeDetector: ChangeDetectorRef,

--- a/app/mikane/src/app/pages/participant/participant.component.html
+++ b/app/mikane/src/app/pages/participant/participant.component.html
@@ -195,7 +195,7 @@
 		color="primary"
 		class="add-users-button-mobile"
 		(click)="openDialog()"
-		[ngClass]="{ iOS: contextService.isIos }"
+		[ngClass]="{ iOS: contextService.isIos, hidden: scrollService.isScrolledToBottom() | async }"
 	>
 		<mat-icon>person_add</mat-icon>
 	</button>

--- a/app/mikane/src/app/pages/participant/participant.component.scss
+++ b/app/mikane/src/app/pages/participant/participant.component.scss
@@ -72,6 +72,14 @@
 	bottom: 80px;
 	right: 20px;
 	z-index: 999;
+	opacity: 1;
+	transition: opacity 0.2s ease;
+
+	&.hidden {
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.2s ease;
+	}
 
 	&.iOS {
 		bottom: 110px;

--- a/app/mikane/src/app/pages/participant/participant.component.spec.ts
+++ b/app/mikane/src/app/pages/participant/participant.component.spec.ts
@@ -244,7 +244,6 @@ describe('ParticipantComponent', () => {
 					data: {
 						users: jasmine.any(Observable),
 					},
-					autoFocus: false,
 				});
 			});
 

--- a/app/mikane/src/app/pages/participant/participant.component.ts
+++ b/app/mikane/src/app/pages/participant/participant.component.ts
@@ -35,6 +35,7 @@ import { EventService, PuddingEvent, EventStatusType } from 'src/app/services/ev
 import { ExpenseService } from 'src/app/services/expense/expense.service';
 import { MessageService } from 'src/app/services/message/message.service';
 import { User, UserBalance, UserService } from 'src/app/services/user/user.service';
+import { ScrollService } from 'src/app/services/scroll/scroll.service';
 import { ApiError } from 'src/app/types/apiError.type';
 import { ProgressSpinnerComponent } from '../../shared/progress-spinner/progress-spinner.component';
 import { ExpenditureDialogComponent } from '../expenditures/expenditure-dialog/expenditure-dialog.component';
@@ -97,6 +98,7 @@ export class ParticipantComponent implements OnInit, OnDestroy {
 		protected authService: AuthService,
 		public breakpointService: BreakpointService,
 		public contextService: ContextService,
+		public scrollService: ScrollService,
 	) {}
 
 	ngOnInit() {
@@ -195,7 +197,6 @@ export class ParticipantComponent implements OnInit, OnDestroy {
 					}),
 				),
 			},
-			autoFocus: false,
 		});
 
 		dialogRef

--- a/app/mikane/src/app/services/scroll/scroll.service.spec.ts
+++ b/app/mikane/src/app/services/scroll/scroll.service.spec.ts
@@ -1,14 +1,50 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ScrollService } from './scroll.service';
 
 describe('ScrollService', () => {
 	let service: ScrollService;
 
-	beforeEach(async () => {
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			providers: [ScrollService],
+		});
+
 		service = TestBed.inject(ScrollService);
 	});
 
 	it('should be created', () => {
 		expect(service).toBeTruthy();
 	});
+
+	it('should emit scroll position on scroll event', fakeAsync(() => {
+		let emittedScrollPosition: number | undefined;
+
+		service.scrollPosition$.subscribe((scrollPosition) => {
+			emittedScrollPosition = scrollPosition;
+		});
+
+		// Simulate a scroll event
+		window.dispatchEvent(new Event('scroll'));
+
+		// Advance the clock to allow for the debounce time in the handleScroll function
+		tick(100);
+
+		expect(emittedScrollPosition).toBeDefined();
+	}));
+
+	it('should emit scroll position on resize event', fakeAsync(() => {
+		let emittedScrollPosition: number | undefined;
+
+		service.scrollPosition$.subscribe((scrollPosition) => {
+			emittedScrollPosition = scrollPosition;
+		});
+
+		// Simulate a resize event
+		window.dispatchEvent(new Event('resize'));
+
+		// Advance the clock to allow for the debounce time in the handleScroll function
+		tick(100);
+
+		expect(emittedScrollPosition).toBeDefined();
+	}));
 });

--- a/app/mikane/src/app/services/scroll/scroll.service.spec.ts
+++ b/app/mikane/src/app/services/scroll/scroll.service.spec.ts
@@ -1,0 +1,14 @@
+import { TestBed } from '@angular/core/testing';
+import { ScrollService } from './scroll.service';
+
+describe('ScrollService', () => {
+	let service: ScrollService;
+
+	beforeEach(async () => {
+		service = TestBed.inject(ScrollService);
+	});
+
+	it('should be created', () => {
+		expect(service).toBeTruthy();
+	});
+});

--- a/app/mikane/src/app/services/scroll/scroll.service.ts
+++ b/app/mikane/src/app/services/scroll/scroll.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from "@angular/core";
+import { BehaviorSubject, Observable, map } from "rxjs";
+
+@Injectable({
+	providedIn: 'root'
+})
+export class ScrollService {
+	private ticking = false;
+
+	private scrollPositionSubject = new BehaviorSubject<number>(0);
+	scrollPosition$ = this.scrollPositionSubject.asObservable();
+
+	constructor() {
+		window.addEventListener('scroll', () => this.handleScroll());
+		window.addEventListener('resize', () => this.handleScroll());
+	}
+
+	handleScroll(): void {
+		if (!this.ticking) {
+			window.requestAnimationFrame(() => {
+				const lastKnownScrollY = window.scrollY || document.documentElement.scrollTop;
+				this.ticking = false;
+
+				this.scrollPositionSubject.next(lastKnownScrollY);
+			});
+
+			this.ticking = true;
+		}
+	}
+
+	isScrolledToBottom(): Observable<boolean> {
+		return this.scrollPosition$.pipe(
+			map(scrollTop => {
+				const scrollHeight = document.documentElement.scrollHeight;
+				const clientHeight = window.innerHeight;
+
+				// If scrolling is not possible, consider it as not scrolled to the bottom
+				if (scrollHeight <= clientHeight) {
+					return false;
+				}
+
+				return scrollTop + clientHeight >= scrollHeight;
+			})
+		);
+	}
+}


### PR DESCRIPTION
Implements a scroll service listening on scroll and resize events (resize required for proper functionality on mobile). On mobile, when the page is scrolled to the bottom, the "new event", "add user to event", "new expense", and "new category" buttons will be hidden so the user can view the content underneath them.

Closes #253 