### PR TITLE
fix: Disable edit event inputs for non-active events + fix hidden 'ready to settle' text for mobile

### DIFF
--- a/app/mikane/src/app/features/mobile/event-item/event-item.component.html
+++ b/app/mikane/src/app/features/mobile/event-item/event-item.component.html
@@ -18,7 +18,7 @@
 			A
 		</span>
 	</div>
-	<div *ngIf="event.description" class="description">
+	<div class="description">
 		{{ event.status.id === EventStatusType.READY_TO_SETTLE ? 'READY TO SETTLE' : event.description }}
 	</div>
 </mat-list-item>

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.html
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.html
@@ -48,22 +48,27 @@
 
 <ng-template #formContent>
 	<form (ngSubmit)="editEvent()" class="event-settings-content form">
+		@if (event.status.id !== EventStatusType.ACTIVE) {
+			<div class="only-active-edit">
+				Only active events can be edited
+			</div>
+		}
 		<mat-form-field appearance="fill">
 			<mat-label>Event Name</mat-label>
-			<input matInput name="name" [(ngModel)]="eventData.name" required [appEventName]="eventData.id" #name="ngModel" />
+			<input matInput name="name" [(ngModel)]="eventData.name" required [disabled]="event.status.id !== EventStatusType.ACTIVE" [appEventName]="eventData.id" #name="ngModel" />
 			<mat-error *ngIf="name.errors?.['required']">Event name is required</mat-error>
 			<mat-error *ngIf="name.errors?.['duplicate']">Event name already exists</mat-error>
 			<mat-error *ngIf="name.errors?.['invalid']">Invalid event name</mat-error>
 		</mat-form-field>
 		<mat-form-field appearance="fill">
 			<mat-label>Event Description</mat-label>
-			<input matInput name="description" [(ngModel)]="eventData.description" />
+			<input matInput name="description" [(ngModel)]="eventData.description" [disabled]="event.status.id !== EventStatusType.ACTIVE" />
 		</mat-form-field>
 		<button
 			mat-raised-button
 			color="primary"
 			type="submit"
-			[disabled]="name.invalid || name.pending"
+			[disabled]="event.status.id !== EventStatusType.ACTIVE || name.invalid || name.pending"
 			[ngClass]="(breakpointService.isMobile() | async) ? 'save-button-mobile' : 'save-button-pc'"
 		>
 			Save

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.scss
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.scss
@@ -44,6 +44,10 @@
 	flex-direction: column;
 	margin-bottom: 40px;
 
+	.only-active-edit {
+		margin-bottom: 18px;
+	}
+
 	.save-button-pc {
 		max-width: 140px;
 	}


### PR DESCRIPTION
Disable edit event inputs when event is not active, and fix bug where the 'ready to settle' subtext in the events list would not show for mobile.

Fixes #333, fixes #334