### PR TITLE
fix: use event name as title in event tabs

### DIFF
--- a/app/mikane/src/app/app-routing.module.ts
+++ b/app/mikane/src/app/app-routing.module.ts
@@ -17,36 +17,43 @@ const routes: Routes = [
 	},
 	{
 		path: 'login',
+		title: 'Login | Mikane',
 		canActivate: [loggedInGuard],
 		loadChildren: () => import('./pages/login/login.routes'),
 	},
 	{
 		path: 'register',
+		title: 'Register | Mikane',
 		canActivate: [loggedInGuard],
 		loadChildren: () => import('./pages/register/register-user.routes'),
 	},
 	{
 		path: 'account',
+		title: 'Account | Mikane',
 		canActivate: [authGuard],
 		loadChildren: () => import('./pages/account/account.routes'),
 	},
 	{
 		path: 'reset-password',
+		title: 'Reset password | Mikane',
 		canActivate: [loggedInGuard],
 		loadChildren: () => import('./pages/reset-password/reset-password.routes'),
 	},
 	{
 		path: 'guests',
+		title: 'Guests | Mikane',
 		canActivate: [authGuard],
 		loadChildren: () => import('./pages/guests/guests.routes'),
 	},
 	{
 		path: 'invite',
+		title: 'Invite User | Mikane',
 		canActivate: [authGuard],
 		loadChildren: () => import('./pages/invite/invite.routes'),
 	},
 	{
 		path: 'delete-account',
+		title: 'Delete Account | Mikane',
 		canActivate: [authGuard],
 		loadChildren: () => import('./pages/delete-account/delete-account.routes'),
 	},

--- a/app/mikane/src/app/pages/events/event/event.component.ts
+++ b/app/mikane/src/app/pages/events/event/event.component.ts
@@ -5,14 +5,13 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, Router, RouterLink, RouterOutlet } from '@angular/router';
 import { BehaviorSubject, combineLatest, map } from 'rxjs';
 import { MenuComponent } from 'src/app/features/menu/menu.component';
 import { MobileEventNavbarComponent } from 'src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component';
 import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.service';
 import { ContextService } from 'src/app/services/context/context.service';
-import { EventService, PuddingEvent, EventStatusType } from 'src/app/services/event/event.service';
+import { EventService, EventStatusType, PuddingEvent } from 'src/app/services/event/event.service';
 import { MessageService } from 'src/app/services/message/message.service';
 import { CategoryComponent } from '../../category/category.component';
 import { EventInfoComponent } from '../../event-info/event-info.component';
@@ -77,8 +76,7 @@ export class EventComponent implements OnInit {
 				icon: 'settings',
 				location: './settings',
 			});
