### PR TITLE
fix: Restrict editing/deleting user data to signed-in user

### DIFF
--- a/server/src/api/users.ts
+++ b/server/src/api/users.ts
@@ -317,6 +317,11 @@ router.put("/users/:id", authCheck, async (req, res, next) => {
       throw new ErrorExt(ec.PUD016);
     }
 
+    // Users can only edit their own data
+    if (req.session.userId !== userId) {
+      throw new ErrorExt(ec.PUD136);
+    }
+
     const username: string | undefined = req.body.username;
     const firstName: string | undefined = req.body.firstName;
     const lastName: string | undefined = req.body.lastName;
@@ -370,6 +375,11 @@ router.put("/users/:id/preferences", authCheck, async (req, res, next) => {
       throw new ErrorExt(ec.PUD016);
     }
 
+    // Users can only edit their own preferences
+    if (req.session.userId !== userId) {
+      throw new ErrorExt(ec.PUD136);
+    }
+
     const publicEmail: boolean | undefined = req.body.publicEmail !== undefined
       ? req.body.publicEmail === true
       : undefined;
@@ -415,6 +425,11 @@ router.delete("/users/:id", authCheck, async (req, res, next) => {
     const valid = await db.verifyDeleteAccountKey(key);
     if (!valid) {
       throw new ErrorExt(ec.PUD106);
+    }
+
+    // Users can only delete their own account
+    if (req.session.userId !== userId) {
+      throw new ErrorExt(ec.PUD137);
     }
 
     const success = await db.deleteUser(userId, key);

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -1282,3 +1282,21 @@ export const PUD135: ErrorCode = {
   status: 500,
   log: true
 };
+
+/**
+ * PUD-136: Users can only edit their own data - you are signed-in as another user (400)
+ */
+export const PUD136: ErrorCode = {
+  code: "PUD-136",
+  message: "Users can only edit their own data - you are signed-in as another user",
+  status: 400
+};
+
+/**
+ * PUD-137: Users can only delete their own account - you are signed-in as another user (400)
+ */
+export const PUD137: ErrorCode = {
+  code: "PUD-137",
+  message: "Users can only delete their own account - you are signed-in as another user",
+  status: 400
+};

--- a/server/tests/users.test.ts
+++ b/server/tests/users.test.ts
@@ -351,6 +351,18 @@ describe("users", async () => {
       expect(res.status).toEqual(400);
       expect(res.body.code).toEqual(ec.PUD059.code);
     });
+
+    test("fail edit user when signed-in as another user", async () => {
+      const res = await request(app)
+        .put("/api/users/" + user2.id)
+        .set("Cookie", authToken)
+        .send({
+          firstName: "Changed"
+        });
+
+      expect(res.status).toEqual(400);
+      expect(res.body.code).toEqual(ec.PUD136.code);
+    });
   });
 
   /* -------------------------- */
@@ -589,6 +601,18 @@ describe("users", async () => {
 
         expect(res.status).toEqual(400);
         expect(res.body.code).toEqual(ec.PUD108.code);
+    });
+
+    test("fail delete user when signed-in as another user", async () => {
+      const res = await request(app)
+        .delete("/api/users/" + user2.id)
+        .set("Cookie", authToken)
+        .send({
+          key: deleteAccountKey
+        });
+
+        expect(res.status).toEqual(400);
+        expect(res.body.code).toEqual(ec.PUD137.code);
     });
 
     test("should delete user", async () => {


### PR DESCRIPTION
This pull request restricts the ability to edit user data to only the signed-in user. Previously, there were no checks in the backend to ensure that only the user themselves could make changes to their own data.

This also goes for deleting the user. While this action is already protected by a secret key, as an additional security measure the user must now also be signed in to delete their own account.

Tests have been expanded to test for the changes specifically.

Fixes #351