### PR TITLE
feat: Backend support for user preferences

### DIFF
--- a/server/db_scripts/convert_guest_to_user.sql
+++ b/server/db_scripts/convert_guest_to_user.sql
@@ -19,7 +19,9 @@ returns table (
   created timestamp,
   guest boolean,
   guest_created_by uuid,
-  super_admin boolean
+  super_admin boolean,
+  public_email boolean,
+  public_phone boolean
 ) as
 $$
 declare tmp_user_id uuid;
@@ -57,6 +59,9 @@ begin
     u.guest = true and
     u.deleted = false
   returning u.id into tmp_user_id;
+
+  insert into user_preferences (user_id, public_email, public_phone)
+    values (tmp_user_id, false, true);
 
   return query
   select * from get_user(tmp_user_id, null, false);

--- a/server/db_scripts/edit_guest_user.sql
+++ b/server/db_scripts/edit_guest_user.sql
@@ -16,7 +16,9 @@ returns table (
   created timestamp,
   guest boolean,
   guest_created_by uuid,
-  super_admin boolean
+  super_admin boolean,
+  public_email boolean,
+  public_phone boolean
 ) as
 $$
 begin

--- a/server/db_scripts/edit_user.sql
+++ b/server/db_scripts/edit_user.sql
@@ -18,7 +18,9 @@ returns table (
   created timestamp,
   guest boolean,
   guest_created_by uuid,
-  super_admin boolean
+  super_admin boolean,
+  public_email boolean,
+  public_phone boolean
 ) as
 $$
 begin

--- a/server/db_scripts/edit_user_preferences.sql
+++ b/server/db_scripts/edit_user_preferences.sql
@@ -1,0 +1,46 @@
+drop function if exists edit_user_preferences;
+create or replace function edit_user_preferences(
+  ip_user_id uuid,
+  ip_public_email boolean,
+  ip_public_phone boolean
+)
+returns table (
+  id uuid,
+  username varchar(255),
+  first_name varchar(255),
+  last_name varchar(255),
+  email varchar(255),
+  phone_number varchar(20),
+  "password" varchar(255),
+  created timestamp,
+  guest boolean,
+  guest_created_by uuid,
+  super_admin boolean,
+  public_email boolean,
+  public_phone boolean
+) as
+$$
+begin
+
+  if not exists (select 1 from "user" u where u.id = ip_user_id and u.deleted = false) then
+    raise exception 'User not found' using errcode = 'P0008';
+  end if;
+
+  if not exists (select 1 from user_preferences up where up.user_id = ip_user_id) then
+    raise exception 'Something went wrong - user does not have a preferences entry in the database' using errcode = 'P0134';
+  end if;
+
+  update
+    user_preferences up
+  set
+    public_email = coalesce(ip_public_email, up.public_email),
+    public_phone = coalesce(ip_public_phone, up.public_phone)
+  where
+    up.user_id = ip_user_id;
+  
+  return query
+  select * from get_user(ip_user_id, null, false);
+
+end;
+$$
+language plpgsql;

--- a/server/db_scripts/get_user.sql
+++ b/server/db_scripts/get_user.sql
@@ -15,31 +15,23 @@ returns table (
   created timestamp,
   guest boolean,
   guest_created_by uuid,
-  super_admin boolean
+  super_admin boolean,
+  public_email boolean,
+  public_phone boolean
 ) as
 $$
 begin
-  if (ip_user_id is not null) then
-    return query
-    select
-      u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.password, u.created, u.guest, u.guest_created_by, u.super_admin
-    from
-      "user" u
-    where
-      u.id = ip_user_id and
-      u.deleted = false and
-      u.guest = case when ip_allow_guest = true then u.guest else false end;
-  elsif (ip_username is not null) then
-    return query
-    select
-      u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.password, u.created, u.guest, u.guest_created_by, u.super_admin
-    from
-      "user" u
-    where
-      u.username ilike ip_username and
-      u.deleted = false and
-      u.guest = case when ip_allow_guest = true then u.guest else false end;
-  end if;
+  return query
+  select
+    u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.password, u.created, u.guest, u.guest_created_by, u.super_admin,
+    up.public_email, up.public_phone
+  from
+    "user" u
+    left join user_preferences up on u.id = up.user_id
+  where
+    (u.id = ip_user_id or (ip_user_id is null and u.username ilike ip_username)) and
+    u.deleted = false and
+    u.guest = case when ip_allow_guest = true then u.guest else false end;
 end;
 $$
 language plpgsql;

