### PR TITLE
fix: Update mobile navbar to use signal input

### DIFF
--- a/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.html
+++ b/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.html
@@ -1,7 +1,7 @@
 <div class="navbar" [ngClass]="{ iOS: contextService.isIos }">
 	<a
 		class="nav-button"
-		*ngFor="let link of mobileLinks"
+		*ngFor="let link of mobileLinks()"
 		[routerLink]="link.location"
 		(click)="activeLink = link.location"
 		[ngClass]="{ active: activeLink.includes(link.location), 'nav-back-button': link.location === '/events' }"

--- a/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.spec.ts
+++ b/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.spec.ts
@@ -28,10 +28,10 @@ describe('MobileEventNavbarComponent', () => {
 		fixture = TestBed.createComponent(MobileEventNavbarComponent);
 		component = fixture.componentInstance;
 		component.activeLink = '/events';
-		component.links = [
+		fixture.componentRef.setInput('links', [
 			{ name: 'Link 1', icon: 'icon1', location: '/link1' },
 			{ name: 'Link 2', icon: 'icon2', location: '/link2' },
-		];
+		]);
 		fixture.detectChanges();
 	});
 
@@ -48,7 +48,7 @@ describe('MobileEventNavbarComponent', () => {
 	it('should display the correct number of links', () => {
 		const linkEls = fixture.debugElement.queryAll(By.css('.nav-button'));
 		// Back arrow counts as its own link and is always present
-		expect(linkEls.length).toEqual(component.links.length + 1);
+		expect(linkEls.length).toEqual(component.links().length + 1);
 	});
 
 	it('should set the active class on the active link', () => {

--- a/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.ts
+++ b/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, computed, Input, input } from '@angular/core';
 import { MatRippleModule } from '@angular/material/core';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterLink, RouterOutlet } from '@angular/router';
@@ -18,22 +18,20 @@ interface Route {
 	standalone: true,
 	imports: [CommonModule, RouterLink, RouterOutlet, MatIconModule, MatRippleModule],
 })
-export class MobileEventNavbarComponent implements OnInit {
+export class MobileEventNavbarComponent {
 	@Input() activeLink: string;
-	@Input() links: Route[];
+	links = input.required<Route[]>();
 
-	constructor(public contextService: ContextService) {}
-
-	mobileLinks: Route[];
-
-	ngOnInit(): void {
-		this.mobileLinks = [
+	mobileLinks = computed(() => {
+		return [
 			{
 				name: '',
 				icon: 'arrow_back_ios',
 				location: '/events',
 			},
-			...this.links,
+			...this.links(),
 		];
-	}
+	});
+
+	constructor(public contextService: ContextService) {}
 }

--- a/app/mikane/src/app/pages/events/events.component.ts
+++ b/app/mikane/src/app/pages/events/events.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe, CommonModule, NgFor, NgIf } from '@angular/common';
-import { Component, OnDestroy, OnInit, WritableSignal, computed, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, computed, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
@@ -45,7 +45,7 @@ import { EventDialogComponent } from './event-dialog/event-dialog.component';
 	],
 })
 export class EventsComponent implements OnInit, OnDestroy {
-	events: WritableSignal<PuddingEvent[]> = signal([]);
+	events = signal<PuddingEvent[]>([]);
 	eventsActive = computed(() => {
 		return this.events().filter((event) => event.status.id !== EventStatusType.ARCHIVED);
 	});

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.ts
@@ -7,7 +7,6 @@ import {
 	OnDestroy,
 	OnInit,
 	ViewChild,
-	WritableSignal,
 	computed,
 	signal,
 } from '@angular/core';
@@ -67,10 +66,10 @@ export class ExpendituresComponent implements OnInit, OnDestroy {
 	@Input() $event: BehaviorSubject<PuddingEvent>;
 	event!: PuddingEvent;
 
-	private sortValue: WritableSignal<Sort> = signal({} as Sort);
-	protected expenses: WritableSignal<Expense[]> = signal([]);
-	protected payers: WritableSignal<User[]> = signal([]);
-	protected categories: WritableSignal<Array<{ id: string; name: string; icon: string }>> = signal([]);
+	private sortValue = signal<Sort>({} as Sort);
+	protected expenses = signal<Expense[]>([]);
+	protected payers = signal<User[]>([]);
+	protected categories = signal<Array<{ id: string; name: string; icon: string }>>([]);
 
 	filteredExpenses = computed(() => {
 		return this.sortData(this.sortValue(), this.expenses()).filter((expense) => {
@@ -84,10 +83,10 @@ export class ExpendituresComponent implements OnInit, OnDestroy {
 		});
 	});
 
-	protected filterValue: WritableSignal<string> = signal('');
-	protected payersFilter: WritableSignal<string[]> = signal([]);
+	protected filterValue = signal<string>('');
+	protected payersFilter = signal<string[]>([]);
 	protected payersFilterSelect: string[] = [];
-	protected categoriesFilter: WritableSignal<string[]> = signal([]);
+	protected categoriesFilter = signal<string[]>([]);
 	protected categoriesFilterSelect: string[] = [];
 	protected filteredPayer = computed(() => {
 		return this.payers().find((payer) => this.payersFilter().includes(payer.id));


### PR DESCRIPTION
Updates the mobile navbar to use signal input for the "links" object, which fixes the small issue where the wrong navbar text would be displayed when switching between full view and mobile view without refreshing.

Additional change: Somewhat simplifies the overall signal syntax.

Fixes #342 