### PR TITLE
feat: Preferences on account page

### DIFF
--- a/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.html
+++ b/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.html
@@ -1,5 +1,5 @@
 <div class="navbar" [ngClass]="{ iOS: contextService.isIos }">
-	@for (link of mobileLinks(); track link) {
+	@for (link of mobileLinks(); track link.location) {
 		<a
 			class="nav-button"
 			[routerLink]="link.location"

--- a/app/mikane/src/app/pages/account/account.component.html
+++ b/app/mikane/src/app/pages/account/account.component.html
@@ -14,6 +14,10 @@
 					[ngClass]="(breakpointService.isMobile() | async) ? 'section-mobile' : 'section-pc first'"
 					[user]="user"
 				></app-user-settings>
+				<app-preferences
+					[ngClass]="(breakpointService.isMobile() | async) ? 'section-mobile' : 'section-pc'"
+					[user]="user">
+				</app-preferences>
 				<app-change-password
 					[ngClass]="(breakpointService.isMobile() | async) ? 'section-mobile' : 'section-pc'"
 				></app-change-password>

--- a/app/mikane/src/app/pages/account/account.component.ts
+++ b/app/mikane/src/app/pages/account/account.component.ts
@@ -17,6 +17,7 @@ import { ApiError } from 'src/app/types/apiError.type';
 import { ChangePasswordComponent } from './change-password/change-password.component';
 import { DangerZoneComponent } from './danger-zone/danger-zone.component';
 import { UserSettingsComponent } from './user/user-settings.component';
+import { PreferencesComponent } from './preferences/preferences.component';
 
 @Component({
 	templateUrl: './account.component.html',
@@ -30,6 +31,7 @@ import { UserSettingsComponent } from './user/user-settings.component';
 		RouterLink,
 		MatIconModule,
 		UserSettingsComponent,
+		PreferencesComponent,
 		ChangePasswordComponent,
 		DangerZoneComponent,
 		MenuComponent,

--- a/app/mikane/src/app/pages/account/preferences/preferences.component.html
+++ b/app/mikane/src/app/pages/account/preferences/preferences.component.html
@@ -1,0 +1,74 @@
+@if ((breakpointService.isMobile() | async) === false) {
+	<mat-card>
+		<mat-card-header>
+			<div mat-card-avatar>
+				<mat-icon aria-hidden="false">manage_accounts</mat-icon>
+			</div>
+			<mat-card-title>Preferences</mat-card-title>
+		</mat-card-header>
+		<mat-card-content>
+			<ng-container *ngTemplateOutlet="preferencesContent"></ng-container>
+		</mat-card-content>
+	</mat-card>
+}
+@else {
+	<div class="title-mobile">Preferences</div>
+	<div class="preferences-mobile">
+		<ng-container *ngTemplateOutlet="preferencesContent"></ng-container>
+	</div>
+}
+
+<ng-template #preferencesContent>
+	<div class="preferences">
+		<div class="toggle-line">
+			<span>Email:</span>
+			<span class="toggle">
+				@if (loadingEmail) {
+					<mat-spinner diameter="20" class="toggle-icon"></mat-spinner>
+				}
+				@else if (updatedEmail) {
+					<mat-icon class="toggle-icon" [@fadeInOutAnimation]>check_cirle</mat-icon>
+				}
+				<mat-button-toggle-group
+					[(ngModel)]="publicEmail"
+					[disabled]="loadingEmail"
+					[hideSingleSelectionIndicator]="true"
+					id="emailToggleGroup"
+					(change)="editUserPreferences('email')"
+				>
+					<mat-button-toggle [value]="true">Public</mat-button-toggle>
+					<mat-button-toggle [value]="false">Private</mat-button-toggle>
+				</mat-button-toggle-group>
+			</span>
+		</div>
+		<div class="text">
+			Choose whether your email is visible to others on your profile.
+		</div>
+	</div>
+	<div class="preferences">
+		<div class="toggle-line">
+			<span>Phone number:</span>
+			<span class="toggle">
+				@if (loadingPhone) {
+					<mat-spinner diameter="20" class="mat-spinner"></mat-spinner>
+				}
+				@else if (updatedPhone) {
+					<mat-icon class="toggle-icon" [@fadeInOutAnimation]>check_cirle</mat-icon>
+				}
+				<mat-button-toggle-group
+					[(ngModel)]="publicPhone"
+					[disabled]="loadingPhone"
+					[hideSingleSelectionIndicator]="true"
+					id="phoneToggleGroup"
+					(change)="editUserPreferences('phone')"
+				>
+					<mat-button-toggle [value]="true">Public</mat-button-toggle>
+					<mat-button-toggle [value]="false">Private</mat-button-toggle>
+				</mat-button-toggle-group>
+			</span>
+		</div>
+		<div class="text end">
+			Choose whether your phone number is visible to others. Making it public will help others contact and/or pay you more easily.
+		</div>
+	</div>
+</ng-template>

--- a/app/mikane/src/app/pages/account/preferences/preferences.component.scss
+++ b/app/mikane/src/app/pages/account/preferences/preferences.component.scss
@@ -1,0 +1,64 @@
+.title-mobile {
+	display: flex;
+	align-items: center;
+	height: 50px;
+	margin-bottom: 20px;
+	padding-left: 16px;
+	background-color: rgba(24, 24, 24, 1);
+	border-top: 1px solid #333333;
+	stroke: #333333;
+}
+
+.preferences-mobile {
+	margin-left: 10vw;
+	margin-right: 10vw;
+  margin-bottom: 30px;
+}
+
+.preferences {
+	margin-bottom: 30px;
+
+	.toggle-line {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 10px;
+
+		.toggle {
+			display: flex;
+			align-items: center;
+
+			.toggle-icon {
+				margin-right: 10px;
+			}
+		}
+	}
+
+	.text {
+		color: rgba(255, 255, 255, 0.58);
+
+		&.end {
+			margin-bottom: 10px;
+		}
+	}
+}
+
+.mat-spinner::ng-deep circle{
+	stroke: #FFFFFF !important;
+}
+
+.mdc-card__actions {
+	padding: 0px !important;
+}
+
+.mat-mdc-card-content {
+	padding: 0 55px 16px !important;
+}
+
+.mat-mdc-card-header {
+	padding: 16px 16px 0;
+}
+
+mat-card-title {
+	padding-left: 0 !important;
+}

--- a/app/mikane/src/app/pages/account/preferences/preferences.component.spec.ts
+++ b/app/mikane/src/app/pages/account/preferences/preferences.component.spec.ts
@@ -1,0 +1,62 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MessageService } from 'src/app/services/message/message.service';
+import { UserService } from 'src/app/services/user/user.service';
+import { User } from 'src/app/services/user/user.service';
+import { PreferencesComponent } from './preferences.component';
+
+describe('PreferencesComponent', () => {
+  let component: PreferencesComponent;
+  let fixture: ComponentFixture<PreferencesComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        MatCardModule,
+        MatIconModule,
+        FormsModule,
+        ReactiveFormsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatButtonModule,
+        MatButtonToggleModule,
+        MatProgressSpinnerModule,
+        BrowserAnimationsModule,
+      ],
+      providers: [
+        { provide: UserService, useValue: {} },
+        { provide: MessageService, useValue: {} },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PreferencesComponent);
+    component = fixture.componentInstance;
+    component.user = {
+      id: '1',
+      publicEmail: false,
+      publicPhone: true,
+    } as User;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize publicEmail and publicPhone from user', () => {
+    expect(component.user.publicEmail).toEqual(false);
+    expect(component.user.publicPhone).toEqual(true);
+  });
+});

