### PR TITLE
fix: Remove sensitive user information from responses including user data

### DIFF
--- a/server/src/api.json
+++ b/server/src/api.json
@@ -474,7 +474,7 @@
           "Users"
         ],
         "summary": "Get user",
-        "description": "Get information about a specific user",
+        "description": "Get information about a specific user. If the requester is not the signed-in user, some sensitive information may be excluded.",
         "operationId": "getUser",
         "security": [
           { "cookieAuth": [] }

--- a/server/src/api/events.ts
+++ b/server/src/api/events.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import * as db from "../db/dbEvents";
 import { authCheck, authKeyCheck } from "../middlewares/authCheck";
+import { removeUserInfoFromPayments, removeUserInfoFromUserBalances } from "../parsers/parseUserInfo";
 import { isUUID } from "../utils/validators/uuidValidator";
 import { Event, Payment, UserBalance } from "../types/types";
 import { ErrorExt } from "../types/errorExt";
@@ -79,6 +80,9 @@ router.get("/events/:id/balances", authCheck, async (req, res, next) => {
 
     const usersWithBalance: UserBalance[] = await db.getEventBalances(eventId);
 
+    // Remove sensitive user information
+    removeUserInfoFromUserBalances(usersWithBalance, userId ?? "");
+
     // Put logged in user first in list
     if (userId) {
       const index = usersWithBalance.findIndex(userBalance => userBalance.user.id === userId);
@@ -107,6 +111,9 @@ router.get("/events/:id/payments", authKeyCheck, async (req, res, next) => {
     }
 
     const payments: Payment[] = await db.getEventPayments(eventId);
+
+    // Remove sensitive user information
+    removeUserInfoFromPayments(payments, userId ?? "");
 
     // Put logged in user first in list
     if (userId) {

--- a/server/src/parsers/parseUserInfo.ts
+++ b/server/src/parsers/parseUserInfo.ts
@@ -1,0 +1,81 @@
+import { User, UserBalance, Payment } from "../types/types";
+
+/**
+ * Remove sensitive information for users who are not the signed-in user
+ * @param users List of users
+ * @param activeUserId ID of signed in user
+ */
+export const removeUserInfo = (users: User[], activeUserId: string) => {
+  for (const user of users) {
+    if (user.id !== activeUserId) {
+      if (!user.publicEmail) {
+        delete user.email;
+      }
+      if (!user.publicPhone) {
+        delete user.phone;
+      }
+      delete user.superAdmin;
+      delete user.publicEmail;
+      delete user.publicPhone;
+    }
+  }
+};
+
+/**
+ * Remove sensitive information for users who are not the signed-in user
+ * @param userBalances List of user balances
+ * @param activeUserId ID of signed in user
+ */
+export const removeUserInfoFromUserBalances = (userBalances: UserBalance[], activeUserId: string) => {
+  for (const userBalance of userBalances) {
+    if (userBalance.user.id !== activeUserId) {
+      if (!userBalance.user.publicEmail) {
+        delete userBalance.user.email;
+      }
+      if (!userBalance.user.publicPhone) {
+        delete userBalance.user.phone;
+      }
+      delete userBalance.user.superAdmin;
+      delete userBalance.user.publicEmail;
+      delete userBalance.user.publicPhone;
+    }
+  }
+};
+
+/**
+ * Remove sensitive information for users who are not the signed-in user
+ * @param payments List of payments
+ * @param activeUserId ID of signed in user
+ */
+export const removeUserInfoFromPayments = (payments: Payment[], activeUserId: string) => {
+  const processedUsers = new Set<string>();
+
+  for (const payment of payments) {
+    if (!processedUsers.has(payment.sender.id) && payment.sender.id !== activeUserId) {
+      if (!payment.sender.publicEmail) {
+        delete payment.sender.email;
+      }
+      if (!payment.sender.publicPhone) {
+        delete payment.sender.phone;
+      }
+      delete payment.sender.superAdmin;
+      delete payment.sender.publicEmail;
+      delete payment.sender.publicPhone;
+
+      processedUsers.add(payment.sender.id);
+    }
+    if (!processedUsers.has(payment.receiver.id) && payment.receiver.id !== activeUserId) {
+      if (!payment.receiver.publicEmail) {
+        delete payment.receiver.email;
+      }
+      if (!payment.receiver.publicPhone) {
+        delete payment.receiver.phone;
+      }
+      delete payment.receiver.superAdmin;
+      delete payment.receiver.publicEmail;
+      delete payment.receiver.publicPhone;
+
+      processedUsers.add(payment.receiver.id);
+    }
+  }
+};


### PR DESCRIPTION
In all endpoints that return user data, the email and phone properties are now selectively included on a per user basis based on that user's preferences. For the signed in user however, all data will still be returned.

Fixes #347