-		}
-		else if (!this.isEventAdmin() && !this.isMobile()) {
+		} else if (!this.isEventAdmin() && !this.isMobile()) {
 			eventLinks.push({
 				name: 'Info',
 				icon: 'info',
@@ -93,19 +91,19 @@ export class EventComponent implements OnInit {
 		private route: ActivatedRoute,
 		private router: Router,
 		private messageService: MessageService,
-		private titleService: Title,
 		public breakpointService: BreakpointService,
-		public contextService: ContextService
+		public contextService: ContextService,
 	) {
 		const event = this.router.getCurrentNavigation()?.extras.state?.['event'];
 		if (event) {
 			this.event = event;
 			this.isEventAdmin.set(event.userInfo.isAdmin);
-			this.titleService.setTitle(event.name);
 		}
 	}
 
-	onOutletLoaded(component: ExpendituresComponent | EventInfoComponent | EventSettingsComponent | ParticipantComponent | CategoryComponent) {
+	onOutletLoaded(
+		component: ExpendituresComponent | EventInfoComponent | EventSettingsComponent | ParticipantComponent | CategoryComponent,
+	) {
 		if (
 			component instanceof ExpendituresComponent ||
 			component instanceof EventInfoComponent ||
@@ -134,14 +132,13 @@ export class EventComponent implements OnInit {
 					return events.find((event) => {
 						return event.id === params['eventId'];
 					});
-				})
+				}),
 			)
 			.subscribe({
 				next: (event) => {
 					if (event) {
 						this.event = event;
 						this.isEventAdmin.set(event.userInfo.isAdmin);
-						this.titleService.setTitle(event.name);
 						this.$event.next(event);
 					} else {
 						// Event not found, redirect to event list

--- a/app/mikane/src/app/pages/events/events.routes.ts
+++ b/app/mikane/src/app/pages/events/events.routes.ts
@@ -1,9 +1,26 @@
-import { Route } from '@angular/router';
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, ResolveFn, Route } from '@angular/router';
+import { map } from 'rxjs';
 import { authGuard } from 'src/app/services/auth/auth.guard';
-import { EventComponent } from './event/event.component';
-import { EventsComponent } from './events.component';
+import { EventService } from 'src/app/services/event/event.service';
 import { eventInfoGuard } from '../event-info/event-info.guard';
 import { eventSettingsGuard } from '../event-settings/event-settings.guard';
+import { EventComponent } from './event/event.component';
+import { EventsComponent } from './events.component';
+
+const eventTitleResolver: ResolveFn<string> = (route: ActivatedRouteSnapshot) => {
+	return inject(EventService)
+		.loadEvents()
+		.pipe(
+			map((events) => {
+				return (
+					events.find((event) => {
+						return event.id === route.parent?.params['eventId'];
+					})?.name + ' | Mikane'
+				);
+			}),
+		);
+};
 
 export default [
 	{ path: '', component: EventsComponent },
@@ -14,27 +31,33 @@ export default [
 		children: [
 			{
 				path: 'participants',
+				title: eventTitleResolver,
 				loadChildren: () => import('../participant/participant.routes'),
 			},
 			{
 				path: 'expenses',
+				title: eventTitleResolver,
 				loadChildren: () => import('../expenditures/expenditures.routes'),
 			},
 			{
 				path: 'categories',
+				title: eventTitleResolver,
 				loadChildren: () => import('../category/category.routes'),
 			},
 			{
 				path: 'payment',
+				title: eventTitleResolver,
 				loadChildren: () => import('../payment-structure/payment-structure.routes'),
 			},
 			{
 				path: 'info',
+				title: eventTitleResolver,
 				canActivate: [eventInfoGuard],
 				loadChildren: () => import('../event-info/event-info.routes'),
 			},
 			{
 				path: 'settings',
+				title: eventTitleResolver,
 				canActivate: [eventSettingsGuard],
 				loadChildren: () => import('../event-settings/event-settings.routes'),
 			},

--- a/app/mikane/src/app/pages/profile/profile.component.ts
+++ b/app/mikane/src/app/pages/profile/profile.component.ts
@@ -4,6 +4,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription, catchError, map, of, switchMap } from 'rxjs';
 import { MenuComponent } from 'src/app/features/menu/menu.component';
@@ -40,8 +41,9 @@ export class ProfileComponent implements OnInit, OnDestroy {
 		private authService: AuthService,
 		private userService: UserService,
 		private messageService: MessageService,
+		private titleService: Title,
 		private route: ActivatedRoute,
-		private router: Router
+		private router: Router,
 	) {}
 
 	ngOnInit() {
@@ -62,12 +64,13 @@ export class ProfileComponent implements OnInit, OnDestroy {
 					this.messageService.showError('Something went wrong');
 					console.error('something went wrong while getting user on profile page', err);
 					return of(undefined);
-				})
+				}),
 			)
 			.subscribe({
 				next: (user) => {
 					if (user) {
 						this.user = user;
+						this.titleService.setTitle(`${user.name} | Mikane`);
 						this.loading = false;
 					} else {
 						this.messageService.showError('User not found');


### PR DESCRIPTION
When switching tabs in event, event name is fetched and used as the title

Fixes #298