--- a/app/mikane/src/app/pages/account/preferences/preferences.component.ts
+++ b/app/mikane/src/app/pages/account/preferences/preferences.component.ts
@@ -1,0 +1,112 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, OnDestroy } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { Subscription } from 'rxjs';
+import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.service';
+import { MessageService } from 'src/app/services/message/message.service';
+import { User, UserService } from 'src/app/services/user/user.service';
+import { ApiError } from 'src/app/types/apiError.type';
+import { animate, state, style, transition, trigger } from '@angular/animations';
+
+@Component({
+	selector: 'app-preferences',
+	templateUrl: './preferences.component.html',
+	styleUrls: ['./preferences.component.scss'],
+	standalone: true,
+	imports: [
+		CommonModule,
+		MatCardModule,
+		MatIconModule,
+		FormsModule,
+		ReactiveFormsModule,
+		MatFormFieldModule,
+		MatInputModule,
+		MatButtonModule,
+		MatButtonToggleModule,
+		MatProgressSpinnerModule,
+	],
+	animations: [
+    trigger('fadeInOutAnimation', [
+      state('in', style({ opacity: 1 })),
+      transition('void => *', [
+        style({ opacity: 0 }),
+        animate(200, style({ opacity: 1 }))
+      ]),
+      transition('* => void', [
+        animate(200, style({ opacity: 0 }))
+      ])
+    ])
+  ]
+})
+export class PreferencesComponent implements OnDestroy {
+	@Input() user: User;
+	private editPreferencesSubscription: Subscription;
+	protected publicEmail: boolean;
+	protected publicPhone: boolean;
+	protected loadingEmail: boolean;
+	protected loadingPhone: boolean;
+	protected updatedEmail: boolean;
+	protected updatedPhone: boolean;
+
+	constructor(
+		private userService: UserService,
+		private messageService: MessageService,
+		public breakpointService: BreakpointService
+	) {}
+
+	ngOnInit(): void {
+		this.publicEmail = this.user.publicEmail;
+		this.publicPhone = this.user.publicPhone;
+	}
+
+	editUserPreferences(type: 'email' | 'phone') {
+		if (type === 'email') {
+			this.loadingEmail = true;
+		}
+		else if (type === 'phone') {
+			this.loadingPhone = true;
+		}
+		this.editPreferencesSubscription = this.userService
+			.editUserPreferences(
+				this.user.id,
+				type === 'email' ? this.publicEmail : undefined,
+				type === 'phone' ? this.publicPhone : undefined
+			)
+			.subscribe({
+				next: (user) => {
+					this.user = user;
+					if (type === 'email') {
+						this.loadingEmail = false;
+						this.updatedEmail = true;
+						setTimeout(() => {
+							this.updatedEmail = false;
+						}, 1000);
+					}
+					else if (type === 'phone') {
+						this.loadingPhone = false;
+						this.updatedPhone = true;
+						setTimeout(() => {
+							this.updatedPhone = false;
+						}, 1000);
+					}
+				},
+				error: (err: ApiError) => {
+					this.messageService.showError('Failed to change user preferences');
+					console.error('something went wrong while changing user preference', err?.error?.message);
+					this.loadingEmail = false;
+					this.loadingPhone = false;
+				},
+			});
+	}
+
+	ngOnDestroy(): void {
+		this.editPreferencesSubscription?.unsubscribe();
+	}
+}