--- a/server/db_scripts/get_users.sql
+++ b/server/db_scripts/get_users.sql
@@ -16,6 +16,8 @@ returns table (
   guest_created_by uuid,
   super_admin boolean,
   deleted boolean,
+  public_email boolean,
+  public_phone boolean,
   event_id uuid,
   is_event_admin boolean,
   event_joined_time timestamp
@@ -28,11 +30,13 @@ begin
     return query
     select
       u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.created, u.guest, u.guest_created_by, u.super_admin, u.deleted,
+      up.public_email, up.public_phone,
       null::uuid as event_id,
       null::boolean as is_event_admin,
       null::timestamp as event_joined_time
     from
       "user" u
+      left join user_preferences up on u.id = up.user_id
     where
       ((ip_exclude_user_id is not null and u.id != ip_exclude_user_id) or
       (ip_exclude_user_id is null and u.id = u.id)) and
@@ -52,11 +56,13 @@ begin
     return query
     select
       u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.created, u.guest, u.guest_created_by, u.super_admin, u.deleted,
+      up.public_email, up.public_phone,
       e.id as event_id, ue.admin as is_event_admin, ue.joined_time as event_joined_time
     from
       "user" u
       inner join user_event ue on ue.user_id = u.id
       inner join "event" e on e.id = ue.event_id
+      left join user_preferences up on u.id = up.user_id
     where
       ue.event_id = ip_event_id and
       ((ip_exclude_user_id is not null and u.id != ip_exclude_user_id) or

--- a/server/db_scripts/new_guest_user.sql
+++ b/server/db_scripts/new_guest_user.sql
@@ -16,7 +16,9 @@ returns table (
   created timestamp,
   guest boolean,
   guest_created_by uuid,
-  super_admin boolean
+  super_admin boolean,
+  public_email boolean,
+  public_phone boolean
 ) as
 $$
 begin

--- a/server/db_scripts/new_user.sql
+++ b/server/db_scripts/new_user.sql
@@ -18,7 +18,9 @@ returns table (
   created timestamp,
   guest boolean,
   guest_created_by uuid,
-  super_admin boolean
+  super_admin boolean,
+  public_email boolean,
+  public_phone boolean
 ) as
 $$
 declare tmp_user_id uuid;
@@ -38,6 +40,9 @@ begin
   insert into "user"(username, first_name, last_name, email, phone_number, "password", created, guest, super_admin, deleted)
     values (ip_username, ip_first_name, nullif(ip_last_name, ''), nullif(ip_email, ''), nullif(ip_phone_number, ''), ip_password, CURRENT_TIMESTAMP, false, false, false)
     returning "user".id into tmp_user_id;
+
+  insert into user_preferences (user_id, public_email, public_phone)
+    values (tmp_user_id, false, true);
 
   return query
   select * from get_user(tmp_user_id, null, false);

--- a/server/db_scripts/schema/2.2-2.3_migrations.sql
+++ b/server/db_scripts/schema/2.2-2.3_migrations.sql
@@ -1,0 +1,6 @@
+create table user_preferences (
+  user_id uuid not null references "user"(id) on delete cascade,
+  public_email boolean not null,
+  public_phone boolean not null,
+  primary key (user_id)
+);

--- a/server/db_scripts/schema/db_schema.sql
+++ b/server/db_scripts/schema/db_schema.sql
@@ -104,6 +104,13 @@ create table password_reset_key (
   expires timestamp not null
 );
 
+create table user_preferences (
+  user_id uuid not null references "user"(id) on delete cascade,
+  public_email boolean not null,
+  public_phone boolean not null,
+  primary key (user_id)
+);
+
 insert into event_status_type (id, name)
   values (1, 'Active'), (2, 'Ready to settle'), (3, 'Archived');
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mikane_server",
-  "version": "2.2.3-SNAPSHOT.3",
+  "version": "2.2.3-SNAPSHOT.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mikane_server",
-      "version": "2.2.3-SNAPSHOT.3",
+      "version": "2.2.3-SNAPSHOT.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "cors": "^2.8.5",
@@ -16,7 +16,7 @@
         "helmet": "^7.1.0",
         "nodemailer": "^6.9.13",
         "pg": "^8.11.5",
-        "swagger-ui-express": "^5.0.0"
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -4901,9 +4901,10 @@
       "integrity": "sha512-rLvJBgualxNZcwKOmTFzy4zF1nHy+3S0pUDDR/ageDRZgi8aITSe7pVYiAy03xGQZtqEifjwEtHQE+eF14gveg=="
     },
     "node_modules/swagger-ui-express": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.0.tgz",
-      "integrity": "sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
       "dependencies": {
         "swagger-ui-dist": ">=5.0.0"
       },
@@ -9829,9 +9830,9 @@
       "integrity": "sha512-rLvJBgualxNZcwKOmTFzy4zF1nHy+3S0pUDDR/ageDRZgi8aITSe7pVYiAy03xGQZtqEifjwEtHQE+eF14gveg=="
     },
     "swagger-ui-express": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.0.tgz",
