### PR TITLE
feat: Navigate to user profiles

### DIFF
--- a/app/mikane/src/app/features/mobile/category-item/category-item.component.html
+++ b/app/mikane/src/app/features/mobile/category-item/category-item.component.html
@@ -35,7 +35,7 @@
 			<mat-list-item>
 				<div class="user data">
 					<span class="name">
-						<img [src]="user.avatarURL" alt="User avatar" class="avatar" />
+						<img [src]="user.avatarURL" alt="User avatar" class="avatar" (click)="gotoUserProfile(user)" />
 						{{ user.name }}
 					</span>
 					<span>

--- a/app/mikane/src/app/features/mobile/category-item/category-item.component.ts
+++ b/app/mikane/src/app/features/mobile/category-item/category-item.component.ts
@@ -42,6 +42,7 @@ export class CategoryItemComponent {
 	@Output() toggleWeighted = new EventEmitter<{ categoryId: string; weighted: boolean }>();
 	@Output() deleteCategoryDialog = new EventEmitter<{ categoryId: string }>();
 	@Output() gotoCategoryExpenses = new EventEmitter<{ category: Category }>();
+	@Output() gotoUser = new EventEmitter<{ user: { id: string, guest: boolean, username: string } }>();
 
 	dropdownOpen = false;
 	lowerHeight = 0;
@@ -88,5 +89,9 @@ export class CategoryItemComponent {
 
 	gotoExpenses = () => {
 		this.gotoCategoryExpenses.emit({ category: this.category });
+	};
+
+	gotoUserProfile = (user: { id: string, guest: boolean, username: string }) => {
+		this.gotoUser.emit({ user: user });
 	};
 }

--- a/app/mikane/src/app/features/mobile/participant-item/participant-item.component.html
+++ b/app/mikane/src/app/features/mobile/participant-item/participant-item.component.html
@@ -1,7 +1,7 @@
 <mat-list-item class="wrapper">
 	<div class="upper">
 		<div class="title">
-			<img [src]="userBalance.user.avatarURL" alt="User avatar" class="avatar" />
+			<img [src]="userBalance.user.avatarURL" alt="User avatar" class="avatar" (click)="gotoUserProfile(); $event.stopPropagation()" />
 			<div>
 				<div class="number-of-expenses">Number of expenses: {{ userBalance.expensesCount }}</div>
 				<div class="name">

--- a/app/mikane/src/app/features/mobile/participant-item/participant-item.component.ts
+++ b/app/mikane/src/app/features/mobile/participant-item/participant-item.component.ts
@@ -3,7 +3,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
-import { UserBalance } from 'src/app/services/user/user.service';
+import { User, UserBalance } from 'src/app/services/user/user.service';
 
 @Component({
 	selector: 'app-participant-item',
@@ -15,7 +15,12 @@ import { UserBalance } from 'src/app/services/user/user.service';
 export class ParticipantItemComponent {
 	@Input() userBalance: UserBalance;
 	@Input() eventActive: boolean;
+	@Output() gotoUser = new EventEmitter<{ user: User }>();
 	@Output() removeUser = new EventEmitter<{ userId: string }>();
+
+	gotoUserProfile() {
+		this.gotoUser.emit({ user: this.userBalance.user });
+	}
 
 	removeUserFromEvent() {
 		this.removeUser.emit({ userId: this.userBalance.user.id });

--- a/app/mikane/src/app/features/mobile/payment-item/payment-item.component.html
+++ b/app/mikane/src/app/features/mobile/payment-item/payment-item.component.html
@@ -1,7 +1,13 @@
 <div class="wrapper">
 	<mat-list-item (click)="toggleDropdown()">
 		<div class="upper">
-			<img [src]="sender.sender.avatarURL" alt="Sender avatar" class="avatar" />
+			<img
+				[src]="sender.sender.avatarURL"
+				alt="Sender avatar"
+				class="avatar"
+				[ngClass]="{ 'clickable': !sender.sender.guest }"
+				(click)="gotoUserProfile(sender.sender)"
+			/>
 			<mat-icon matListItemIcon class="dropdown-arrow">
 				{{ dropdownOpen ? "arrow_drop_up" : "arrow_drop_down" }}
 			</mat-icon>
@@ -20,7 +26,13 @@
 			<mat-list-item>
 				<div class="payment">
 					<span class="name">
-						<img [src]="receiver.receiver.avatarURL" alt="Receiver avatar" class="avatar" />
+						<img
+							[src]="receiver.receiver.avatarURL"
+							alt="Receiver avatar"
+							class="avatar"
+							[ngClass]="{ 'clickable': !receiver.receiver.guest }"
+							(click)="gotoUserProfile(receiver.receiver)"
+						/>
 						{{ self && receiver.receiver.id === currentUser.id ? "You" : receiver.receiver.name }}
 					</span>
 					<span class="amount-color"> {{ receiver.amount | currency: "" : "" : "1.2-2" : "no" }} kr </span>

--- a/app/mikane/src/app/features/mobile/payment-item/payment-item.component.ts
+++ b/app/mikane/src/app/features/mobile/payment-item/payment-item.component.ts
@@ -6,6 +6,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
+import { Router } from '@angular/router';
 import { User } from 'src/app/services/user/user.service';
 import { FormControlPipe } from 'src/app/shared/forms/form-control.pipe';
 
@@ -42,6 +43,10 @@ export class PaymentItemComponent implements OnInit {
 	dropdownOpen: boolean;
 	lowerHeight: number | string;
 
+	constructor(
+		private router: Router,
+	) {}
+
 	ngOnInit(): void {
 		this.dropdownOpen = this.self ? true : false;
 		this.lowerHeight = this.self ? 'auto' : 0;
@@ -61,4 +66,10 @@ export class PaymentItemComponent implements OnInit {
 			this.lowerHeight = 0;
 		}
 	};
+
+	gotoUserProfile(user: User) {
+		if (!user.guest) {
+			this.router.navigate(['u', user.id]);
+		}
+	}
 }

--- a/app/mikane/src/app/pages/account/user/user-settings.component.html
+++ b/app/mikane/src/app/pages/account/user/user-settings.component.html
@@ -130,7 +130,7 @@
 					<mat-card-actions class="setting-row">
 						@if (editMode) {
 							<div>
-								<button type="button" mat-button color="accent" (click)="toggleEditMode()" class="user-settings-actions">
+								<button type="button" mat-button color="accent" (click)="cancelEditMode()" class="user-settings-actions">
 									Cancel
 								</button>
 								<button type="submit" mat-raised-button [disabled]="editUserForm.invalid || editUserForm.pending" color="primary">
@@ -268,7 +268,7 @@
 			<span class="buttons">
 				@if (editMode) {
 					<div>
-						<button type="button" mat-button color="accent" (click)="toggleEditMode()" class="user-settings-actions">
+						<button type="button" mat-button color="accent" (click)="cancelEditMode()" class="user-settings-actions">
 							Cancel
 						</button>
 						<button type="submit" mat-raised-button [disabled]="editUserForm.invalid || editUserForm.pending" color="primary">

--- a/app/mikane/src/app/pages/account/user/user-settings.component.ts
+++ b/app/mikane/src/app/pages/account/user/user-settings.component.ts
@@ -86,8 +86,12 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
 			});
 	}
 
-	toggleEditMode() {
+	cancelEditMode() {
 		this.editUserForm.patchValue(this.user);
+		this.toggleEditMode();
+	}
+
+	toggleEditMode() {
 		this.editMode = !this.editMode;
 	}
 

--- a/app/mikane/src/app/pages/category/category.component.html
+++ b/app/mikane/src/app/pages/category/category.component.html
@@ -47,7 +47,13 @@
 											<ng-container matColumnDef="name">
 												<th mat-header-cell *matHeaderCellDef>Participant</th>
 												<td mat-cell *matCellDef="let user" class="user">
-													<img [src]="user.avatarURL" alt="User avatar" class="avatar" />
+													<img
+														[src]="user.avatarURL"
+														alt="User avatar"
+														class="avatar"
+														[ngClass]="{ 'clickable': !user.guest }"
+														(click)="gotoUserProfile(user)"
+													/>
 													{{ user.name }}
 												</td>
 												<td mat-footer-cell *matFooterCellDef>
@@ -223,7 +229,9 @@
 					<mat-card appearance="outlined" class="no-categories"> No expense categories </mat-card>
 				}
 			</div>
-		} @else {
+		}
+
+		@else {
 			@if (categories.length > 0) {
 				<mat-nav-list class="categories-list-mobile">
 					@for (category of categories; track category.id) {
@@ -234,6 +242,7 @@
 							[filterUsers]="filterUsers"
 							(addUser)="addUser($event.categoryId)"
 							(removeUser)="removeUser($event.categoryId, $event.userId)"
+							(gotoUser)="gotoUserProfile($event.user)"
 							(openWeightEditDialog)="openWeightEditDialog($event.categoryId, $event.userId, $event.weight)"
 							(openEditCategoryDialog)="openEditCategoryDialog(category.id, category.name, category.icon)"
 							(toggleWeighted)="toggleWeighted($event.categoryId, $event.weighted)"

--- a/app/mikane/src/app/pages/category/category.component.scss
+++ b/app/mikane/src/app/pages/category/category.component.scss
@@ -70,6 +70,15 @@
 		border-radius: 50%;
 		object-fit: cover;
 
+		&.clickable {
+			transition: filter 0.2s;
+			cursor: pointer;
+			
+			&:hover {
+				filter: brightness(1.2);
+			}
+		}
+
 		&.option {
 			margin-right: 12px;
 		}

--- a/app/mikane/src/app/pages/category/category.component.ts
+++ b/app/mikane/src/app/pages/category/category.component.ts
@@ -406,6 +406,12 @@ export class CategoryComponent implements OnInit, AfterViewChecked, OnDestroy {
 		});
 	}
 
+	gotoUserProfile(user: { id: string, guest: boolean, username: string }) {
+		if (!user.guest) {
+			this.router.navigate(['u', user.id]);
+		}
+	}
+
 	ngOnDestroy(): void {
 		this.destroy$.next();
 		this.destroy$.complete();

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.html
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.html
@@ -71,8 +71,10 @@
 								<th mat-header-cell *matHeaderCellDef mat-sort-header>Paid by</th>
 								<td mat-cell *matCellDef="let expense">
 									<div class="payer">
-										<img [src]="expense.payer.avatarURL" alt="User avatar" class="payer-avatar" />
-										{{ expense.payer.name }}
+										<div class="payer" [ngClass]="{ 'clickable': !expense.payer.guest }" (click)="gotoUserProfile(expense.payer)">
+											<img [src]="expense.payer.avatarURL" alt="User avatar" class="payer-avatar" />
+											{{ expense.payer.name }}
+										</div>
 									</div>
 								</td>
 							</ng-container>

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.scss
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.scss
@@ -31,6 +31,30 @@
 	width: 40px;
 }
 
+.clickable {
+	cursor: pointer;
+	transition: filter 0.2s;
+	position: relative;
+
+	&:before {
+		content: '';
+		position: absolute;
+		top: -5px;
+		left: -5px;
+		width: calc(100% + 10px);
+		height: calc(100% + 10px);
+		border-radius: 6px;
+		background-color: rgba(255, 255, 255, 0);
+		transition: background-color 0.3s;
+		z-index: -1;
+	}
+
+	&:hover::before {
+		background-color: rgba(255, 255, 255, 0.2);
+		z-index: 0;
+	}
+}
+
 .payer {
 	display: flex;
 	align-items: center;

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.ts
@@ -340,6 +340,12 @@ export class ExpendituresComponent implements OnInit, OnDestroy {
 		});
 	}
 
+	gotoUserProfile(user: User) {
+		if (!user.guest) {
+			this.router.navigate(['u', user.id]);
+		}
+	}
+
 	applyFilter(event: Event) {
 		const filterValue = (event.target as HTMLInputElement).value;
 		this.filterValue.update(() => {

--- a/app/mikane/src/app/pages/expenditures/expense/expense.component.html
+++ b/app/mikane/src/app/pages/expenditures/expense/expense.component.html
@@ -23,8 +23,10 @@
 			<div class="title">
 				<div class="header">Paid by</div>
 				<div class="payer">
-					<img [src]="expense.payer.avatarURL" alt="User avatar" class="payer-avatar" />
-					<div id="payer-name">{{ expense.payer.name }}</div>
+					<div class="payer-inner" (click)="gotoUserProfile()">
+						<img [src]="expense.payer.avatarURL" alt="User avatar" class="payer-avatar" />
+						<div id="payer-name">{{ expense.payer.name }}</div>
+					</div>
 				</div>
 			</div>
 			@if (expense.description) {

--- a/app/mikane/src/app/pages/expenditures/expense/expense.component.scss
+++ b/app/mikane/src/app/pages/expenditures/expense/expense.component.scss
@@ -39,24 +39,27 @@
 
 .payer {
 	display: flex;
-	align-items: center;
 
-	font-size: 1.2em;
-	margin-top: 4px;
+	.payer-inner {
+		display: flex;
+		align-items: center;
+		margin-top: 4px;
+		font-size: 1.2em;
 
-	.payer-avatar {
-		position: relative;
-		width: 24px;
-		height: 24px;
-		margin-right: 6px;
-		border-radius: 50%;
-		object-fit: cover;
-		margin-right: 10px;
-	}
-	
-	.payer-name {
-		position: relative;
-		top: 1px;
+		.payer-avatar {
+			position: relative;
+			width: 24px;
+			height: 24px;
+			margin-right: 6px;
+			border-radius: 50%;
+			object-fit: cover;
+			margin-right: 10px;
+		}
+		
+		.payer-name {
+			position: relative;
+			top: 1px;
+		}
 	}
 }
 

--- a/app/mikane/src/app/pages/expenditures/expense/expense.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expense/expense.component.ts
@@ -180,6 +180,12 @@ export class ExpenseComponent implements OnInit, OnDestroy {
 		});
 	}
 
+	gotoUserProfile() {
+		if (!this.expense.payer.guest) {
+			this.router.navigate(['u', this.expense.payer.id]);
+		}
+	}
+
 	ngOnDestroy(): void {
 		this.destroy$.next();
 		this.destroy$.complete();

--- a/app/mikane/src/app/pages/participant/participant.component.html
+++ b/app/mikane/src/app/pages/participant/participant.component.html
@@ -58,7 +58,13 @@
 								<mat-expansion-panel-header>
 									<mat-panel-title>
 										<div class="user first">
-											<img [src]="userWithBalance.user.avatarURL" alt="User avatar" class="avatar" />
+											<img
+												[src]="userWithBalance.user.avatarURL"
+												alt="User avatar"
+												class="avatar"
+												[ngClass]="{ 'clickable': !userWithBalance.user.guest }"
+												(click)="gotoUserProfile(userWithBalance.user)"
+											/>
 											{{ userWithBalance.user.name }}
 										</div>
 										<div class="count" [ngClass]="{ 'no-expenses': userWithBalance.expensesCount === 0 }">
@@ -168,7 +174,9 @@
 					<mat-card appearance="outlined"> No participants </mat-card>
 				}
 			</div>
-		} @else {
+		}
+
+		@else {
 			<div class="header-mobile">
 				@if (inEvent) {
 					<span class="in-event">
@@ -202,6 +210,7 @@
 						[userBalance]="userWithBalance"
 						[eventActive]="event?.status.id === EventStatusType.ACTIVE"
 						(click)="gotoUserExpenses(userWithBalance)"
+						(gotoUser)="gotoUserProfile($event.user)"
 						(removeUser)="deleteUserDialog($event.userId)"
 					></app-participant-item>
 				}

--- a/app/mikane/src/app/pages/participant/participant.component.scss
+++ b/app/mikane/src/app/pages/participant/participant.component.scss
@@ -24,6 +24,15 @@
 		margin-right: 16px;
 		border-radius: 50%;
 		object-fit: cover;
+		
+		&.clickable {
+			transition: filter 0.2s;
+			cursor: pointer;
+			
+			&:hover {
+				filter: brightness(1.2);
+			}
+		}
 	}
 }
 

--- a/app/mikane/src/app/pages/participant/participant.component.ts
+++ b/app/mikane/src/app/pages/participant/participant.component.ts
@@ -388,6 +388,12 @@ export class ParticipantComponent implements OnInit, OnDestroy {
 		this.router.navigate(['events', this.event.id, 'settings']);
 	}
 
+	gotoUserProfile(user: User) {
+		if (!user.guest) {
+			this.router.navigate(['u', user.id]);
+		}
+	}
+
 	gotoUserExpenses(user: UserBalance) {
 		if (user.expensesCount < 1) {
 			return;

--- a/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.html
+++ b/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.html
@@ -3,7 +3,13 @@
 		<mat-expansion-panel [expanded]="self">
 			<mat-expansion-panel-header (click)="panelToggled()">
 				<div class="user">
-					<img [src]="sender.sender.avatarURL" alt="Sender avatar" class="avatar" />
+					<img
+						[src]="sender.sender.avatarURL"
+						alt="Sender avatar"
+						class="avatar"
+						[ngClass]="{ 'clickable': !sender.sender.guest }"
+						(click)="gotoUserProfile(sender.sender)"
+					/>
 					<mat-panel-title>{{ self && sender.sender.id === currentUser.id ? "You" : sender.sender.name }}</mat-panel-title>
 				</div>
 			</mat-expansion-panel-header>
@@ -15,7 +21,13 @@
 							{{ self && sender.sender.id === currentUser.id ? "Owe money to" : "Owes money to" }}
 						</th>
 						<td mat-cell *matCellDef="let receiver" class="user">
-							<img [src]="receiver.receiver.avatarURL" alt="Receiver avatar" class="avatar" />
+							<img
+								[src]="receiver.receiver.avatarURL"
+								alt="Receiver avatar"
+								class="avatar"
+								[ngClass]="{ 'clickable': !receiver.receiver.guest }"
+								(click)="gotoUserProfile(receiver.receiver)"
+							/>
 							{{ self && receiver.receiver.id === currentUser.id ? "You" : receiver.receiver.name }}
 						</td>
 					</ng-container>

--- a/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.scss
+++ b/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.scss
@@ -14,5 +14,14 @@
 		margin-right: 16px;
 		border-radius: 50%;
 		object-fit: cover;
+		
+		&.clickable {
+			transition: filter 0.2s;
+			cursor: pointer;
+			
+			&:hover {
+				filter: brightness(1.2);
+			}
+		}
 	}
 }

--- a/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.ts
+++ b/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, CurrencyPipe } from '@angular/common';
+import { AsyncPipe, CommonModule, CurrencyPipe } from '@angular/common';
 import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -6,6 +6,7 @@ import { MatAccordion, MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatTableModule } from '@angular/material/table';
+import { Router } from '@angular/router';
 import { PaymentItemComponent } from 'src/app/features/mobile/payment-item/payment-item.component';
 import { User } from 'src/app/services/user/user.service';
 
@@ -15,6 +16,7 @@ import { User } from 'src/app/services/user/user.service';
 	styleUrls: ['./payment-expansion-panel-item.component.scss'],
 	standalone: true,
 	imports: [
+		CommonModule,
 		MatButtonModule,
 		MatIconModule,
 		MatExpansionModule,
@@ -41,6 +43,10 @@ export class PaymentExpansionPanelItemComponent {
 
 	displayedColumns: string[] = ['name', 'amount'];
 
+	constructor(
+		private router: Router,
+	) {}
+
 	openExpand(open: boolean) {
 		if (open) {
 			this.accordion.openAll();
@@ -54,6 +60,12 @@ export class PaymentExpansionPanelItemComponent {
 			this.allPanelsExpanded.emit(true);
 		} else if (!this.accordion._headers.some((panel) => panel._isExpanded())) {
 			this.allPanelsExpanded.emit(false);
+		}
+	}
+
+	gotoUserProfile(user: User) {
+		if (!user.guest) {
+			this.router.navigate(['u', user.id]);
 		}
 	}
 }

--- a/app/mikane/src/app/pages/payment-structure/payment-structure.component.html
+++ b/app/mikane/src/app/pages/payment-structure/payment-structure.component.html
@@ -55,7 +55,9 @@
 					</div>
 				}
 			</div>
-		} @else {
+		}
+
+		@else {
 			@if (senders.length > 0) {
 				<div>
 					@if (paymentsSelf.length > 0) {

--- a/app/mikane/src/app/pages/profile/profile.component.html
+++ b/app/mikane/src/app/pages/profile/profile.component.html
@@ -23,13 +23,23 @@
 						<div class="user-row">
 							<span class="user-padding">
 								<mat-icon class="icon">email</mat-icon>
-								<a [href]="'mailto:' + user?.email">{{ user?.email }} </a>
+								@if (user?.email) {
+									<a [href]="'mailto:' + user?.email">{{ user?.email }} </a>
+								}
+								@else {
+									<i>Private</i>
+								}
 							</span>
 						</div>
 						<div class="user-row">
 							<span class="user-padding">
 								<mat-icon class="icon">phone</mat-icon>
-								{{ user?.phone }}
+								@if (user?.phone) {
+									{{ user?.phone }}
+								}
+								@else {
+									<i>Private</i>
+								}
 							</span>
 						</div>
 					</mat-card-content>
@@ -50,13 +60,23 @@
 					<div class="user-row">
 						<span class="user-padding">
 							<mat-icon class="icon">email</mat-icon>
-							<a [href]="'mailto:' + user?.email">{{ user?.email }} </a>
+							@if (user?.email) {
+								<a [href]="'mailto:' + user?.email">{{ user?.email }} </a>
+							}
+							@else {
+								<i>Private</i>
+							}
 						</span>
 					</div>
 					<div class="user-row">
 						<span class="user-padding">
 							<mat-icon class="icon">phone</mat-icon>
-							{{ user?.phone }}
+							@if (user?.phone) {
+								{{ user?.phone }}
+							}
+							@else {
+								<i>Private</i>
+							}
 						</span>
 					</div>
 				</div>

--- a/app/mikane/src/app/services/category/category.service.ts
+++ b/app/mikane/src/app/services/category/category.service.ts
@@ -15,6 +15,8 @@ export interface Category {
 	users: Array<{
 		id: string;
 		name: string;
+		username: string;
+		guest: boolean;
 		avatarURL: string;
 		weight?: number;
 	}>;

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "2.2.0",
+    "version": "2.3.0",
     "title": "Mikane API",
     "description": "Documentation for all endpoints in the Mikane API"
   },
@@ -4215,9 +4215,21 @@
                   "type": "string",
                   "example": "Test name"
                 },
+                "username": {
+                  "type": "string",
+                  "example": "Test username"
+                },
+                "avatarURL": {
+                  "type": "string",
+                  "example": "https://gravatar.com/avatar/aaaa"
+                },
                 "weight": {
                   "type": "number",
                   "example": 3
+                },
+                "guest": {
+                  "type": "boolean",
+                  "example": false
                 }
               }
             }

--- a/server/src/parsers/parseCategories.ts
+++ b/server/src/parsers/parseCategories.ts
@@ -46,6 +46,7 @@ export const parseCategories = (catInput: CategoryDB[], target: Target, usersInE
               {
                 id: user.user_id,
                 name: "Deleted user",
+                username: "Deleted user",
                 avatarURL: getGravatarURL("", { size: 50, default: "mp" }),
                 weight: user.weight,
                 guest: user.guest
@@ -53,12 +54,12 @@ export const parseCategories = (catInput: CategoryDB[], target: Target, usersInE
               {
                 id: user.user_id,
                 name: user.first_name,
-                guest: user.guest,
                 username: user.username,
                 firstName: user.first_name,
                 lastName: user.last_name,
                 avatarURL: getGravatarURL(user.email ?? "", { size: 50, default: user.guest ? "mp" : "identicon" }),
-                weight: user.weight
+                weight: user.weight,
+                guest: user.guest
               }
             );
           }
@@ -96,7 +97,6 @@ export const parseCategories = (catInput: CategoryDB[], target: Target, usersInE
       // Set unique names of users where they are shared
       setDisplayNames(category.users, usersInEvent);
       for (const user of category.users) {
-        delete user.username;
         delete user.firstName;
         delete user.lastName;
       }

--- a/server/src/types/types.ts
+++ b/server/src/types/types.ts
@@ -61,7 +61,7 @@ export type Category = {
     id: string,
     name: string,
     guest: boolean,
-    username?: string,
+    username: string,
     firstName?: string,
     lastName?: string,
     avatarURL: string,


### PR DESCRIPTION
Adds clickable user elements to various pages, so it is possible to see any user's profile page by clicking on a user. The following pages have been adjusted:

- Participants page:
	- Full view: User avatars are clickable, with a brightness hover effect
	- Mobile view: User avatars are clickable
- Expenses page:
	- Full view: Payer object is clickable as a whole, with a "box" appearing around the user to show it's clickable when hovered
	- Mobile view: The user needs to click into the expense page first, from where the user can click on the user (both avatar and name)
- Categories page:
	- Full view: User avatars are clickable, with a brightness hover effect
	- Mobile view: User avatars are clickable
- Payments page:
	- Full view: User avatars are clickable (both senders and receivers), with a brightness hover effect
	- Mobile view: User avatars are clickable (both senders and receivers)

As guests do not have any profile pages, guests (and their avatars) are not clickable.

Additional change 1:
Profile pages for users that have not set their email/phone public will now show "private" for the respective user details.

Additional change 2:
Backend has been slightly adjusted to always include username and guest information for users in categories.

Fixes #357 