--- a/app/mikane/src/app/pages/account/user/user-settings.component.html
+++ b/app/mikane/src/app/pages/account/user/user-settings.component.html
@@ -10,14 +10,6 @@
 			<div>
 				<form [formGroup]="editUserForm" (ngSubmit)="editUser()">
 					<div class="setting-row">
-						@if (!editMode) {
-							<span class="user-padding"> Username: </span>
-						}
-						@if (!editMode) {
-							<span class="user-details">
-								{{ editUserForm.get("username").value }}
-							</span>
-						}
 						@if (editMode) {
 							<mat-form-field appearance="fill" class="input-field">
 								<mat-label>Username</mat-label>
@@ -29,20 +21,18 @@
 									<mat-error>Username already taken</mat-error>
 								}
 								@if (editUserForm.get("username")?.errors?.["invalid"]) {
-									<mat-error>Invalid username</mat-error>
+									<mat-error>Between 3-40 characters - only letters, numbers, hyphens, underscores</mat-error>
 								}
 							</mat-form-field>
 						}
-					</div>
-					<div class="setting-row">
-						@if (!editMode) {
-							<span class="user-padding"> First name: </span>
-						}
-						@if (!editMode) {
+						@else {
+							<span class="user-padding"> Username: </span>
 							<span class="user-details">
-								{{ editUserForm.get("firstName").value }}
+								{{ editUserForm.get("username").value }}
 							</span>
 						}
+					</div>
+					<div class="setting-row">
 						@if (editMode) {
 							<mat-form-field appearance="fill" class="input-field">
 								<mat-label>First Name</mat-label>
@@ -58,16 +48,14 @@
 								}
 							</mat-form-field>
 						}
