### PR TITLE
feat: Get user by username

### DIFF
--- a/app/mikane/src/app/features/menu/menu.component.spec.ts
+++ b/app/mikane/src/app/features/menu/menu.component.spec.ts
@@ -83,17 +83,17 @@ describe('MenuComponent', () => {
 	});
 
 	it('should navigate to profile page when onProfileClick is called', () => {
-		const user: User = { id: '1', name: 'Test User' } as User;
+		const user: User = { id: '1', username: 'testuser', name: 'Test User' } as User;
 		component.user = user;
 		component.onProfileClick();
 
-		expect(routerSpy.navigate).toHaveBeenCalledWith(['/u', user.id]);
+		expect(routerSpy.navigate).toHaveBeenCalledWith(['/u', user.username]);
 	});
 
 	it('should not navigate to profile page when onProfileClick is called and already on profile page', () => {
-		const user: User = { id: '1', name: 'Test User' } as User;
+		const user: User = { id: '1', username: 'testuser', name: 'Test User' } as User;
 		component.user = user;
-		spyPropertyGetter(routerSpy, 'url').and.returnValue(`/u/${user.id}`);
+		spyPropertyGetter(routerSpy, 'url').and.returnValue(`/u/${user.username}`);
 		component.onProfileClick();
 
 		expect(routerSpy.navigate).not.toHaveBeenCalled();

--- a/app/mikane/src/app/features/menu/menu.component.ts
+++ b/app/mikane/src/app/features/menu/menu.component.ts
@@ -50,11 +50,11 @@ export class MenuComponent implements OnInit {
 	}
 
 	onProfileClick() {
-		if (this.router.url === '/u/' + this.user.id) {
+		if (this.router.url === '/u/' + this.user.username) {
 			this.splitButton.toggled = false;
 			return;
 		}
-		this.router.navigate(['/u', this.user.id]);
+		this.router.navigate(['/u', this.user.username]);
 	}
 
 	logout() {

--- a/app/mikane/src/app/features/mobile/event-item/event-item.component.html
+++ b/app/mikane/src/app/features/mobile/event-item/event-item.component.html
@@ -2,7 +2,7 @@
 	<div class="event-title">
 		<span class="title-text">{{ event.name }}</span>
 		@if (event.private) {
-			<mat-icon>passkey</mat-icon>
+			<mat-icon	matTooltip="This event is private" [matTooltipShowDelay]="200" class="joined-icon">	passkey	</mat-icon>
 		} @else if (event.userInfo.inEvent) {
 			<mat-icon matTooltip="You are in this event" [matTooltipShowDelay]="200" class="joined-icon"> how_to_reg </mat-icon>
 		}

--- a/app/mikane/src/app/features/mobile/payment-item/payment-item.component.ts
+++ b/app/mikane/src/app/features/mobile/payment-item/payment-item.component.ts
@@ -69,7 +69,7 @@ export class PaymentItemComponent implements OnInit {
 
 	gotoUserProfile(user: User) {
 		if (!user.guest) {
-			this.router.navigate(['u', user.id]);
+			this.router.navigate(['u', user.username]);
 		}
 	}
 }

--- a/app/mikane/src/app/pages/category/category.component.ts
+++ b/app/mikane/src/app/pages/category/category.component.ts
@@ -408,7 +408,7 @@ export class CategoryComponent implements OnInit, AfterViewChecked, OnDestroy {
 
 	gotoUserProfile(user: { id: string, guest: boolean, username: string }) {
 		if (!user.guest) {
-			this.router.navigate(['u', user.id]);
+			this.router.navigate(['u', user.username]);
 		}
 	}
 

--- a/app/mikane/src/app/pages/events/event-dialog/event-dialog.component.html
+++ b/app/mikane/src/app/pages/events/event-dialog/event-dialog.component.html
@@ -1,4 +1,4 @@
-<h1 mat-dialog-title>{{ data?.edit ? "Edit event" : "Create event" }}</h1>
+<h1 mat-dialog-title>{{ data?.edit ? "Change event name" : "Create event" }}</h1>
 <div mat-dialog-content>
 	<mat-form-field appearance="fill">
 		<mat-label>Event Name</mat-label>
@@ -17,6 +17,18 @@
 		<mat-label>Event Description</mat-label>
 		<input matInput name="description" [(ngModel)]="event.description" />
 	</mat-form-field>
+	@if (data?.edit === false) {
+		<div class="private">
+			<div class="toggle-line">
+				<span>Private:</span>
+				<span class="toggle">
+					<mat-slide-toggle id="privateToggle" name="private" [(ngModel)]="event.private">
+					</mat-slide-toggle>
+				</span>
+			</div>
+			<div class="subtext">Private events are only visible to participants in the event.</div>
+		</div>
+	}
 </div>
 <div mat-dialog-actions class="dialog-buttons">
 	<button mat-button (click)="onNoClick()">Cancel</button>

--- a/app/mikane/src/app/pages/events/event-dialog/event-dialog.component.scss
+++ b/app/mikane/src/app/pages/events/event-dialog/event-dialog.component.scss
@@ -1,3 +1,24 @@
 mat-form-field {
 	width: 100%;
 }
+
+.private {
+	margin-bottom: 20px;
+
+	.toggle-line {
+		display: flex;
+		align-items: center;
+		margin-bottom: 6px;
+		color: white;
+
+		.toggle {
+			display: flex;
+			align-items: center;
+			margin-left: 10px;
+		}
+	}
+
+	.subtext {
+		color: rgba(255, 255, 255, 0.58);
+	}
+}

--- a/app/mikane/src/app/pages/events/event-dialog/event-dialog.component.ts
+++ b/app/mikane/src/app/pages/events/event-dialog/event-dialog.component.ts
@@ -4,6 +4,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { PuddingEvent } from 'src/app/services/event/event.service';
 import { EventNameValidatorDirective } from 'src/app/shared/forms/validators/async-event-name.validator';
@@ -19,11 +20,12 @@ import { EventNameValidatorDirective } from 'src/app/shared/forms/validators/asy
 		FormsModule,
 		MatButtonModule,
 		EventNameValidatorDirective,
+		MatSlideToggleModule,
 		MatProgressSpinnerModule,
 	],
 })
 export class EventDialogComponent {
-	event: { id?: string; name: string; description: string } = { name: '', description: '' };
+	event: { id?: string; name: string; description: string, private: boolean } = { name: '', description: '', private: false };
 	edit: boolean;
 	currentName: string;
 	currentDescription: string;
@@ -33,9 +35,10 @@ export class EventDialogComponent {
 		@Inject(MAT_DIALOG_DATA) public data: { edit: boolean; event: PuddingEvent },
 	) {
 		if (data?.event) {
+			this.event.id = data.event.id;
 			this.event.name = data.event.name;
 			this.event.description = data.event.description;
-			this.event.id = data.event.id;
+			this.event.private = data.event.private;
 			this.currentName = data.event.name;
 			this.currentDescription = data.event.description;
 		}

--- a/app/mikane/src/app/pages/events/events.component.html
+++ b/app/mikane/src/app/pages/events/events.component.html
@@ -22,7 +22,9 @@
 								<span class="event-name">
 									<span class="name-text">{{ event.name }}</span>
 									@if (event.private) {
-										<mat-icon>passkey</mat-icon>
+										<mat-icon	matTooltip="This event is private" [matTooltipShowDelay]="200" class="joined-icon">
+											passkey
+										</mat-icon>
 									} @else if (event.userInfo.inEvent) {
 										<mat-icon matTooltip="You are in this event" [matTooltipShowDelay]="200" class="joined-icon">
 											how_to_reg
@@ -66,7 +68,9 @@
 								<span class="event-name">
 									<span class="name-text">{{ event.name }}</span>
 									@if (event.private) {
-										<mat-icon>passkey</mat-icon>
+										<mat-icon	matTooltip="This event is private" [matTooltipShowDelay]="200" class="joined-icon">
+											passkey
+										</mat-icon>
 									} @else if (event.userInfo.inEvent) {
 										<mat-icon matTooltip="You are in this event" [matTooltipShowDelay]="200" class="joined-icon">
 											how_to_reg

--- a/app/mikane/src/app/pages/events/events.component.ts
+++ b/app/mikane/src/app/pages/events/events.component.ts
@@ -149,11 +149,14 @@ export class EventsComponent implements OnInit, OnDestroy {
 	openDialog() {
 		const dialogRef = this.dialog.open(EventDialogComponent, {
 			width: '350px',
+			data: {
+				edit: false
+			}
 		});
 
-		dialogRef.afterClosed().subscribe((event: { name: string; description: string }) => {
+		dialogRef.afterClosed().subscribe((event: { name: string; description: string, private: boolean }) => {
 			if (event) {
-				this.eventService.createEvent(event).subscribe({
+				this.eventService.createEvent({ name: event.name, description: event.description, privateEvent: event.private }).subscribe({
 					next: (newEvent) => {
 						this.events.update((events) => {
 							events.unshift(newEvent);

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.ts
@@ -342,7 +342,7 @@ export class ExpendituresComponent implements OnInit, OnDestroy {
 
 	gotoUserProfile(user: User) {
 		if (!user.guest) {
-			this.router.navigate(['u', user.id]);
+			this.router.navigate(['u', user.username]);
 		}
 	}
 

--- a/app/mikane/src/app/pages/expenditures/expense/expense.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expense/expense.component.ts
@@ -182,7 +182,7 @@ export class ExpenseComponent implements OnInit, OnDestroy {
 
 	gotoUserProfile() {
 		if (!this.expense.payer.guest) {
-			this.router.navigate(['u', this.expense.payer.id]);
+			this.router.navigate(['u', this.expense.payer.username]);
 		}
 	}
 

--- a/app/mikane/src/app/pages/participant/participant.component.ts
+++ b/app/mikane/src/app/pages/participant/participant.component.ts
@@ -390,7 +390,7 @@ export class ParticipantComponent implements OnInit, OnDestroy {
 
 	gotoUserProfile(user: User) {
 		if (!user.guest) {
-			this.router.navigate(['u', user.id]);
+			this.router.navigate(['u', user.username]);
 		}
 	}
 

--- a/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.ts
+++ b/app/mikane/src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component.ts
@@ -65,7 +65,7 @@ export class PaymentExpansionPanelItemComponent {
 
 	gotoUserProfile(user: User) {
 		if (!user.guest) {
-			this.router.navigate(['u', user.id]);
+			this.router.navigate(['u', user.username]);
 		}
 	}
 }

--- a/app/mikane/src/app/pages/profile/profile.component.ts
+++ b/app/mikane/src/app/pages/profile/profile.component.ts
@@ -50,11 +50,11 @@ export class ProfileComponent implements OnInit, OnDestroy {
 		this.subscription = this.route.paramMap
 			.pipe(
 				map((params) => {
-					return params.get('username');
+					return params.get('usernameOrId');
 				}),
-				switchMap((username) => {
-					if (username) {
-						return this.userService.loadUserByUsername(username);
+				switchMap((usernameOrId) => {
+					if (usernameOrId) {
+						return this.userService.loadUserByUsernameOrId(usernameOrId);
 					} else {
 						// Username not in URL, showing logged in user profile page
 						return this.authService.getCurrentUser().pipe(switchMap((user) => this.userService.loadUserById(user.id)));

--- a/app/mikane/src/app/pages/profile/profile.component.ts
+++ b/app/mikane/src/app/pages/profile/profile.component.ts
@@ -50,13 +50,13 @@ export class ProfileComponent implements OnInit, OnDestroy {
 		this.subscription = this.route.paramMap
 			.pipe(
 				map((params) => {
-					return params.get('id');
+					return params.get('username');
 				}),
-				switchMap((id) => {
-					if (id) {
-						return this.userService.loadUserById(id);
+				switchMap((username) => {
+					if (username) {
+						return this.userService.loadUserByUsername(username);
 					} else {
-						// User id not in URL, showing logged in user profile page
+						// Username not in URL, showing logged in user profile page
 						return this.authService.getCurrentUser().pipe(switchMap((user) => this.userService.loadUserById(user.id)));
 					}
 				}),

--- a/app/mikane/src/app/pages/profile/profile.routes.ts
+++ b/app/mikane/src/app/pages/profile/profile.routes.ts
@@ -3,5 +3,5 @@ import { ProfileComponent } from './profile.component';
 
 export default [
 	{ path: '', component: ProfileComponent },
-	{ path: ':id', component: ProfileComponent },
+	{ path: ':username', component: ProfileComponent },
 ] as Route[];

--- a/app/mikane/src/app/pages/profile/profile.routes.ts
+++ b/app/mikane/src/app/pages/profile/profile.routes.ts
@@ -3,5 +3,5 @@ import { ProfileComponent } from './profile.component';
 
 export default [
 	{ path: '', component: ProfileComponent },
-	{ path: ':username', component: ProfileComponent },
+	{ path: ':usernameOrId', component: ProfileComponent },
 ] as Route[];

--- a/app/mikane/src/app/services/event/event.service.spec.ts
+++ b/app/mikane/src/app/services/event/event.service.spec.ts
@@ -138,7 +138,7 @@ describe('EventService', () => {
 
 	describe('#createEvent', () => {
 		it('should create event', () => {
-			service.createEvent({ name: 'name', description: 'description' }).subscribe({
+			service.createEvent({ name: 'name', description: 'description', privateEvent: false }).subscribe({
 				next: (result) => {
 					expect(result).withContext('should return result').toEqual(mockEvent);
 				},

--- a/app/mikane/src/app/services/event/event.service.ts
+++ b/app/mikane/src/app/services/event/event.service.ts
@@ -59,8 +59,8 @@ export class EventService {
 		return this.httpClient.get<PuddingEvent>(this.apiUrl + `/${eventId}`);
 	}
 
-	createEvent({ name, description }: { name: string; description: string }): Observable<PuddingEvent> {
-		return this.httpClient.post<PuddingEvent>(this.apiUrl, { name, description, private: false });
+	createEvent({ name, description, privateEvent }: { name: string; description: string, privateEvent: boolean }): Observable<PuddingEvent> {
+		return this.httpClient.post<PuddingEvent>(this.apiUrl, { name, description, private: privateEvent });
 	}
 
 	editEvent({ id, name, description, privateEvent, status }: { id: string; name?: string; description?: string; privateEvent?: boolean; status?: EventStatusType }): Observable<PuddingEvent> {

--- a/app/mikane/src/app/services/user/user.service.spec.ts
+++ b/app/mikane/src/app/services/user/user.service.spec.ts
@@ -110,14 +110,26 @@ describe('UserService', () => {
 		});
 	});
 
-	describe('loadUserByUsername', () => {
-		it('should return a user', () => {
+	describe('loadUserByUsernameOrId', () => {
+		it('should return a user by username', () => {
 			const mockUser: User = { id: '1', username: 'user1', name: 'User 1' } as User;
 			const username = 'user1';
-			service.loadUserByUsername(username).subscribe((user) => {
+			service.loadUserByUsernameOrId(username).subscribe((user) => {
 				expect(user).toEqual(mockUser);
 			});
 			const req = httpMock.expectOne(apiUrl + `users/username/${username}`);
+
+			expect(req.request.method).toBe('GET');
+			req.flush(mockUser);
+		});
+
+		it('should return a user by ID', () => {
+			const mockUser: User = { id: '1', username: 'user1', name: 'User 1' } as User;
+			const userId = '1';
+			service.loadUserByUsernameOrId(userId).subscribe((user) => {
+				expect(user).toEqual(mockUser);
+			});
+			const req = httpMock.expectOne(apiUrl + `users/username/${userId}`);
 
 			expect(req.request.method).toBe('GET');
 			req.flush(mockUser);

--- a/app/mikane/src/app/services/user/user.service.spec.ts
+++ b/app/mikane/src/app/services/user/user.service.spec.ts
@@ -110,6 +110,20 @@ describe('UserService', () => {
 		});
 	});
 
+	describe('loadUserByUsername', () => {
+		it('should return a user', () => {
+			const mockUser: User = { id: '1', username: 'user1', name: 'User 1' } as User;
+			const username = 'user1';
+			service.loadUserByUsername(username).subscribe((user) => {
+				expect(user).toEqual(mockUser);
+			});
+			const req = httpMock.expectOne(apiUrl + `users/username/${username}`);
+
+			expect(req.request.method).toBe('GET');
+			req.flush(mockUser);
+		});
+	});
+
 	describe('createUser', () => {
 		it('should create a user', () => {
 			const mockUser: User = {

--- a/app/mikane/src/app/services/user/user.service.ts
+++ b/app/mikane/src/app/services/user/user.service.ts
@@ -94,6 +94,15 @@ export class UserService {
 	}
 
 	/**
+	 * Loads a user by their username.
+	 * @param username The username of the user to load.
+	 * @returns An Observable that emits the loaded User object.
+	 */
+	loadUserByUsername(username: string) {
+		return this.httpClient.get<User>(this.apiUrl + `/username/${username}`);
+	}
+
+	/**
 	 * Creates a new user with the given name and event ID.
 	 * @param eventId The ID of the event the user is associated with.
 	 * @param name The name of the user.

--- a/app/mikane/src/app/services/user/user.service.ts
+++ b/app/mikane/src/app/services/user/user.service.ts
@@ -94,12 +94,12 @@ export class UserService {
 	}
 
 	/**
-	 * Loads a user by their username.
-	 * @param username The username of the user to load.
+	 * Loads a user by their username or ID.
+	 * @param usernameId The username or ID of the user to load.
 	 * @returns An Observable that emits the loaded User object.
 	 */
-	loadUserByUsername(username: string) {
-		return this.httpClient.get<User>(this.apiUrl + `/username/${username}`);
+	loadUserByUsernameOrId(usernameId: string) {
+		return this.httpClient.get<User>(this.apiUrl + `/username/${usernameId}`);
 	}
 
 	/**

--- a/server/db_scripts/get_user.sql
+++ b/server/db_scripts/get_user.sql
@@ -29,9 +29,12 @@ begin
     "user" u
     left join user_preferences up on u.id = up.user_id
   where
-    (u.id = ip_user_id or (ip_user_id is null and u.username ilike ip_username)) and
+    (u.id = ip_user_id or u.username ilike ip_username) and
     u.deleted = false and
-    u.guest = case when ip_allow_guest = true then u.guest else false end;
+    u.guest = case when ip_allow_guest = true then u.guest else false end
+  order by
+    u.id = ip_user_id desc, u.username ilike ip_username desc
+  limit 1;
 end;
 $$
 language plpgsql;

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -858,6 +858,73 @@
         }
       }
     },
+    "/users/username/{username}": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Get user by username",
+        "description": "Get information about a specific user by username. If the requester is not the signed-in user, some sensitive information may be excluded.",
+        "operationId": "getUserByUsername",
+        "security": [
+          { "cookieAuth": [] }
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "Username",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "myUsername"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserDetailed"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NoAuthResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/users/changepassword": {
       "post": {
         "tags": [

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -858,22 +858,22 @@
         }
       }
     },
-    "/users/username/{username}": {
+    "/users/username/{usernameId}": {
       "get": {
         "tags": [
           "Users"
         ],
-        "summary": "Get user by username",
-        "description": "Get information about a specific user by username. If the requester is not the signed-in user, some sensitive information may be excluded.",
-        "operationId": "getUserByUsername",
+        "summary": "Get user by username (also accepts ID)",
+        "description": "Get information about a specific user by username (also accepts user ID). If the requester is not the signed-in user, some sensitive information may be excluded.",
+        "operationId": "getUserByUsernameId",
         "security": [
           { "cookieAuth": [] }
         ],
         "parameters": [
           {
-            "name": "username",
+            "name": "usernameId",
             "in": "path",
-            "description": "Username",
+            "description": "Username or user ID",
             "required": true,
             "schema": {
               "type": "string",

--- a/server/src/api/users.ts
+++ b/server/src/api/users.ts
@@ -87,6 +87,32 @@ router.get("/users/:id", authCheck, async (req, res, next) => {
 });
 
 /*
+* Get a specific user by username
+*/
+router.get("/users/username/:username", authCheck, async (req, res, next) => {
+  try {
+    const username = req.params.username;
+    const activeUserId = req.session.userId;
+    if (!activeUserId) {
+      throw new ErrorExt(ec.PUD054);
+    }
+
+    const user = await db.getUser(null, 280, username);
+    if (!user) {
+      throw new ErrorExt(ec.PUD008);
+    }
+
+    // Remove sensitive information if user is not signed in user
+    removeUserInfo([user], activeUserId);
+
+    res.status(200).send(user);
+  }
+  catch (err) {
+    next(err);
+  }
+});
+
+/*
 * Get a list of a user's expenses
 */
 router.get("/users/:id/expenses/:eventId", authCheck, async (req, res, next) => {

--- a/server/src/api/users.ts
+++ b/server/src/api/users.ts
@@ -87,17 +87,24 @@ router.get("/users/:id", authCheck, async (req, res, next) => {
 });
 
 /*
-* Get a specific user by username
+* Get a specific user by username (also accepts ID)
 */
-router.get("/users/username/:username", authCheck, async (req, res, next) => {
+router.get("/users/username/:usernameOrUserId", authCheck, async (req, res, next) => {
   try {
-    const username = req.params.username;
+    const usernameOrUserId = req.params.usernameOrUserId;
     const activeUserId = req.session.userId;
     if (!activeUserId) {
       throw new ErrorExt(ec.PUD054);
     }
 
-    const user = await db.getUser(null, 280, username);
+    let user: User | null;
+    if (isUUID(usernameOrUserId)) {
+      user = await db.getUser(usernameOrUserId, 280);
+    }
+    else {
+      user = await db.getUser(null, 280, usernameOrUserId);
+    }
+
     if (!user) {
       throw new ErrorExt(ec.PUD008);
     }

--- a/server/tests/users.test.ts
+++ b/server/tests/users.test.ts
@@ -365,6 +365,49 @@ describe("users", async () => {
     });
   });
 
+  /* ------------------------------- */
+  /* GET /users/username/:usernameId */
+  /* ------------------------------- */
+  describe("GET /users/username/:usernameId", async () => {
+    test("should get user by username", async () => {
+      const res = await request(app)
+        .get("/api/users/username/" + user.username)
+        .set("Cookie", authToken);
+
+      expect(res.status).toEqual(200);
+      expect(res.headers["content-type"]).toEqual(expect.stringContaining("json"));
+      expect(res.body.username).toEqual("testuser");
+    });
+
+    test("should get user by ID", async () => {
+      const res = await request(app)
+        .get("/api/users/username/" + user.id)
+        .set("Cookie", authToken);
+
+      expect(res.status).toEqual(200);
+      expect(res.headers["content-type"]).toEqual(expect.stringContaining("json"));
+      expect(res.body.username).toEqual("testuser");
+    });
+
+    test("should not find user with unknown username", async () => {
+      const res = await request(app)
+        .get("/api/users/username/unknownuser")
+        .set("Cookie", authToken);
+
+      expect(res.status).toEqual(404);
+      expect(res.body.code).toEqual(ec.PUD008.code);
+    });
+
+    test("should not find user with unknown user ID", async () => {
+      const res = await request(app)
+        .get("/api/users/username/5c756c8d-1ad1-47ba-8a24-3091911f3a35")
+        .set("Cookie", authToken);
+
+      expect(res.status).toEqual(404);
+      expect(res.body.code).toEqual(ec.PUD008.code);
+    });
+  });
+
   /* -------------------------- */
   /* PUT /users/:id/preferences */
   /* -------------------------- */


### PR DESCRIPTION
Added a new endpoint for getting a user by their username. The profile page has been updated to use the user's username in the URL instead of the user ID.

Additional change 1:
A toggle for setting the event private when creating a new event was missing from the "private events" PR. This has now been implemented.

Additional change 2:
Added back missing tooltip and styling for private event icon.

Fixes #260 