### PR TITLE
feat: Improve event info page, and more

### DIFF
--- a/app/mikane/src/app/features/confirm-dialog/confirm-dialog.component.html
+++ b/app/mikane/src/app/features/confirm-dialog/confirm-dialog.component.html
@@ -1,6 +1,9 @@
 <h1 mat-dialog-title>{{ data?.title }}</h1>
 <div mat-dialog-content>
 	<p>{{ data?.content }}</p>
+	@if (data?.extraContent) {
+		<p>{{ data.extraContent }}</p>
+	}
 </div>
 <div mat-dialog-actions class="dialog-buttons">
 	<button mat-button (click)="onNoClick()">Cancel</button>

--- a/app/mikane/src/app/features/confirm-dialog/confirm-dialog.component.ts
+++ b/app/mikane/src/app/features/confirm-dialog/confirm-dialog.component.ts
@@ -11,7 +11,7 @@ import { MatButtonModule } from '@angular/material/button';
 export class ConfirmDialogComponent {
 	constructor(
 		public dialogRef: MatDialogRef<ConfirmDialogComponent>,
-		@Inject(MAT_DIALOG_DATA) public data: { title: string; content: string; confirm: string }
+		@Inject(MAT_DIALOG_DATA) public data: { title: string; content: string; extraContent?: string; confirm: string }
 	) {
 		if (!data || !data.title || !data.content || !data.confirm) {
 			throw 'Something is missing in confirm dialog data';

--- a/app/mikane/src/app/features/mobile/category-item/category-item.component.html
+++ b/app/mikane/src/app/features/mobile/category-item/category-item.component.html
@@ -2,24 +2,24 @@
 	<mat-list-item (click)="toggleDropdown()">
 		<div class="upper">
 			<div class="leftside">
-				<mat-icon matListItemIcon class="category-icon">{{ category.icon ?? "shopping_cart" }}</mat-icon>
+				<mat-icon matListItemIcon class="category-icon">{{ category().icon ?? "shopping_cart" }}</mat-icon>
 				<mat-icon matListItemIcon class="dropdown-arrow">
 					{{ dropdownOpen ? "arrow_drop_up" : "arrow_drop_down" }}
 				</mat-icon>
 				<div>
-					<div class="number-of-participants">Number of participants: {{ category.users.length }}</div>
+					<div class="number-of-participants">Number of participants: {{ category().users.length }}</div>
 					<div class="name">
-						{{ category.name }}
+						{{ category().name }}
 					</div>
 				</div>
 			</div>
 			<button
 				mat-icon-button
 				class="expenses-button"
-				[disabled]="category.numberOfExpenses === 0"
+				[disabled]="category().numberOfExpenses === 0"
 				(click)="gotoExpenses(); $event.stopPropagation()"
 			>
-				<div class="count">{{ category.numberOfExpenses }}</div>
+				<div class="count">{{ category().numberOfExpenses }}</div>
 				<mat-icon class="icon">payment</mat-icon>
 			</button>
 		</div>
@@ -28,10 +28,10 @@
 		<div class="user header">
 			<span class="name"> User </span>
 			<span>
-				{{ category.weighted ? "Weight" : "" }}
+				{{ category().weighted ? "Weight" : "" }}
 			</span>
 		</div>
-		@for (user of category.users; track user.id) {
+		@for (user of category().users; track user.id) {
 			<mat-list-item>
 				<div class="user data">
 					<span class="name">
@@ -39,18 +39,18 @@
 						{{ user.name }}
 					</span>
 					<span>
-						{{ category.weighted ? user.weight : "" }}
+						{{ category().weighted ? user.weight : "" }}
 					</span>
-					@if (category.weighted && eventActive) {
-						<button mat-icon-button (click)="openEditWeight(category.id, user.id, user.weight)" class="button">
+					@if (category().weighted && eventActive()) {
+						<button mat-icon-button (click)="openEditWeight(category().id, user.id, user.weight)" class="button">
 							<mat-icon>edit</mat-icon>
 						</button>
 					}
-					@if (eventActive) {
+					@if (eventActive()) {
 						<button
 							mat-icon-button
-							(click)="removeUserFromCategory(category.id, user.id)"
-							[ngClass]="{ button: !category.weighted }"
+							(click)="removeUserFromCategory(category().id, user.id)"
+							[ngClass]="{ button: !category().weighted }"
 						>
 							<mat-icon>remove</mat-icon>
 						</button>
@@ -58,26 +58,26 @@
 				</div>
 			</mat-list-item>
 		}
-		@if (eventActive) {
-			@if (filterUsers(category.id).length !== 0) {
-				<form [formGroup]="addUserForm" class="new-user">
+		@if (eventActive()) {
+			@if (filterUsers()(category().id).length !== 0) {
+				<form [formGroup]="addUserForm()" class="new-user">
 					<div class="inputs">
-						<mat-form-field subscriptSizing="dynamic" [ngClass]="{ 'user-input-weighted': !category.weighted }">
+						<mat-form-field subscriptSizing="dynamic" [ngClass]="{ 'user-input-weighted': !category().weighted }">
 							<select
 								matNativeControl
-								[formControl]="addUserForm.get('participantName') | formControl"
+								[formControl]="addUserForm().get('participantName') | formControl"
 								name="participantName"
 								required
 							>
 								<option value="" disabled selected>Add participant</option>
-								@for (user of filterUsers(category.id); track user.id) {
+								@for (user of filterUsers()(category().id); track user.id) {
 									<option [value]="user.id">
 										{{ user.name }}
 									</option>
 								}
 							</select>
 						</mat-form-field>
-						@if (category.weighted) {
+						@if (category().weighted) {
 							<mat-form-field subscriptSizing="dynamic" class="weight-input">
 								<input
 									matInput
@@ -91,15 +91,15 @@
 							</mat-form-field>
 						}
 					</div>
-					@if (eventActive) {
+					@if (eventActive()) {
 						<button
 							mat-icon-button
 							type="button"
-							(click)="addUserToCategory(category.id)"
+							(click)="addUserToCategory(category().id)"
 							[disabled]="
-								addUserForm.get('participantName')?.invalid ||
-								!addUserForm.get('participantName')?.dirty ||
-								(category.weighted && addUserForm.get('weight')?.invalid)
+								addUserForm().get('participantName')?.invalid ||
+								!addUserForm().get('participantName')?.dirty ||
+								(category().weighted && addUserForm().get('weight')?.invalid)
 							"
 							class="add-user"
 						>
@@ -111,16 +111,16 @@
 				<div class="all-users-in-category">No more participants to add</div>
 			}
 		}
-		@if (eventActive) {
+		@if (eventActive()) {
 			<div class="sub-buttons">
-				<button mat-stroked-button color="accent" (click)="toggleWeightedCategory(category.id, category.weighted)">
+				<button mat-stroked-button color="accent" (click)="toggleWeightedCategory(category().id, category().weighted)">
 					Toggle weighted
 				</button>
 				<div>
-					<button mat-icon-button (click)="openEdit(category.id, category.name, category.icon)">
+					<button mat-icon-button (click)="openEdit(category().id, category().name, category().icon)">
 						<mat-icon>edit</mat-icon>
 					</button>
-					<button mat-icon-button [disabled]="category.numberOfExpenses !== 0" color="warn" (click)="deleteCategory(category.id)">
+					<button mat-icon-button [disabled]="category().numberOfExpenses !== 0" color="warn" (click)="deleteCategory(category().id)">
 						<mat-icon>delete</mat-icon>
 					</button>
 				</div>

--- a/app/mikane/src/app/features/mobile/category-item/category-item.component.spec.ts
+++ b/app/mikane/src/app/features/mobile/category-item/category-item.component.spec.ts
@@ -1,5 +1,6 @@
 import { ElementRef } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { FormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { Category } from 'src/app/services/category/category.service';
 import { User } from 'src/app/services/user/user.service';
@@ -31,7 +32,10 @@ describe('CategoryItemComponent', () => {
 			numberOfExpenses: 0,
 			created: new Date(),
 		} as Category;
-		component.category = category;
+		fixture.componentRef.setInput('category', category);
+		fixture.componentRef.setInput('eventActive', true);
+		fixture.componentRef.setInput('addUserForm', {} as FormGroup);
+		fixture.componentRef.setInput('filterUsers', () => ([] as User[]));
 		fixture.detectChanges();
 	});
 

--- a/app/mikane/src/app/features/mobile/category-item/category-item.component.ts
+++ b/app/mikane/src/app/features/mobile/category-item/category-item.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule, CurrencyPipe } from '@angular/common';
-import { Component, ElementRef, EventEmitter, Input, Output, Renderer2, ViewChild } from '@angular/core';
+import { Component, ElementRef, input, output, Renderer2, ViewChild } from '@angular/core';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -31,18 +31,18 @@ import { CategoryIcon } from 'src/app/types/enums';
 })
 export class CategoryItemComponent {
 	@ViewChild('lower') lower: ElementRef;
-	@Input() eventActive: boolean;
-	@Input() category: Category;
-	@Input() addUserForm: FormGroup;
-	@Input() filterUsers: (categoryId: string) => User[];
-	@Output() addUser = new EventEmitter<{ categoryId: string }>();
-	@Output() removeUser = new EventEmitter<{ categoryId: string; userId: string }>();
-	@Output() openEditCategoryDialog = new EventEmitter<{ categoryId: string; name: string; icon: CategoryIcon }>();
-	@Output() openWeightEditDialog = new EventEmitter<{ categoryId: string; userId: string; weight: number }>();
-	@Output() toggleWeighted = new EventEmitter<{ categoryId: string; weighted: boolean }>();
-	@Output() deleteCategoryDialog = new EventEmitter<{ categoryId: string }>();
-	@Output() gotoCategoryExpenses = new EventEmitter<{ category: Category }>();
-	@Output() gotoUser = new EventEmitter<{ user: { id: string, guest: boolean, username: string } }>();
+	category = input.required<Category>();
+	eventActive = input.required<boolean>();
+	addUserForm = input.required<FormGroup>();
+	filterUsers = input.required<(categoryId: string) => User[]>();
+	addUser = output<{ categoryId: string }>();
+	removeUser = output<{ categoryId: string; userId: string }>();
+	openEditCategoryDialog = output<{ categoryId: string; name: string; icon: CategoryIcon }>();
+	openWeightEditDialog = output<{ categoryId: string; userId: string; weight: number }>();
+	toggleWeighted = output<{ categoryId: string; weighted: boolean }>();
+	deleteCategoryDialog = output<{ categoryId: string }>();
+	gotoCategoryExpenses = output<{ category: Category }>();
+	gotoUser = output<{ user: { id: string, guest: boolean, username: string } }>();
 
 	dropdownOpen = false;
 	lowerHeight = 0;
@@ -88,7 +88,7 @@ export class CategoryItemComponent {
 	};
 
 	gotoExpenses = () => {
-		this.gotoCategoryExpenses.emit({ category: this.category });
+		this.gotoCategoryExpenses.emit({ category: this.category() });
 	};
 
 	gotoUserProfile = (user: { id: string, guest: boolean, username: string }) => {

--- a/app/mikane/src/app/features/mobile/event-item/event-item.component.html
+++ b/app/mikane/src/app/features/mobile/event-item/event-item.component.html
@@ -1,16 +1,16 @@
-<mat-list-item class="wrapper" [ngClass]="{ 'ready-to-settle': event.status.id === EventStatusType.READY_TO_SETTLE }">
+<mat-list-item class="wrapper" [ngClass]="{ 'ready-to-settle': event().status.id === EventStatusType.READY_TO_SETTLE }">
 	<div class="event-title">
-		<span class="title-text">{{ event.name }}</span>
-		@if (event.private) {
+		<span class="title-text">{{ event().name }}</span>
+		@if (event().private) {
 			<mat-icon	matTooltip="This event is private" [matTooltipShowDelay]="200" class="joined-icon">	passkey	</mat-icon>
-		} @else if (event.userInfo.inEvent) {
+		} @else if (event().userInfo.inEvent) {
 			<mat-icon matTooltip="You are in this event" [matTooltipShowDelay]="200" class="joined-icon"> how_to_reg </mat-icon>
 		}
-		@if (event.userInfo.isAdmin) {
+		@if (event().userInfo.isAdmin) {
 			<span matTooltip="You are an admin for this event" [matTooltipShowDelay]="200" class="admin-icon"> A </span>
 		}
 	</div>
 	<div class="description">
-		{{ event.status.id === EventStatusType.READY_TO_SETTLE ? "READY TO SETTLE" : event.description }}
+		{{ event().status.id === EventStatusType.READY_TO_SETTLE ? "READY TO SETTLE" : event().description }}
 	</div>
 </mat-list-item>

--- a/app/mikane/src/app/features/mobile/event-item/event-item.component.ts
+++ b/app/mikane/src/app/features/mobile/event-item/event-item.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -13,6 +13,6 @@ import { EventStatusType, PuddingEvent } from 'src/app/services/event/event.serv
 	imports: [CommonModule, MatIconModule, MatListModule, MatTooltipModule],
 })
 export class EventItemComponent {
-	@Input() event: PuddingEvent;
+	event = input.required<PuddingEvent>();
 	readonly EventStatusType = EventStatusType;
 }

--- a/app/mikane/src/app/features/mobile/expense-item/expense-item.component.html
+++ b/app/mikane/src/app/features/mobile/expense-item/expense-item.component.html
@@ -1,16 +1,16 @@
 <mat-list-item class="wrapper" (click)="gotoExpense()">
-	<mat-icon matListItemIcon class="expense-icon">{{ expense.categoryInfo?.icon ?? "shopping_cart" }}</mat-icon>
+	<mat-icon matListItemIcon class="expense-icon">{{ expense().categoryInfo?.icon ?? "shopping_cart" }}</mat-icon>
 	<div class="price-category">
-		<span class="amount-color-darker">{{ expense.amount | currency : "" : "" : "1.2-2" : "no" }} kr</span>
-		<span class="category"> / {{ expense.categoryInfo?.name }} </span>
+		<span class="amount-color-darker">{{ expense().amount | currency : "" : "" : "1.2-2" : "no" }} kr</span>
+		<span class="category"> / {{ expense().categoryInfo?.name }} </span>
 	</div>
 	<div class="title">
-		{{ expense.name }}
+		{{ expense().name }}
 	</div>
 	<div class="payer">
-		<img [src]="expense.payer?.avatarURL" alt="User avatar" class="payer-avatar" />
+		<img [src]="expense().payer?.avatarURL" alt="User avatar" class="payer-avatar" />
 		<span class="payer-name">
-			{{ expense.payer?.name }}
+			{{ expense().payer?.name }}
 		</span>
 	</div>
 </mat-list-item>

--- a/app/mikane/src/app/features/mobile/expense-item/expense-item.component.spec.ts
+++ b/app/mikane/src/app/features/mobile/expense-item/expense-item.component.spec.ts
@@ -46,7 +46,7 @@ describe('ExpenseItemComponent', () => {
 				icon: 'shopping',
 			},
 		} as Expense;
-		component.expense = expense;
+		fixture.componentRef.setInput('expense', expense);
 		fixture.detectChanges();
 	});
 
@@ -85,7 +85,7 @@ describe('ExpenseItemComponent', () => {
 	});
 
 	it('should show shopping cart icon if category is not set', () => {
-		component.expense.categoryInfo = null;
+		component.expense().categoryInfo = null;
 		fixture.detectChanges();
 		const iconEl = fixture.debugElement.query(By.css('.expense-icon')).nativeElement;
 

--- a/app/mikane/src/app/features/mobile/expense-item/expense-item.component.ts
+++ b/app/mikane/src/app/features/mobile/expense-item/expense-item.component.ts
@@ -1,5 +1,5 @@
 import { CurrencyPipe } from '@angular/common';
-import { Component, Input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -13,12 +13,12 @@ import { Expense } from 'src/app/services/expense/expense.service';
 	imports: [MatIconModule, CurrencyPipe, MatListModule],
 })
 export class ExpenseItemComponent {
-	@Input() expense: Expense;
+	expense = input.required<Expense>();
 
 	constructor(private router: Router, private route: ActivatedRoute) {}
 
 	gotoExpense() {
-		this.router.navigate([this.expense.id], {
+		this.router.navigate([this.expense().id], {
 			relativeTo: this.route,
 			queryParams: { ...this.route.snapshot.queryParams }
 		});

--- a/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.html
+++ b/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.html
@@ -3,8 +3,8 @@
 		<a
 			class="nav-button"
 			[routerLink]="link.location"
-			(click)="activeLink = link.location"
-			[ngClass]="{ active: activeLink.includes(link.location), 'nav-back-button': link.location === '/events' }"
+			(click)="activeLink.set(link.location)"
+			[ngClass]="{ active: activeLink().includes(link.location), 'nav-back-button': link.location === '/events' }"
 			matRipple
 		>
 			<mat-icon [ngClass]="{ 'back-icon': link.location === '/events' }">{{ link.icon }}</mat-icon>

--- a/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.spec.ts
+++ b/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.spec.ts
@@ -27,7 +27,7 @@ describe('MobileEventNavbarComponent', () => {
 	beforeEach(() => {
 		fixture = TestBed.createComponent(MobileEventNavbarComponent);
 		component = fixture.componentInstance;
-		component.activeLink = '/events';
+		fixture.componentRef.setInput('activeLink', '/events');
 		fixture.componentRef.setInput('links', [
 			{ name: 'Link 1', icon: 'icon1', location: '/link1' },
 			{ name: 'Link 2', icon: 'icon2', location: '/link2' },
@@ -54,6 +54,6 @@ describe('MobileEventNavbarComponent', () => {
 	it('should set the active class on the active link', () => {
 		const activeLinkEl = fixture.debugElement.query(By.css('.active')).nativeElement;
 
-		expect(activeLinkEl.getAttribute('href')).toEqual(component.activeLink);
+		expect(activeLinkEl.getAttribute('href')).toEqual(component.activeLink());
 	});
 });

--- a/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.ts
+++ b/app/mikane/src/app/features/mobile/mobile-event-navbar/mobile-event-navbar.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, Input, input } from '@angular/core';
+import { Component, computed, input, model } from '@angular/core';
 import { MatRippleModule } from '@angular/material/core';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterLink, RouterOutlet } from '@angular/router';
@@ -19,7 +19,7 @@ interface Route {
 	imports: [CommonModule, RouterLink, RouterOutlet, MatIconModule, MatRippleModule],
 })
 export class MobileEventNavbarComponent {
-	@Input() activeLink: string;
+	activeLink = model.required<string>();
 	links = input.required<Route[]>();
 
 	mobileLinks = computed(() => {

--- a/app/mikane/src/app/features/mobile/participant-item/participant-item.component.html
+++ b/app/mikane/src/app/features/mobile/participant-item/participant-item.component.html
@@ -1,15 +1,15 @@
 <mat-list-item class="wrapper">
 	<div class="upper">
 		<div class="title">
-			<img [src]="userBalance.user.avatarURL" alt="User avatar" class="avatar" (click)="gotoUserProfile(); $event.stopPropagation()" />
+			<img [src]="userBalance().user.avatarURL" alt="User avatar" class="avatar" (click)="gotoUserProfile(); $event.stopPropagation()" />
 			<div>
-				<div class="number-of-expenses">Number of expenses: {{ userBalance.expensesCount }}</div>
+				<div class="number-of-expenses">Number of expenses: {{ userBalance().expensesCount }}</div>
 				<div class="name">
-					{{ userBalance.user.name }}
+					{{ userBalance().user.name }}
 				</div>
 			</div>
 		</div>
-		@if (eventActive && userBalance.expensesCount === 0) {
+		@if (eventActive() && numberOfParticipants() > 1 && userBalance().expensesCount === 0 && (numberOfAdmins() > 1 || !userBalance().user.eventInfo.isAdmin)) {
 			<button	mat-icon-button (click)="removeUserFromEvent(); $event.stopPropagation()">
 				<mat-icon>remove</mat-icon>
 			</button>
@@ -19,15 +19,15 @@
 		<div class="balances">
 			<div>
 				<span class="text">Spending:</span>
-				<span> {{ userBalance.spending | currency : "" : "" : "1.2-2" : "no" }} kr </span>
+				<span> {{ userBalance().spending | currency : "" : "" : "1.2-2" : "no" }} kr </span>
 			</div>
 			<div>
 				<span class="text">Expenses:</span>
-				<span> {{ userBalance.expenses | currency : "" : "" : "1.2-2" : "no" }} kr </span>
+				<span> {{ userBalance().expenses | currency : "" : "" : "1.2-2" : "no" }} kr </span>
 			</div>
 			<div>
 				<span class="text">Balance:</span>
-				<span class="amount-color"> {{ userBalance.balance | currency : "" : "" : "1.2-2" : "no" }} kr </span>
+				<span class="amount-color"> {{ userBalance().balance | currency : "" : "" : "1.2-2" : "no" }} kr </span>
 			</div>
 		</div>
 	</div>

--- a/app/mikane/src/app/features/mobile/participant-item/participant-item.component.ts
+++ b/app/mikane/src/app/features/mobile/participant-item/participant-item.component.ts
@@ -1,5 +1,5 @@
 import { CurrencyPipe } from '@angular/common';
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
@@ -13,16 +13,18 @@ import { User, UserBalance } from 'src/app/services/user/user.service';
 	imports: [MatButtonModule, MatIconModule, CurrencyPipe, MatListModule],
 })
 export class ParticipantItemComponent {
-	@Input() userBalance: UserBalance;
-	@Input() eventActive: boolean;
-	@Output() gotoUser = new EventEmitter<{ user: User }>();
-	@Output() removeUser = new EventEmitter<{ userId: string }>();
+	userBalance = input.required<UserBalance>();
+	eventActive = input.required<boolean>();
+	numberOfParticipants = input.required<number>();
+	numberOfAdmins = input.required<number>();
+	gotoUser = output<{ user: User}>();
+	removeUser = output<{ userId: string }>();
 
 	gotoUserProfile() {
-		this.gotoUser.emit({ user: this.userBalance.user });
+		this.gotoUser.emit({ user: this.userBalance().user });
 	}
 
 	removeUserFromEvent() {
-		this.removeUser.emit({ userId: this.userBalance.user.id });
+		this.removeUser.emit({ userId: this.userBalance().user.id });
 	}
 }

--- a/app/mikane/src/app/features/mobile/payment-item/payment-item.component.html
+++ b/app/mikane/src/app/features/mobile/payment-item/payment-item.component.html
@@ -2,27 +2,27 @@
 	<mat-list-item (click)="toggleDropdown()">
 		<div class="upper">
 			<img
-				[src]="payment.sender.avatarURL"
+				[src]="payment().sender.avatarURL"
 				alt="Sender avatar"
 				class="avatar"
-				[ngClass]="{ 'clickable': !payment.sender.guest }"
-				(click)="gotoUserProfile(payment.sender)"
+				[ngClass]="{ 'clickable': !payment().sender.guest }"
+				(click)="gotoUserProfile(payment().sender)"
 			/>
 			<mat-icon matListItemIcon class="dropdown-arrow">
 				{{ dropdownOpen ? "arrow_drop_up" : "arrow_drop_down" }}
 			</mat-icon>
 			<div>
 				<div class="name">
-					{{ self && payment.sender.id === currentUser.id ? "You" : payment.sender.name }}
+					{{ self() && payment().sender.id === currentUser().id ? "You" : payment().sender.name }}
 				</div>
 				<div class="subtext">
-					{{ self && payment.sender.id === currentUser.id ? "Owe money to..." : "Owes money to..." }}
+					{{ self() && payment().sender.id === currentUser().id ? "Owe money to..." : "Owes money to..." }}
 				</div>
 			</div>
 		</div>
 	</mat-list-item>
 	<div #lower class="lower" [style.height.px]="lowerHeight">
-		@for (receiver of payment.receivers; track receiver.receiver.id) {
+		@for (receiver of payment().receivers; track receiver.receiver.id) {
 			<mat-list-item>
 				<div class="payment">
 					<span class="name">
@@ -34,8 +34,8 @@
 							(click)="gotoUserProfile(receiver.receiver)"
 						/>
 						<div>
-							{{ self && receiver.receiver.id === currentUser.id ? "You" : receiver.receiver.name }}
-							@if (self && payment.sender.id === currentUser.id && receiver.receiver.phone) {
+							{{ self() && receiver.receiver.id === currentUser().id ? "You" : receiver.receiver.name }}
+							@if (self() && payment().sender.id === currentUser().id && receiver.receiver.phone) {
 								<div class="phone-number">
 									{{ receiver.receiver.phone.slice(0, 2) + ' ' + receiver.receiver.phone.slice(2, 4) + ' ' + receiver.receiver.phone.slice(4, 6) + ' ' + receiver.receiver.phone.slice(6) }}
 								</div>

--- a/app/mikane/src/app/features/mobile/payment-item/payment-item.component.spec.ts
+++ b/app/mikane/src/app/features/mobile/payment-item/payment-item.component.spec.ts
@@ -44,15 +44,15 @@ describe('PaymentItemComponent', () => {
 	beforeEach(() => {
 		fixture = TestBed.createComponent(PaymentItemComponent);
 		component = fixture.componentInstance;
-		component.payment = {
+		fixture.componentRef.setInput('payment', {
 			sender: { id: '1', name: 'Sender' } as User,
 			receivers: [
 				{ receiver: { id: '2', name: 'Receiver 1' } as User, amount: 50 },
 				{ receiver: { id: '3', name: 'Receiver 2' } as User, amount: 50 },
 			],
-		};
-		component.self = false;
-		component.currentUser = { id: '1', name: 'Sender' } as User;
+		});
+		fixture.componentRef.setInput('self', false);
+		fixture.componentRef.setInput('currentUser', { id: '1', name: 'Sender' } as User);
 		fixture.detectChanges();
 	});
 
@@ -63,18 +63,18 @@ describe('PaymentItemComponent', () => {
 	it('should display the sender name', () => {
 		const senderNameEl = fixture.debugElement.query(By.css('.upper .name')).nativeElement;
 
-		expect(senderNameEl.textContent).toContain(component.payment.sender.name);
+		expect(senderNameEl.textContent).toContain(component.payment().sender.name);
 	});
 
 	it('should display the correct number of receivers', () => {
 		const receiverEls = fixture.debugElement.queryAll(By.css('.lower .name'));
 
-		expect(receiverEls.length).toEqual(component.payment.receivers.length);
+		expect(receiverEls.length).toEqual(component.payment().receivers.length);
 	});
 
 	it('should display the correct receiver name and amount', () => {
 		const receiverEls = fixture.debugElement.queryAll(By.css('.payment'));
-		component.payment.receivers.forEach((receiver, index) => {
+		component.payment().receivers.forEach((receiver, index) => {
 			const nameEl = receiverEls[index].query(By.css('.name')).nativeElement;
 			const amountEl = receiverEls[index].query(By.css('.amount-color')).nativeElement;
 
@@ -109,7 +109,7 @@ describe('PaymentItemComponent', () => {
 	});
 
 	it('should set lowerHeight to scrollHeight when self is true', fakeAsync(() => {
-		component.self = true;
+		fixture.componentRef.setInput('self', true);
 		component.lower = { nativeElement: { scrollHeight: 100 } } as ElementRef;
 		component.ngOnInit();
 		fixture.detectChanges();

--- a/app/mikane/src/app/features/mobile/payment-item/payment-item.component.ts
+++ b/app/mikane/src/app/features/mobile/payment-item/payment-item.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule, CurrencyPipe } from '@angular/common';
-import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, input, OnInit, ViewChild } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -30,15 +30,15 @@ import { FormControlPipe } from 'src/app/shared/forms/form-control.pipe';
 })
 export class PaymentItemComponent implements OnInit {
 	@ViewChild('lower') lower: ElementRef;
-	@Input() payment: {
+	payment = input.required<{
 		sender: User;
 		receivers: Array<{
 			receiver: User;
 			amount: number;
 		}>;
-	};
-	@Input() self: boolean;
-	@Input() currentUser: User;
+	}>();
+	self = input.required<boolean>();
+	currentUser = input.required<User>();
 
 	dropdownOpen: boolean;
 	lowerHeight: number | string;
@@ -48,8 +48,8 @@ export class PaymentItemComponent implements OnInit {
 	) {}
 
 	ngOnInit(): void {
-		this.dropdownOpen = this.self ? true : false;
-		this.lowerHeight = this.self ? 'auto' : 0;
+		this.dropdownOpen = this.self() ? true : false;
+		this.lowerHeight = this.self() ? 'auto' : 0;
 		if (this.lowerHeight === 'auto') {
 			setTimeout(() => {
 				this.lowerHeight = this.lower.nativeElement.scrollHeight;

--- a/app/mikane/src/app/features/split-button/split-button-item/split-button-item.component.html
+++ b/app/mikane/src/app/features/split-button/split-button-item/split-button-item.component.html
@@ -1,4 +1,4 @@
 <a (keyup)="onEnter($event)" tabindex="0" (click)="onClick()" matRipple>
-	<mat-icon aria-hidden="true" class="icon">{{ icon }}</mat-icon>
-	<span class="text">{{ text }}</span>
+	<mat-icon aria-hidden="true" class="icon">{{ icon() }}</mat-icon>
+	<span class="text">{{ text() }}</span>
 </a>

--- a/app/mikane/src/app/features/split-button/split-button-item/split-button-item.component.spec.ts
+++ b/app/mikane/src/app/features/split-button/split-button-item/split-button-item.component.spec.ts
@@ -18,6 +18,8 @@ describe('SplitButtonItemComponent', () => {
 	beforeEach(() => {
 		fixture = TestBed.createComponent(SplitButtonItemComponent);
 		component = fixture.componentInstance;
+		fixture.componentRef.setInput('icon', 'test-icon');
+		fixture.componentRef.setInput('text', 'test-text');
 		fixture.detectChanges();
 	});
 
@@ -42,16 +44,12 @@ describe('SplitButtonItemComponent', () => {
 	});
 
 	it('should display the correct icon', () => {
-		component.icon = 'test-icon';
-		fixture.detectChanges();
 		const iconEl = fixture.debugElement.query(By.css('.icon')).nativeElement;
 
 		expect(iconEl.textContent).toContain('test-icon');
 	});
 
 	it('should display the correct text', () => {
-		component.text = 'test-text';
-		fixture.detectChanges();
 		const textEl = fixture.debugElement.query(By.css('.text')).nativeElement;
 
 		expect(textEl.textContent).toContain('test-text');

--- a/app/mikane/src/app/features/split-button/split-button-item/split-button-item.component.ts
+++ b/app/mikane/src/app/features/split-button/split-button-item/split-button-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { MatRippleModule } from '@angular/material/core';
 import { MatIconModule } from '@angular/material/icon';
 
@@ -10,9 +10,9 @@ import { MatIconModule } from '@angular/material/icon';
 	imports: [MatIconModule, MatRippleModule],
 })
 export class SplitButtonItemComponent {
-	@Output() splitButtonClick = new EventEmitter();
-	@Input() icon = '';
-	@Input() text = '';
+	splitButtonClick = output();
+	icon = input.required<string>();
+	text = input.required<string>();
 
 	onEnter($event?: KeyboardEvent) {
 		if ($event.key === 'Enter' || $event.key === ' ') {

--- a/app/mikane/src/app/features/split-button/split-button.component.ts
+++ b/app/mikane/src/app/features/split-button/split-button.component.ts
@@ -1,6 +1,6 @@
 import { animate, style, transition, trigger } from '@angular/animations';
 import { CommonModule } from '@angular/common';
-import { Component, ContentChildren, ElementRef, EventEmitter, HostListener, Output, QueryList } from '@angular/core';
+import { Component, ContentChildren, ElementRef, HostListener, output, QueryList } from '@angular/core';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatIconModule } from '@angular/material/icon';
 import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.service';
@@ -20,7 +20,7 @@ import { SplitButtonItemDirective } from './split-button-item/split-button-item.
 	imports: [CommonModule, MatButtonToggleModule, MatIconModule],
 })
 export class SplitButtonComponent {
-	@Output() splitButtonClick = new EventEmitter();
+	splitButtonClick = output();
 	@ContentChildren(SplitButtonItemDirective) items: QueryList<SplitButtonItemDirective>;
 	@HostListener('document:click', ['$event.target']) outsideClick(target: HTMLElement) {
 		if (!this.toggled) {

--- a/app/mikane/src/app/pages/category/category.component.html
+++ b/app/mikane/src/app/pages/category/category.component.html
@@ -175,19 +175,19 @@
 											<button
 												mat-raised-button
 												type="button"
+												color="accent"
+												(click)="toggleWeighted(category.id, category.weighted)"
+											>
+												Toggle weighted
+											</button>
+											<button
+												mat-raised-button
+												type="button"
 												color="primary"
 												(click)="openEditCategoryDialog(category.id, category.name, category.icon)"
 											>
 												Edit category
 												<mat-icon>edit</mat-icon>
-											</button>
-											<button
-												mat-raised-button
-												type="button"
-												color="accent"
-												(click)="toggleWeighted(category.id, category.weighted)"
-											>
-												Toggle weighted
 											</button>
 											@if (category.numberOfExpenses === 0) {
 												<button

--- a/app/mikane/src/app/pages/event-info/event-info.component.html
+++ b/app/mikane/src/app/pages/event-info/event-info.component.html
@@ -55,14 +55,16 @@
 		{{ event?.status.name }}
 	</button>
 	<div>
-		@if (event?.status.id === EventStatusType.ACTIVE) {
-			This event is currently <b>active</b>, allowing participants to add to or modify it as needed. Once the event is ready for settlement, it will transition to 'ready to settle' status.
-		}
-		@else if (event?.status.id === EventStatusType.READY_TO_SETTLE) {
-			This event is currently <b>ready to settle</b>. Once all participants have completed their payments, the event will be marked as settled.
-		}
-		@else {
-			This event is currently marked as <b>settled</b>, indicating that all participants have completed their payments, and the event has been finalized.
+		@switch (event?.status.id) {
+			@case (EventStatusType.ACTIVE) {
+				This event is currently <b>active</b>, allowing participants to add to or modify it as needed. Once the event is ready for settlement, it will transition to 'ready to settle' status.
+			}
+			@case (EventStatusType.READY_TO_SETTLE) {
+				This event is currently <b>ready to settle</b>. Once all participants have completed their payments, the event will be marked as settled.
+			}
+			@case (EventStatusType.SETTLED) {
+				This event is currently marked as <b>settled</b>, indicating that all participants have completed their payments, and the event has been finalized.
+			}
 		}
 	</div>
 </ng-template>

--- a/app/mikane/src/app/pages/event-info/event-info.component.html
+++ b/app/mikane/src/app/pages/event-info/event-info.component.html
@@ -10,16 +10,34 @@
 						<mat-card-title>Event information</mat-card-title>
 					</mat-card-header>
 					<mat-card-content>
-						<div class="header">Event admins</div>
+						<div class="header">Status</div>
+						<div class="event-info-content">
+							<ng-container *ngTemplateOutlet="statusContent"></ng-container>
+						</div>
+						<div class="header">Privacy</div>
+						<div class="event-info-content">
+							<ng-container *ngTemplateOutlet="privacyContent"></ng-container>
+						</div>
+						<div class="header">Administrators</div>
 						<div class="event-info-content">
 							<ng-container *ngTemplateOutlet="adminsContent"></ng-container>
 						</div>
 					</mat-card-content>
 				</mat-card>
 			</div>
-		} @else {
-			<div class="header-mobile admins">Event admins</div>
-			<div class="admins">
+		}
+		<!-- Mobile -->
+		@else {
+			<div class="header-mobile">Status</div>
+			<div class="event-info-content">
+				<ng-container *ngTemplateOutlet="statusContent"></ng-container>
+			</div>
+			<div class="header-mobile">Privacy</div>
+			<div class="event-info-content">
+				<ng-container *ngTemplateOutlet="privacyContent"></ng-container>
+			</div>
+			<div class="header-mobile">Administrators</div>
+			<div class="event-admins-content-mobile">
 				<ng-container *ngTemplateOutlet="adminsContent"></ng-container>
 			</div>
 		}
@@ -28,9 +46,50 @@
 	<app-loading-spinner></app-loading-spinner>
 }
 
+<ng-template #statusContent>
+	<button
+		mat-stroked-button
+		disabled
+		class="event-info-marker"
+	>
+		{{ event?.status.name }}
+	</button>
+	<div>
+		@if (event?.status.id === EventStatusType.ACTIVE) {
+			This event is currently <b>active</b>, allowing participants to add to or modify it as needed. Once the event is ready for settlement, it will transition to 'ready to settle' status.
+		}
+		@else if (event?.status.id === EventStatusType.READY_TO_SETTLE) {
+			This event is currently <b>ready to settle</b>. Once all participants have completed their payments, the event will be marked as settled.
+		}
+		@else {
+			This event is currently marked as <b>settled</b>, indicating that all participants have completed their payments, and the event has been finalized.
+		}
+	</div>
+</ng-template>
+
+<ng-template #privacyContent>
+	<button
+		mat-stroked-button
+		type="button"
+		color="accent"
+		disabled
+		class="event-info-marker"
+	>
+		{{ event?.private ? 'Private' : 'Public' }}
+	</button>
+	<div>
+		@if (event?.private) {
+			This event is marked as <b>private</b>, meaning only participants have access to it. To view this event, a user must be added by an existing participant.
+		}
+		@else {
+			This event is marked as <b>public</b>, meaning all users can view the event and join or leave at their convenience.
+		}
+	</div>
+</ng-template>
+
 <ng-template #adminsContent>
-	<div [ngClass]="{ 'info-full-view': breakpointService.isMobile() | async }">
-		If you need to change anything regarding this event, please contact one of the admins listed below:
+	<div [ngClass]="{ 'info-mobile': breakpointService.isMobile() | async }">
+		If any changes are needed for this event, please reach out to one of the administrators listed below:
 	</div>
 	<div class="admins-content" [ngClass]="{ 'full-view': (breakpointService.isMobile() | async) === false }">
 		<mat-nav-list>

--- a/app/mikane/src/app/pages/event-info/event-info.component.scss
+++ b/app/mikane/src/app/pages/event-info/event-info.component.scss
@@ -5,8 +5,9 @@
 	margin-top: 2em;
 
 	.card {
-		width: 30vw;
+		width: 40vw;
 		min-width: 40em;
+		max-width: 50em;
 
 		.header {
 			padding: 12px 16px;
@@ -21,10 +22,15 @@
 .event-info-content {
 	padding-left: 16px;
 	padding-right: 16px;
+	margin-bottom: 30px;
 }
 
-.info-full-view {
-	margin: 20px 14px 10px;
+.event-admins-content-mobile {
+	margin-bottom: 90px;
+}
+
+.info-mobile {
+	margin: 20px 14px 6px;
 }
 
 .admins-content {

--- a/app/mikane/src/app/pages/event-info/event-info.component.ts
+++ b/app/mikane/src/app/pages/event-info/event-info.component.ts
@@ -12,7 +12,7 @@ import { Router } from '@angular/router';
 import { BehaviorSubject, Subscription, combineLatest, filter, switchMap } from 'rxjs';
 import { AuthService } from 'src/app/services/auth/auth.service';
 import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.service';
-import { PuddingEvent } from 'src/app/services/event/event.service';
+import { EventStatusType, PuddingEvent } from 'src/app/services/event/event.service';
 import { MessageService } from 'src/app/services/message/message.service';
 import { User, UserService } from 'src/app/services/user/user.service';
 import { EventNameValidatorDirective } from 'src/app/shared/forms/validators/async-event-name.validator';
@@ -48,6 +48,7 @@ export class EventInfoComponent implements OnInit, OnDestroy {
 	currentUser: User;
 
 	private eventSubscription: Subscription;
+	readonly EventStatusType = EventStatusType;
 
 	constructor(
 		private router: Router,

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.html
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.html
@@ -39,7 +39,7 @@
 				<ng-container *ngTemplateOutlet="statusContent"></ng-container>
 			</div>
 			<div class="header-mobile admins">Manage administrators</div>
-			<div class="admins22222222">
+			<div>
 				<ng-container *ngTemplateOutlet="adminsContent"></ng-container>
 			</div>
 			<div class="header-mobile">Delete event</div>
@@ -117,31 +117,35 @@
 	>
 		{{ event?.status.name }}
 	</button>
-	@if (event?.status.id === EventStatusType.ACTIVE) {
-		<div>
-			<div class="event-settings-text">
-				This event is currently <b>active</b>. Setting it as 'ready to settle' will prevent further edits and prompt participants to settle their payments.
+	@switch (event?.status.id) {
+		@case (EventStatusType.ACTIVE) {
+			<div>
+				<div class="event-settings-text">
+					This event is currently <b>active</b>. Setting it as 'ready to settle' will prevent further edits and prompt participants to settle their payments.
+				</div>
+				<button mat-raised-button color="primary" (click)="setStatus(EventStatusType.READY_TO_SETTLE)" class="status-button">
+					Set event as ready to settle
+				</button>
 			</div>
-			<button mat-raised-button color="primary" (click)="setStatus(EventStatusType.READY_TO_SETTLE)" class="status-button">
-				Set event as ready to settle
-			</button>
-		</div>
-	} @else if (event?.status.id === EventStatusType.READY_TO_SETTLE) {
-		<div>
-			<div class="event-settings-text">
-				This event is currently <b>ready to settled</b>. Once all participants have settled their payments, the event should be
-				set as settled. Should any changes be neccessary, set the event as active again.
+		}
+		@case (EventStatusType.READY_TO_SETTLE) {
+			<div>
+				<div class="event-settings-text">
+					This event is currently <b>ready to settled</b>. Once all participants have settled their payments, the event should be
+					set as settled. Should any changes be neccessary, set the event as active again.
+				</div>
+				<button mat-raised-button color="primary" (click)="setStatus(EventStatusType.SETTLED)" class="status-button">
+					Set event as settled
+				</button>
+				<button mat-raised-button color="accent" (click)="setStatus(EventStatusType.ACTIVE)" class="status-button">Set event as active</button>
 			</div>
-			<button mat-raised-button color="primary" (click)="setStatus(EventStatusType.SETTLED)" class="status-button">
-				Set event as settled
-			</button>
+		}
+		@case (EventStatusType.SETTLED) {
+			<div class="event-settings-text">
+				This event is currently <b>settled</b>. Set it to active to allow participants to edit it again.
+			</div>
 			<button mat-raised-button color="accent" (click)="setStatus(EventStatusType.ACTIVE)" class="status-button">Set event as active</button>
-		</div>
-	} @else {
-		<div class="event-settings-text">
-			This event is currently <b>settled</b>. Set it to active to allow participants to edit it again.
-		</div>
-		<button mat-raised-button color="accent" (click)="setStatus(EventStatusType.ACTIVE)" class="status-button">Set event as active</button>
+		}
 	}
 </ng-template>
 

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.html
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.html
@@ -18,7 +18,7 @@
 						<div class="event-settings-content settle">
 							<ng-container *ngTemplateOutlet="statusContent"></ng-container>
 						</div>
-						<div class="header">Manage admins</div>
+						<div class="header">Manage administrators</div>
 						<div class="event-settings-content admins">
 							<ng-container *ngTemplateOutlet="adminsContent"></ng-container>
 						</div>
@@ -29,15 +29,17 @@
 					</mat-card-content>
 				</mat-card>
 			</div>
-		} @else {
+		} 
+		<!-- Mobile -->
+		@else {
 			<div class="header-mobile">Edit event</div>
 			<ng-container *ngTemplateOutlet="editContent"></ng-container>
 			<div class="header-mobile">Change status</div>
 			<div class="event-settings-content settle">
 				<ng-container *ngTemplateOutlet="statusContent"></ng-container>
 			</div>
-			<div class="header-mobile admins">Manage admins</div>
-			<div class="admins">
+			<div class="header-mobile admins">Manage administrators</div>
+			<div class="admins22222222">
 				<ng-container *ngTemplateOutlet="adminsContent"></ng-container>
 			</div>
 			<div class="header-mobile">Delete event</div>
@@ -108,33 +110,38 @@
 </ng-template>
 
 <ng-template #statusContent>
+	<button
+		mat-stroked-button
+		disabled
+		class="event-info-marker"
+	>
+		{{ event?.status.name }}
+	</button>
 	@if (event?.status.id === EventStatusType.ACTIVE) {
 		<div>
 			<div class="event-settings-text">
 				This event is currently <b>active</b>. Setting it as 'ready to settle' will prevent further edits and prompt participants to settle their payments.
 			</div>
-			<button mat-raised-button color="primary" (click)="setStatus(EventStatusType.READY_TO_SETTLE)">
+			<button mat-raised-button color="primary" (click)="setStatus(EventStatusType.READY_TO_SETTLE)" class="status-button">
 				Set event as ready to settle
 			</button>
 		</div>
-	} @else {
-		@if (event?.status.id === EventStatusType.READY_TO_SETTLE) {
-			<div>
-				<div class="event-settings-text">
-					This event is currently <b>ready to settle</b>. Once all participants have settled their payments, the event should be
-					set as settled. Should any changes be neccessary, set the event as active again.
-				</div>
-				<button mat-raised-button color="primary" (click)="setStatus(EventStatusType.SETTLED)" class="status-button">
-					Set event as settled
-				</button>
-				<button mat-raised-button color="accent" (click)="setStatus(EventStatusType.ACTIVE)" class="status-button">Set event as active</button>
-			</div>
-		} @else {
+	} @else if (event?.status.id === EventStatusType.READY_TO_SETTLE) {
+		<div>
 			<div class="event-settings-text">
-				This event is currently <b>settled</b>. Set it to active to allow participants to edit it again.
+				This event is currently <b>ready to settled</b>. Once all participants have settled their payments, the event should be
+				set as settled. Should any changes be neccessary, set the event as active again.
 			</div>
-			<button mat-raised-button color="accent" (click)="setStatus(EventStatusType.ACTIVE)">Set event as active</button>
-		}
+			<button mat-raised-button color="primary" (click)="setStatus(EventStatusType.SETTLED)" class="status-button">
+				Set event as settled
+			</button>
+			<button mat-raised-button color="accent" (click)="setStatus(EventStatusType.ACTIVE)" class="status-button">Set event as active</button>
+		</div>
+	} @else {
+		<div class="event-settings-text">
+			This event is currently <b>settled</b>. Set it to active to allow participants to edit it again.
+		</div>
+		<button mat-raised-button color="accent" (click)="setStatus(EventStatusType.ACTIVE)" class="status-button">Set event as active</button>
 	}
 </ng-template>
 
@@ -164,7 +171,7 @@
 		<div class="add-admin" [ngClass]="{ mobile: breakpointService.isMobile() | async }">
 			@if (otherUsersInEvent.length !== 0) {
 				<mat-form-field>
-					<mat-select [formControl]="addAdminForm.get('userId') | formControl" name="userId" placeholder="Add admins" required>
+					<mat-select [formControl]="addAdminForm.get('userId') | formControl" name="userId" placeholder="Add admin" required>
 						@for (user of otherUsersInEvent; track user.id) {
 							<mat-option [value]="user.id">
 								<span class="name">

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.scss
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.scss
@@ -7,6 +7,7 @@
 	.card {
 		width: 40vw;
 		min-width: 40em;
+		max-width: 57em;
 
 		.header {
 			padding: 12px 16px;
@@ -145,6 +146,10 @@
 .header-mobile {
 	height: 50px;
 	margin-bottom: 20px;
+
+	&.admins {
+		margin-bottom: 0 !important;
+	}
 }
 
 .event-settings-text {

--- a/app/mikane/src/app/pages/events/event/event.component.html
+++ b/app/mikane/src/app/pages/events/event/event.component.html
@@ -25,8 +25,8 @@
 			<a
 				mat-tab-link
 				[routerLink]="link.location"
-				(click)="activeLink = link.location"
-				[active]="activeLink.includes(link.location)"
+				(click)="activeLink.set(link.location)"
+				[active]="activeLink().includes(link.location)"
 				[ngClass]="{ 'settings-tab': link.name === 'Settings' || link.name === 'Info' }"
 			>
 				@if (link.name === "Settings" || link.name === "Info") {
@@ -41,7 +41,7 @@
 		}
 	</nav>
 } @else {
-	<app-mobile-event-navbar [activeLink]="activeLink" [links]="links()"></app-mobile-event-navbar>
+	<app-mobile-event-navbar [activeLink]="activeLink()" [links]="links()"></app-mobile-event-navbar>
 }
 <mat-tab-nav-panel #tabPanel></mat-tab-nav-panel>
 <div

--- a/app/mikane/src/app/pages/events/event/event.component.ts
+++ b/app/mikane/src/app/pages/events/event/event.component.ts
@@ -43,7 +43,7 @@ export class EventComponent implements OnInit {
 	$event: BehaviorSubject<PuddingEvent> = new BehaviorSubject<PuddingEvent>(undefined);
 	readonly EventStatusType = EventStatusType;
 
-	activeLink = '';
+	activeLink = signal('');
 	isMobile = toSignal(this.breakpointService.isMobile());
 	isEventAdmin = signal(false);
 	links = computed(() => {
@@ -118,11 +118,11 @@ export class EventComponent implements OnInit {
 
 	ngOnInit() {
 		// Set active link based on current URL
-		this.activeLink = this.getActiveLinkFromUrl(window.location.href);
+		this.activeLink.set(this.getActiveLinkFromUrl(window.location.href));
 
 		this.router.events.subscribe((event) => {
 			if (event instanceof NavigationEnd) {
-				this.activeLink = './' + window.location.href.substring(window.location.href.lastIndexOf('/') + 1);
+				this.activeLink.set('./' + window.location.href.substring(window.location.href.lastIndexOf('/') + 1));
 			}
 		});
 

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.ts
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.ts
@@ -254,7 +254,7 @@ export class ExpendituresComponent implements OnInit, OnDestroy {
 						expenses.unshift(expense);
 						return [...expenses];
 					});
-					this.messageService.showSuccess('New expense created');
+					this.messageService.showSuccess('Expense created');
 				},
 				error: (err: ApiError) => {
 					this.messageService.showError('Failed to create expense');

--- a/app/mikane/src/app/pages/participant/participant.component.html
+++ b/app/mikane/src/app/pages/participant/participant.component.html
@@ -152,12 +152,23 @@
 											</button>
 											@if (usersWithBalance.length === 1) {
 												<span matTooltip="Cannot remove the sole participant from an event" style="padding: 8px 0">
-													<button mat-raised-button disabled>Remove User</button>
+													<button mat-raised-button disabled>
+														{{ userWithBalance.user.id === currentUser.id ? 'Leave event' : 'Remove user' }}
+													</button>
 												</span>
 											}
 											@else if (userWithBalance.expensesCount > 0) {
 												<span matTooltip="Cannot remove a user with expenses" style="padding: 8px 0">
-													<button mat-raised-button disabled>Remove User</button>
+													<button mat-raised-button disabled>
+														{{ userWithBalance.user.id === currentUser.id ? 'Leave event' : 'Remove user' }}
+													</button>
+												</span>
+											}
+											@else if (event.adminIds.length === 1 && userWithBalance.user.eventInfo.isAdmin) {
+												<span matTooltip="Cannot remove the sole event admin from an event" style="padding: 8px 0">
+													<button mat-raised-button disabled>
+														{{ userWithBalance.user.id === currentUser.id ? 'Leave event' : 'Remove user' }}
+													</button>
 												</span>
 											}
 											@else {
@@ -167,7 +178,7 @@
 													color="warn"
 													(click)="deleteUserDialog(userWithBalance.user.id)"
 												>
-													Remove User
+													{{ userWithBalance.user.id === currentUser.id ? 'Leave event' : 'Remove user' }}
 												</button>
 											}
 										</div>
@@ -189,7 +200,10 @@
 						<mat-icon>{{ isAdmin ? "star" : "check" }}</mat-icon>
 					</span>
 				} @else {
-					<span class="not-in-event">You are not in this event</span>
+					<div class="not-in-event">
+						<span>You are not in this event</span>
+						<button mat-flat-button color="accent2" (click)="joinEvent()">Join</button>
+					</div>
 				}
 				@if (isAdmin) {
 					<button mat-icon-button (click)="gotoSettings()">
@@ -214,6 +228,8 @@
 					<app-participant-item
 						[userBalance]="userWithBalance"
 						[eventActive]="event?.status.id === EventStatusType.ACTIVE"
+						[numberOfParticipants]="usersWithBalance.length"
+						[numberOfAdmins]="event?.adminIds.length"
 						(click)="gotoUserExpenses(userWithBalance)"
 						(gotoUser)="gotoUserProfile($event.user)"
 						(removeUser)="deleteUserDialog($event.userId)"

--- a/app/mikane/src/app/pages/participant/participant.component.scss
+++ b/app/mikane/src/app/pages/participant/participant.component.scss
@@ -63,6 +63,12 @@
 
 	.not-in-event {
 		color: #7c7c7c;
+
+		button {
+			margin-left: 10px;
+			height: 28px;
+			background-color: #3f3439;
+		}
 	}
 }
 

--- a/app/mikane/src/app/pages/participant/participant.component.spec.ts
+++ b/app/mikane/src/app/pages/participant/participant.component.spec.ts
@@ -62,13 +62,16 @@ describe('ParticipantComponent', () => {
 		fixture = MockRender(ParticipantComponent, {
 			$event: of({
 				id: '1',
+				private: false,
 				status: {
 					id: EventStatusType.ACTIVE,
 					name: 'Active',
-				}
+				},
+				adminIds: []
 			} as PuddingEvent),
 		});
 		component = fixture.point.componentInstance;
+		component.currentUser = { id: '000' } as User;
 		fixture.detectChanges();
 	}
 
@@ -81,7 +84,7 @@ describe('ParticipantComponent', () => {
 	it('should load event', () => {
 		createComponent();
 
-		expect(component.event).toEqual({ id: '1', status: { id: EventStatusType.ACTIVE, name: 'Active' } } as PuddingEvent);
+		expect(component.event).toEqual({ id: '1', private: false, status: { id: EventStatusType.ACTIVE, name: 'Active' }, adminIds: [] } as PuddingEvent);
 		expect(component.displayedColumns).toContain('actions');
 	});
 
@@ -397,10 +400,11 @@ describe('ParticipantComponent', () => {
 				component.deleteUserDialog('1');
 
 				expect(dialogStub.open).toHaveBeenCalledWith(ConfirmDialogComponent, {
-					width: '380px',
+					width: '430px',
 					data: {
-						title: 'Remove User',
+						title: 'Remove user',
 						content: 'Are you sure you want to remove this user?',
+						extraContent: undefined,
 						confirm: 'I am sure',
 					},
 				});
@@ -584,7 +588,7 @@ describe('ParticipantComponent', () => {
 
 			component.createExpenseDialog('1', jasmine.createSpyObj('ExpenseDataSource', ['addExpense']));
 
-			expect(messageServiceStub.showSuccess).toHaveBeenCalledWith('New expense created');
+			expect(messageServiceStub.showSuccess).toHaveBeenCalledWith('Expense created');
 		});
 
 		it('should cancel if no expense is returned from dialog', () => {

--- a/app/mikane/src/app/pages/payment-structure/payment-structure.component.spec.ts
+++ b/app/mikane/src/app/pages/payment-structure/payment-structure.component.spec.ts
@@ -144,76 +144,6 @@ describe('PaymentStructureComponent', () => {
 
 		it('should load payments', () => {
 			expect(eventService.loadPayments).toHaveBeenCalledWith('1');
-			expect(component.payments).toEqual([
-				{
-					sender: {
-						id: '1',
-						name: 'test',
-						email: '',
-					},
-					receiver: {
-						id: '2',
-						name: 'test2',
-						email: '',
-					},
-					amount: 1,
-				},
-				{
-					sender: {
-						id: '1',
-						name: 'test',
-						email: '',
-					},
-					receiver: {
-						id: '3',
-						name: 'test3',
-						email: '',
-					},
-					amount: 2,
-				},
-				{
-					sender: {
-						id: '2',
-						name: 'test2',
-						email: '',
-					},
-					receiver: {
-						id: '1',
-						name: 'test',
-						email: '',
-					},
-					amount: 3,
-				},
-				{
-					sender: {
-						id: '2',
-						name: 'test2',
-						email: '',
-					},
-					receiver: {
-						id: '3',
-						name: 'test3',
-						email: '',
-					},
-					amount: 4,
-				},
-				{
-					sender: {
-						id: '3',
-						name: 'test3',
-						email: '',
-					},
-					receiver: {
-						id: '2',
-						name: 'test2',
-						email: '',
-					},
-					amount: 6,
-				},
-			] as Payment[]);
-		});
-
-		it('should add receivers to senders', () => {
 			expect(component.senders).toEqual([
 				{
 					sender: {
@@ -449,7 +379,6 @@ describe('PaymentStructureComponent', () => {
 		}));
 
 		it('should not have any payments', () => {
-			expect(component.payments).toEqual([]);
 			expect(component.senders).toEqual([]);
 			expect(component.paymentsSelf).toEqual([]);
 			expect(component.paymentsOthers).toEqual([]);

--- a/app/mikane/src/app/pages/payment-structure/payment-structure.component.ts
+++ b/app/mikane/src/app/pages/payment-structure/payment-structure.component.ts
@@ -13,7 +13,7 @@ import { PaymentItemComponent } from 'src/app/features/mobile/payment-item/payme
 import { PaymentExpansionPanelItemComponent } from 'src/app/pages/payment-structure/payment-expansion-panel-item/payment-expansion-panel-item.component';
 import { AuthService } from 'src/app/services/auth/auth.service';
 import { BreakpointService } from 'src/app/services/breakpoint/breakpoint.service';
-import { EventService, Payment } from 'src/app/services/event/event.service';
+import { EventService } from 'src/app/services/event/event.service';
 import { MessageService } from 'src/app/services/message/message.service';
 import { User } from 'src/app/services/user/user.service';
 import { ApiError } from 'src/app/types/apiError.type';
@@ -56,7 +56,6 @@ export class PaymentStructureComponent implements OnInit {
 	allExpandedSelf = true;
 	allExpandedOthers = false;
 
-	payments: Payment[] = [];
 	senders: SenderPayments[] = [];
 	paymentsSelf: SenderPayments[] = [];
 	paymentsOthers: SenderPayments[] = [];
@@ -90,8 +89,6 @@ export class PaymentStructureComponent implements OnInit {
 		this.loading.next(true);
 		this.eventService.loadPayments(this.eventId).subscribe({
 			next: (payments) => {
-				this.payments = payments;
-
 				map(payments, (payment) => {
 					if (
 						this.senders.find((sender) => {
@@ -119,7 +116,7 @@ export class PaymentStructureComponent implements OnInit {
 					);
 				});
 
-				this.senders.map((sender) => {
+				this.senders.forEach((sender) => {
 					if (
 						sender.sender.id === this.currentUser?.id ||
 						sender.receivers.find((receiver) => receiver.receiver.id === this.currentUser?.id)

--- a/app/mikane/src/app/pages/profile/profile.component.html
+++ b/app/mikane/src/app/pages/profile/profile.component.html
@@ -128,18 +128,22 @@
 				</div>
 				<div class="event-right">
 					@if (event.userInfo.inEvent) {
-						<mat-icon [matTooltip]="event.private ? 'You are also in this private event' : 'You are also in this event'" [matTooltipShowDelay]="100" class="right-side-icon">
+						<mat-icon
+							[matTooltip]="'You are ' + ( user.id === event.userInfo.id ? '' : 'also ' ) + 'in this ' + ( event.private ? 'private ': '') + 'event'"
+							[matTooltipShowDelay]="100"
+							class="right-side-icon"
+						>
 							{{ event.private ? 'passkey' : 'how_to_reg' }}
 						</mat-icon>
 					}
 					@if (event.status.id === EventStatusType.ACTIVE) {
 						<mat-icon matTooltip="This event is active" [matTooltipShowDelay]="100" class="right-side-icon">
-							circle
+							 schedule
 						</mat-icon>
 					}
 					@else if (event.status.id === EventStatusType.READY_TO_SETTLE) {
 						<mat-icon matTooltip="This event is ready to be settled" [matTooltipShowDelay]="100" class="right-side-icon">
-							pending
+							paid
 						</mat-icon>
 					}
 					@else if (event.status.id === EventStatusType.SETTLED) {

--- a/app/mikane/src/app/pages/profile/profile.component.html
+++ b/app/mikane/src/app/pages/profile/profile.component.html
@@ -138,7 +138,7 @@
 					}
 					@if (event.status.id === EventStatusType.ACTIVE) {
 						<mat-icon matTooltip="This event is active" [matTooltipShowDelay]="100" class="right-side-icon">
-							 schedule
+							schedule
 						</mat-icon>
 					}
 					@else if (event.status.id === EventStatusType.READY_TO_SETTLE) {

--- a/app/mikane/src/styles.scss
+++ b/app/mikane/src/styles.scss
@@ -22,6 +22,7 @@
 	white-space: nowrap;
 	word-wrap: normal;
 	direction: ltr;
+	font-feature-settings: "liga";
 	-webkit-font-feature-settings: "liga";
 	-webkit-font-smoothing: antialiased;
 }
@@ -231,10 +232,11 @@ a.nostyle:visited {
 	border-top: 1px solid #333333;
 	stroke: #333333;
 	padding-left: 16px;
+}
 
-	&.admins {
-		margin-bottom: 0;
-	}
+.event-info-marker {
+	margin-bottom: 14px !important;
+	background-color: rgba(49, 33, 40, 0.2) !important;
 }
 
 // Hide background of autocompleted inputs


### PR DESCRIPTION
Changes:
- Added event status and privacy information to event info page.
- Deactivated "remove user from event" button for participants in cases they were the sole event admin.
- Fixed an issue where the "remove user from event" button incorrectly appeared in mobile view.
- Improved wording for various scenarios, including:
    - Display "Leave event" if the participant is the signed-in user.
    - Adding an extra warning when removing users from private events.
    - On the profile page, show slightly different hover text for user-in-event icon if the user is the signed-in user.
    - Explanation text for the event statuses.
- When signed-in user leaves a private event, they will now be taken back to the main events page.
- In mobile view, added a "join" button for events the signed-in user is not participating in.
- Converted various inputs to the new input type (corresponding tests also updated).
- Updated icons for event statuses on the profile page.

Fixes #372 