-					</div>
-					<div class="setting-row">
-						@if (!editMode) {
-							<span class="user-padding"> Last name: </span>
-						}
-						@if (!editMode) {
+						@else {
+							<span class="user-padding"> First name: </span>
 							<span class="user-details">
-								{{ editUserForm.get("lastName").value }}
+								{{ editUserForm.get("firstName").value }}
 							</span>
 						}
+					</div>
+					<div class="setting-row">
 						@if (editMode) {
 							<mat-form-field class="input-field">
 								<mat-label>Last Name</mat-label>
@@ -77,16 +65,14 @@
 								}
 							</mat-form-field>
 						}
-					</div>
-					<div class="setting-row">
-						@if (!editMode) {
-							<span class="user-padding"> Email: </span>
-						}
-						@if (!editMode) {
+						@else {
+							<span class="user-padding"> Last name: </span>
 							<span class="user-details">
-								{{ editUserForm.get("email").value }}
+								{{ editUserForm.get("lastName").value }}
 							</span>
 						}
+					</div>
+					<div class="setting-row">
 						@if (editMode) {
 							<mat-form-field class="input-field">
 								<mat-label>Email</mat-label>
@@ -102,16 +88,14 @@
 								}
 							</mat-form-field>
 						}
-					</div>
-					<div class="setting-row">
-						@if (!editMode) {
-							<span class="user-padding"> Phone number: </span>
-						}
-						@if (!editMode) {
+						@else {
+							<span class="user-padding"> Email: </span>
 							<span class="user-details">
-								{{ editUserForm.get("phone").value }}
+								{{ editUserForm.get("email").value }}
 							</span>
 						}
+					</div>
+					<div class="setting-row">
 						@if (editMode) {
 							<mat-form-field class="input-field">
 								<mat-label>Phone Number</mat-label>
@@ -127,6 +111,12 @@
 								}
 							</mat-form-field>
 						}
+						@else {
+							<span class="user-padding"> Phone number: </span>
+							<span class="user-details">
+								{{ editUserForm.get("phone").value }}
+							</span>
+						}
 					</div>
 					@if (!editMode) {
 						<div class="setting-row">
@@ -138,25 +128,23 @@
 					}
 					<br />
 					<mat-card-actions class="setting-row">
-						@if (!editMode) {
+						@if (editMode) {
+							<div>
+								<button type="button" mat-button color="accent" (click)="toggleEditMode()" class="user-settings-actions">
+									Cancel
+								</button>
+								<button type="submit" mat-raised-button [disabled]="editUserForm.invalid || editUserForm.pending" color="primary">
+									<mat-icon>check_cirle</mat-icon>
+									Save changes
+								</button>
+							</div>
+						}
+						@else {
 							<button type="button" mat-raised-button color="primary" (click)="toggleEditMode()">
 								<mat-icon>edit</mat-icon>
 								Edit
 							</button>
 						}
-						<div>
-							@if (editMode) {
-								<button type="button" mat-button color="accent" (click)="toggleEditMode()" class="user-settings-actions">
-									Cancel
-								</button>
-							}
-							@if (editMode) {
-								<button type="submit" mat-raised-button color="primary">
-									<mat-icon>check_cirle</mat-icon>
-									Save changes
-								</button>
-							}
-						</div>
 					</mat-card-actions>
 				</form>
 			</div>
@@ -167,14 +155,6 @@
 	<div class="user-settings-mobile">
 		<form [formGroup]="editUserForm" (ngSubmit)="editUser()">
 			<div>
-				@if (!editMode) {
-					<span class="user-property-title"> Username: </span>
-				}
-				@if (!editMode) {
-					<span class="user-details">
-						{{ editUserForm.get("username").value }}
-					</span>
-				}
 				@if (editMode) {
 					<mat-form-field appearance="fill" class="input-field">
 						<mat-label>Username</mat-label>
@@ -186,20 +166,18 @@
 							<mat-error>Username already taken</mat-error>
 						}
 						@if (editUserForm.get("username")?.errors?.["invalid"]) {
-							<mat-error>Invalid username</mat-error>
+							<mat-error>Between 3-40 characters - only letters, numbers, hyphens, underscores</mat-error>
 						}
 					</mat-form-field>
 				}