-      "integrity": "sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
       "requires": {
         "swagger-ui-dist": ">=5.0.0"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,7 @@
     "helmet": "^7.1.0",
     "nodemailer": "^6.9.13",
     "pg": "^8.11.5",
-    "swagger-ui-express": "^5.0.0"
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -701,6 +701,83 @@
         }
       }
     },
+    "/users/{id}/preferences": {
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Edit user preferences",
+        "description": "Edit a user's preferences",
+        "operationId": "putUserPreferences",
+        "security": [
+          { "cookieAuth": [] }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "User ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "24b96dad-e95a-4794-9dea-25fd2bbd21a1"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "User preferences",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditUserPreferencesObject"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserDetailed"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoAuthResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/users/{id}/expenses/{eventId}": {
       "get": {
         "tags": [
@@ -3713,9 +3790,9 @@
             "type": "string",
             "example": "Test"
           },
-          "email": {
+          "phone": {
             "type": "string",
-            "example": "test@user.com"
+            "example": "12131415"
           },
           "created": {
             "type": "date-time",
@@ -3746,9 +3823,9 @@
             "type": "string",
             "example": "Test"
           },
-          "email": {
+          "phone": {
             "type": "string",
-            "example": "test@user.com"
+            "example": "12131415"
           },
           "created": {
             "type": "date-time",
@@ -3830,6 +3907,14 @@
           "superAdmin": {
             "type": "boolean",
             "example": "false"
+          },
+          "publicEmail": {
+            "type": "boolean",
+            "example": "false"
+          },
+          "publicPhone": {
+            "type": "boolean",
+            "example": "true"
           }
         }
       },
@@ -4233,6 +4318,19 @@
           "phone": {
             "type": "string",
             "example": "12131415"
+          }
+        }
+      },
+      "EditUserPreferencesObject": {
+        "type": "object",
+        "properties": {
+          "publicEmail": {
+            "type": "boolean",
+            "example": "false"
+          },
+          "publicPhone": {
+            "type": "boolean",
+            "example": "true"
           }
         }
       },

--- a/server/src/api/users.ts
+++ b/server/src/api/users.ts
@@ -317,14 +317,17 @@ router.put("/users/:id", authCheck, async (req, res, next) => {
       throw new ErrorExt(ec.PUD059);
     }
 
-    // Validate email and phone number
+    // Validate username, email and phone number
+    if (username && !isValidUsername(username)) {
+      throw new ErrorExt(ec.PUD132);
+    }
     if (email && !isEmail(email)) {
       throw new ErrorExt(ec.PUD004);
     }
     if (phoneNumber && !isPhoneNumber(phoneNumber)) {
       throw new ErrorExt(ec.PUD113);
     }
-    
+
     const data = {
       username: username,
       firstName: firstName,
@@ -334,6 +337,43 @@ router.put("/users/:id", authCheck, async (req, res, next) => {
     };
 
     const user = await db.editUser(userId, data);
+    if (!user) {
+      throw new ErrorExt(ec.PUD008);
+    }
+    res.status(200).send(user);
+  }
+  catch (err) {
+    next(err);
+  }
+});
+
+/*
+* Edit user preferences
+*/
+router.put("/users/:id/preferences", authCheck, async (req, res, next) => {
+  try {
+    const userId = req.params.id;
+    if (!isUUID(userId)) {
+      throw new ErrorExt(ec.PUD016);
+    }
+
+    const publicEmail: boolean | undefined = req.body.publicEmail !== undefined
+      ? req.body.publicEmail === true
+      : undefined;
+    const publicPhone: boolean | undefined = req.body.publicPhone !== undefined
+      ? req.body.publicPhone === true
+      : undefined;
+
+    if (publicEmail === undefined && publicPhone === undefined) {
+      throw new ErrorExt(ec.PUD133);
+    }
+
+    const data = {
+      publicEmail: publicEmail,
+      publicPhone: publicPhone
+    };
+
+    const user = await db.editUserPreferences(userId, data);
     if (!user) {
       throw new ErrorExt(ec.PUD008);
     }

--- a/server/src/api/validation.ts
+++ b/server/src/api/validation.ts
@@ -5,6 +5,7 @@ import { authCheck } from "../middlewares/authCheck";
 import { isEmail } from "../utils/validators/emailValidator";
 import { isUUID } from "../utils/validators/uuidValidator";
 import { ErrorExt } from "../types/errorExt";
+import { isValidUsername } from "../utils/validators/usernameValidator";
 import { isPhoneNumber } from "../utils/validators/phoneValidator";
 const router = express.Router();
 
@@ -23,6 +24,9 @@ router.post("/validation/user/username", async (req, res, next) => {
     }
     if (userId !== undefined && !isUUID(userId)) {
       throw new ErrorExt(ec.PUD016);
+    }
+    if (!isValidUsername(username)) {
+      throw new ErrorExt(ec.PUD132);
     }
 
     const valid = await db.validateUsername(username.trim(), userId);

--- a/server/src/db/dbUsers.ts
+++ b/server/src/db/dbUsers.ts
@@ -7,7 +7,7 @@ import * as ec from "../types/errorCodes";
 
 /**
  * DB interface: Get user information
- * @param userId 
+ * @param userId
  * @param avatarSize Pixel size of user avatar
  * @param username
  * @returns User data
@@ -200,6 +200,33 @@ export const editUser = async (userId: string, data: { username?: string, firstN
         throw new ErrorExt(ec.PUD019, err);
       else
         throw new ErrorExt(ec.PUD028, err);
+    });
+
+  return user;
+};
+
+/**
+ * DB interface: Edit a user's preferences
+ * @param userId User ID to edit
+ * @param data Data object
+ * @returns Edited user
+ */
+export const editUserPreferences = async (userId: string, data: { publicEmail?: boolean, publicPhone?: boolean }) => {
+  const query = {
+    text: "SELECT * FROM edit_user_preferences($1, $2, $3)",
+    values: [userId, data.publicEmail, data.publicPhone]
+  };
+  const user: User = await pool.query(query)
+    .then(data => {
+      return parseUser(data.rows[0]);
+    })
+    .catch(err => {
+      if (err.code === "P0008")
+        throw new ErrorExt(ec.PUD008, err);
+      else if (err.code === "P0134")
+        throw new ErrorExt(ec.PUD134, err);
+      else
+        throw new ErrorExt(ec.PUD135, err);
     });
 
   return user;

--- a/server/src/parsers/parseUsers.ts
+++ b/server/src/parsers/parseUsers.ts
@@ -39,10 +39,13 @@ export const parseUsers = (usersInput: UserDB[], withEventData: boolean, exclude
       firstName: userObj.first_name,
       lastName: userObj.last_name,
       email: userObj.email,
+      phone: userObj.phone_number,
       created: userObj.created,
       avatarURL: getGravatarURL(userObj.email ?? "", { size: avatarSize ?? 200, default: userObj.guest ? "mp" : "identicon" }),
       guest: userObj.guest,
       superAdmin: userObj.super_admin,
+      publicEmail: userObj.public_email ?? false,
+      publicPhone: userObj.public_phone ?? false,
       eventInfo: withEventData && userObj.event_id && userObj.event_joined_time ? {
         id: userObj.event_id,
         isAdmin: userObj.is_event_admin ?? false,
@@ -130,7 +133,9 @@ export const parseUser = (userObj: UserDB, avatarSize?: number): User => {
     created: userObj.created,
     avatarURL: getGravatarURL(userObj.email ?? "", { size: avatarSize ?? 200, default: userObj.guest ? "mp" : "identicon" }),
     guest: userObj.guest,
-    superAdmin: userObj.super_admin
+    superAdmin: userObj.super_admin,
+    publicEmail: userObj.public_email ?? false,
+    publicPhone: userObj.public_phone ?? false
   };
 };
 

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -1253,3 +1253,32 @@ export const PUD132: ErrorCode = {
   message: "Username can only contain alphanumeric characters (letters and numbers), hyphens, and underscores. Must be between 3-40 characters. Username cannot begin or end with hyphen/underscore",
   status: 400
 };
+
+/**
+ * PUD-133: Request body must include at least one user preferences property (400)
+ */
+export const PUD133: ErrorCode = {
+  code: "PUD-133",
+  message: "Request body must include at least one user preferences property",
+  status: 400
+};
+
+/**
+ * PUD-134: Something went wrong - user does not have a preferences entry in the database (500)
+ */
+export const PUD134: ErrorCode = {
+  code: "PUD-134",
+  message: "Something went wrong - user does not have a preferences entry in the database",
+  status: 500,
+  log: true
+};
+
+/**
+ * PUD-135: edit_user_preferences (500)
+ */
+export const PUD135: ErrorCode = {
+  code: "PUD-135",
+  message: "Something went wrong while editing user preferences",
+  status: 500,
+  log: true
+};

--- a/server/src/types/types.ts
+++ b/server/src/types/types.ts
@@ -1,118 +1,120 @@
 import { CategoryIcon } from "./enums";
 
 export type User = {
-  id: string;
-  name: string;
-  username: string;
-  firstName?: string;
-  lastName?: string;
-  email?: string;
-  phone?: string;
-  created?: Date;
-  avatarURL?: string;
-  guest: boolean;
-  superAdmin?: boolean;
+  id: string,
+  name: string,
+  username: string,
+  firstName?: string,
+  lastName?: string,
+  email?: string,
+  phone?: string,
+  created?: Date,
+  avatarURL?: string,
+  guest: boolean,
+  superAdmin?: boolean,
+  publicEmail?: boolean,
+  publicPhone?: boolean,
   eventInfo?: {
-    id: string;
-    isAdmin: boolean;
-    joinedTime: Date;
-  };
+    id: string,
+    isAdmin: boolean,
+    joinedTime: Date
+  }
 };
 
 export type Guest = {
-  id: string;
-  name: string;
-  guest: boolean;
-  avatarURL: string;
-  firstName: string;
-  lastName: string;
-  guestCreatedBy?: string;
-}
+  id: string,
+  name: string,
+  guest: boolean,
+  avatarURL: string,
+  firstName: string,
+  lastName: string,
+  guestCreatedBy?: string
+};
 
 export type Event = {
-  id: string;
-  name: string;
-  description: string;
-  created: Date;
-  adminIds: string[];
-  private: boolean;
+  id: string,
+  name: string,
+  description: string,
+  created: Date,
+  adminIds: string[],
+  private: boolean,
   status: {
     id: number,
     name: string
   },
   userInfo?: {
-    id: string;
-    inEvent: boolean;
-    isAdmin: boolean;
-  };
+    id: string,
+    inEvent: boolean,
+    isAdmin: boolean
+  }
 };
 
 export type Category = {
-  id: string;
-  name: string;
-  icon: CategoryIcon;
-  weighted: boolean;
-  created: Date;
-  numberOfExpenses: number;
-  userWeights?: Map<string, number>;
+  id: string,
+  name: string,
+  icon: CategoryIcon,
+  weighted: boolean,
+  created: Date,
+  numberOfExpenses: number,
+  userWeights?: Map<string, number>,
   users?: {
-    id: string;
-    name: string;
-    guest: boolean;
-    username?: string;
-    firstName?: string;
-    lastName?: string;
-    avatarURL: string;
-    weight: number;
-  }[];
+    id: string,
+    name: string,
+    guest: boolean,
+    username?: string,
+    firstName?: string,
+    lastName?: string,
+    avatarURL: string,
+    weight: number
+  }[]
 };
 
 export type Expense = {
-  id: string;
-  name: string;
-  description: string;
-  amount: number;
-  created: number;
+  id: string,
+  name: string,
+  description: string,
+  amount: number,
+  created: number,
   categoryInfo: {
-    id: string;
-    name: string;
-    icon: CategoryIcon;
-  };
-  payer: User;
+    id: string,
+    name: string,
+    icon: CategoryIcon
+  },
+  payer: User
 };
 
 export type Payment = {
-  sender: User;
-  receiver: User;
-  amount: number;
+  sender: User,
+  receiver: User,
+  amount: number
 };
 
 export type Record = {
-  user: User;
-  amount: number;
+  user: User,
+  amount: number
 };
 
 export type BalanceCalculationResult = {
-  balance: Record[];
-  spending: Record[];
-  expenses: Record[];
+  balance: Record[],
+  spending: Record[],
+  expenses: Record[]
 };
 
 export type UserBalance = {
-  user: User;
-  expensesCount: number;
-  spending: number;
-  expenses: number;
-  balance: number;
+  user: User,
+  expensesCount: number,
+  spending: number,
+  expenses: number,
+  balance: number
 };
 
 export type APIKey = {
-  apiKeyId: string;
-  name: string;
-  hashedKey: string;
-  master: boolean;
-  validFrom?: Date;
-  validTo?: Date;
+  apiKeyId: string,
+  name: string,
+  hashedKey: string,
+  master: boolean,
+  validFrom?: Date,
+  validTo?: Date
 };
 
 export type DBConfig = {

--- a/server/src/types/typesDB.ts
+++ b/server/src/types/typesDB.ts
@@ -7,8 +7,10 @@ export type UserDB = {
   phone_number: string,
   created: Date,
   guest: boolean,
-  guest_created_by: string;
+  guest_created_by: string,
   super_admin: boolean,
+  public_email: boolean,
+  public_phone: boolean,
   deleted: boolean,
   event_id?: string,
   is_event_admin?: boolean,
@@ -41,7 +43,7 @@ export type CategoryDB = {
   user_weights: {
     user_id: string,
     guest: boolean,
-    username: string;
+    username: string,
     first_name: string,
     last_name: string,
     email: string,
@@ -57,7 +59,7 @@ export type ExpenseDB = {
   amount: string,
   category_id: string,
   category_name: string,
-  category_icon: string;
+  category_icon: string,
   created: Date,
   payer_id: string,
   payer_first_name: string,

--- a/server/tests/resetDatabase.ts
+++ b/server/tests/resetDatabase.ts
@@ -20,6 +20,7 @@ export const resetDatabase = async () => {
     DROP TABLE "password_reset_key";
     DROP TABLE "category";
     DROP TABLE "event";
+    DROP TABLE "user_preferences";
     DROP TABLE "user";
     DROP TABLE "event_status_type";
   `);

--- a/server/tests/users.test.ts
+++ b/server/tests/users.test.ts
@@ -353,6 +353,73 @@ describe("users", async () => {
     });
   });
 
+  /* -------------------------- */
+  /* PUT /users/:id/preferences */
+  /* -------------------------- */
+  describe("PUT /users/:id/preferences", async () => {
+    test("should get user preferences - by default, email is private and phone is public", async () => {
+      const res = await request(app)
+        .get("/api/users/" + user.id)
+        .set("Cookie", authToken);
+
+      expect(res.status).toEqual(200);
+      expect(res.body.publicEmail).toEqual(false);
+      expect(res.body.publicPhone).toEqual(true);
+    });
+
+    test("should edit user preferences - email to public", async () => {
+      const res = await request(app)
+        .put(`/api/users/${user.id}/preferences`)
+        .set("Cookie", authToken)
+        .send({
+          publicEmail: true
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.publicEmail).toEqual(true);
+      expect(res.body.publicPhone).toEqual(true);
+    });
+
+    test("should edit user preferences - email to private and phone to private", async () => {
+      const res = await request(app)
+        .put(`/api/users/${user.id}/preferences`)
+        .set("Cookie", authToken)
+        .send({
+          publicEmail: false,
+          publicPhone: false
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.publicEmail).toEqual(false);
+      expect(res.body.publicPhone).toEqual(false);
+    });
+
+    test("should edit user preferences - phone to public", async () => {
+      const res = await request(app)
+        .put(`/api/users/${user.id}/preferences`)
+        .set("Cookie", authToken)
+        .send({
+          publicPhone: true
+        });
+
+      expect(res.status).toEqual(200);
+      expect(res.body.publicEmail).toEqual(false);
+      expect(res.body.publicPhone).toEqual(true);
+    });
+
+    test("fail edit user preferences with wrong property", async () => {
+      const res = await request(app)
+        .put(`/api/users/${user.id}/preferences`)
+        .set("Cookie", authToken)
+        .send({
+          privateEmail: true
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD133.code);
+    });
+  });
+
   /* -------------------------------- */
   /* POST /users/requestdeleteaccount */
   /* -------------------------------- */

--- a/server/tests/validation.test.ts
+++ b/server/tests/validation.test.ts
@@ -85,7 +85,7 @@ describe("validation", async () => {
       expect(res.body.code).toEqual(ec.PUD109.code);
     });
 
-    test("fail when validating invalid username", async () => {
+    test("fail when validating invalid username - only spaces", async () => {
       const res = await request(app)
         .post("/api/validation/user/username")
         .send({
@@ -94,6 +94,72 @@ describe("validation", async () => {
 
       expect(res.status).toEqual(400);
       expect(res.body.code).toEqual(ec.PUD059.code);
+    });
+
+    test("fail when validating invalid username - shorter than 3 characters", async () => {
+      const res = await request(app)
+        .post("/api/validation/user/username")
+        .send({
+          username: "ab"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD132.code);
+    });
+
+    test("fail when validating invalid username - longer than 40 characters", async () => {
+      const res = await request(app)
+        .post("/api/validation/user/username")
+        .send({
+          username: "abcdefghijklmnopqrstuvwxyzabcdefghijklmno"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD132.code);
+    });
+
+    test("fail when validating invalid username - invalid character !", async () => {
+      const res = await request(app)
+        .post("/api/validation/user/username")
+        .send({
+          username: "abc!d"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD132.code);
+    });
+
+    test("fail when validating invalid username - invalid character &", async () => {
+      const res = await request(app)
+        .post("/api/validation/user/username")
+        .send({
+          username: "abc&d"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD132.code);
+    });
+
+    test("fail when validating invalid username - starting with hyphen", async () => {
+      const res = await request(app)
+        .post("/api/validation/user/username")
+        .send({
+          username: "-abc"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD132.code);
+    });
+
+    test("fail when validating invalid username - ending with hyphen", async () => {
+      const res = await request(app)
+        .post("/api/validation/user/username")
+        .send({
+          username: "abc-"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD132.code);
     });
 
     test("fail when validating username with invalid user ID", async () => {


### PR DESCRIPTION
There is now a new database table containing user preferences (currently email and phone visibility settings). Furthermore, a new endpoint for setting a user's preferences has been introduced. This endpoint allows changing a user's email and phone visibility settings. The API documentation has been updated to include this new endpoint. Tests have been updated to test the new endpoint.

Make note that the row per user in the database table is mandatory, and will break if the table is not populated after this PR is merged. For new users, the default preferences will be private email and public phone number.

Additional change:
Extended username validation was missing from the edit user endpoint, along with the endpoint specifically for validating a username. These issues have both been fixed in this PR. Integration tests have also been expanded to test for these conditions.

Fixes #346, fixes #348