-			</div>
-			<div>
-				@if (!editMode) {
-					<span class="user-property-title"> First name: </span>
-				}
-				@if (!editMode) {
+				@else {
+					<span class="user-property-title"> Username: </span>
 					<span class="user-details">
-						{{ editUserForm.get("firstName").value }}
+						{{ editUserForm.get("username").value }}
 					</span>
 				}
+			</div>
+			<div>
 				@if (editMode) {
 					<mat-form-field appearance="fill" class="input-field">
 						<mat-label>First Name</mat-label>
@@ -209,16 +187,14 @@
 						}
 					</mat-form-field>
 				}
-			</div>
-			<div>
-				@if (!editMode) {
-					<span class="user-property-title"> Last name: </span>
-				}
-				@if (!editMode) {
+				@else {
+					<span class="user-property-title"> First name: </span>
 					<span class="user-details">
-						{{ editUserForm.get("lastName").value }}
+						{{ editUserForm.get("firstName").value }}
 					</span>
 				}
+			</div>
+			<div>
 				@if (editMode) {
 					<mat-form-field class="input-field">
 						<mat-label>Last Name</mat-label>
@@ -228,16 +204,14 @@
 						}
 					</mat-form-field>
 				}
-			</div>
-			<div>
-				@if (!editMode) {
-					<span class="user-property-title"> Email: </span>
-				}
-				@if (!editMode) {
+				@else {
+					<span class="user-property-title"> Last name: </span>
 					<span class="user-details">
-						{{ editUserForm.get("email").value }}
+						{{ editUserForm.get("lastName").value }}
 					</span>
 				}
+			</div>
+			<div>
 				@if (editMode) {
 					<mat-form-field class="input-field">
 						<mat-label>Email</mat-label>
@@ -253,16 +227,14 @@
 						}
 					</mat-form-field>
 				}
-			</div>
-			<div>
-				@if (!editMode) {
-					<span class="user-property-title"> Phone number: </span>
-				}
-				@if (!editMode) {
+				@else {
+					<span class="user-property-title"> Email: </span>
 					<span class="user-details">
-						{{ editUserForm.get("phone").value }}
+						{{ editUserForm.get("email").value }}
 					</span>
 				}
+			</div>
+			<div>
 				@if (editMode) {
 					<mat-form-field class="input-field">
 						<mat-label>Phone Number</mat-label>
@@ -278,6 +250,12 @@
 						}
 					</mat-form-field>
 				}
+				@else {
+					<span class="user-property-title"> Phone number: </span>
+					<span class="user-details">
+						{{ editUserForm.get("phone").value }}
+					</span>
+				}
 			</div>
 			@if (!editMode) {
 				<div>
@@ -288,22 +266,22 @@
 				</div>
 			}
 			<span class="buttons">
-				@if (!editMode) {
-					<button type="button" mat-raised-button color="primary" (click)="toggleEditMode()">
-						<mat-icon>edit</mat-icon>
-						Edit
-					</button>
-				}
 				@if (editMode) {
 					<div>
 						<button type="button" mat-button color="accent" (click)="toggleEditMode()" class="user-settings-actions">
 							Cancel
 						</button>
-						<button type="submit" mat-raised-button color="primary">
+						<button type="submit" mat-raised-button [disabled]="editUserForm.invalid || editUserForm.pending" color="primary">
 							<mat-icon>check_cirle</mat-icon>
 							Save changes
 						</button>
 					</div>
+				}
+				@else {
+					<button type="button" mat-raised-button color="primary" (click)="toggleEditMode()">
+						<mat-icon>edit</mat-icon>
+						Edit
+					</button>
 				}
 			</span>
 		</form>

--- a/app/mikane/src/app/pages/account/user/user-settings.component.ts
+++ b/app/mikane/src/app/pages/account/user/user-settings.component.ts
@@ -34,7 +34,6 @@ import { ApiError } from 'src/app/types/apiError.type';
 	],
 })
 export class UserSettingsComponent implements OnInit, OnDestroy {
-	private subscription: Subscription;
 	private editSubscription: Subscription;
 
 	@Input() user: User;
@@ -88,11 +87,11 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
 	}
 
 	toggleEditMode() {
+		this.editUserForm.patchValue(this.user);
 		this.editMode = !this.editMode;
 	}
 
 	ngOnDestroy(): void {
-		this.subscription?.unsubscribe();
 		this.editSubscription?.unsubscribe();
 	}
 }

--- a/app/mikane/src/app/pages/event-info/event-info.component.html
+++ b/app/mikane/src/app/pages/event-info/event-info.component.html
@@ -30,7 +30,7 @@
 
 <ng-template #adminsContent>
 	<div [ngClass]="{ 'info-full-view': breakpointService.isMobile() | async }">
-		If there is anything concerning this event you need to change, contact one of the admins listed below:
+		If you need to change anything regarding this event, please contact one of the admins listed below:
 	</div>
 	<div class="admins-content" [ngClass]="{ 'full-view': (breakpointService.isMobile() | async) === false }">
 		<mat-nav-list>

--- a/app/mikane/src/app/pages/events/event/event.component.html
+++ b/app/mikane/src/app/pages/events/event/event.component.html
@@ -21,7 +21,7 @@
 </mat-toolbar>
 @if ((breakpointService.isMobile() | async) === false) {
 	<nav class="navbar" mat-tab-nav-bar [tabPanel]="tabPanel">
-		@for (link of links(); track link) {
+		@for (link of links(); track link.location) {
 			<a
 				mat-tab-link
 				[routerLink]="link.location"

--- a/app/mikane/src/app/pages/events/events.component.html
+++ b/app/mikane/src/app/pages/events/events.component.html
@@ -1,5 +1,5 @@
 <mat-toolbar class="events-toolbar" [ngClass]="{ 'mobile-toolbar': breakpointService.isMobile() | async }">
-	<span class="logo-container">
+	<span class="logo-container" [ngClass]="{ 'fullview': (breakpointService.isMobile() | async) === false }">
 		<img src="assets/mikane.svg" alt="Mikane logo" class="logo" />
 	</span>
 	<span>MIKANE</span>

--- a/app/mikane/src/app/services/user/user.service.ts
+++ b/app/mikane/src/app/services/user/user.service.ts
@@ -18,6 +18,8 @@ export interface User {
 	guest: boolean;
 	guestCreatedBy?: string;
 	superAdmin?: boolean;
+	publicEmail?: boolean;
+	publicPhone?: boolean;
 	avatarURL?: string;
 	eventInfo?: {
 		id: string;
@@ -137,6 +139,20 @@ export class UserService {
 			lastName,
 			email,
 			phone,
+		});
+	}
+
+	/**
+	 * Updates a user's preferences.
+	 * @param userId - The ID of the user to update.
+	 * @param publicEmail - The user's public email property
+	 * @param publicPhone - The user's public phone number property
+	 * @returns An Observable that emits the updated User object.
+	 */
+	editUserPreferences(userId: string, publicEmail: boolean, publicPhone: boolean): Observable<User> {
+		return this.httpClient.put<User>(this.apiUrl + `/${userId}/preferences`, {
+			publicEmail,
+			publicPhone,
 		});
 	}
 

--- a/app/mikane/src/styles.scss
+++ b/app/mikane/src/styles.scss
@@ -40,6 +40,10 @@ a.nostyle:visited {
 	height: 26px;
 	padding-right: 14px;
 
+	&.fullview {
+		margin-left: 10px;
+	}
+
 	.logo {
 		height: 26px;
 	}


### PR DESCRIPTION
The account page has been adjusted to include a new preferences section, where the user can change the email and phone number visibility (works in both full view and mobile view). The buttons are using Material's button toggle, and will send a API call simply by clicking one of the buttons. A loading icon will be displayed by the button toggle while the request is being handled, and a checkmark will show by the button toggle when the preference has successfully been saved.

Additional change 1:
In the account details section, clicking cancel after modifying any details would not reset their values to the original values. This has now been corrected.

Additional change 2:
In the account details section, the "save changes" button is now disabled if any of the account details are invalid, similar to how registering a new user works.

Additional change 3:
Improved code readability in the user-settings component template. Also there is now a more descriptive error message when the username validation fails due to the new username restrictions.

Additional change 4:
Slightly moved the main Mikane logo to the right, to better match up with the back arrow in other pages.

Additional change 5:
Slightly improved wording of text in event-info page.

Additional change 6:
Updated a couple template iterators related to event links.

Fixes #272 