### PR TITLE
fix: Prevent line breaks in the expense edit/delete column

### DIFF
--- a/app/mikane/src/app/pages/expenditures/expenditures.component.html
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.html
@@ -117,12 +117,14 @@
 								<th mat-header-cell *matHeaderCellDef></th>
 								<td mat-cell *matCellDef="let expense">
 									@if (expense.payer.id === currentUserId || event?.userInfo?.isAdmin) {
-										<button mat-icon-button type="button" (click)="editExpense(expense.id)">
-											<mat-icon>edit</mat-icon>
-										</button>
-										<button mat-icon-button type="button" (click)="removeExpense(expense.id)">
-											<mat-icon>delete</mat-icon>
-										</button>
+										<div class="edit-delete-column">
+											<button mat-icon-button type="button" (click)="editExpense(expense.id)">
+												<mat-icon>edit</mat-icon>
+											</button>
+											<button mat-icon-button type="button" (click)="removeExpense(expense.id)">
+												<mat-icon>delete</mat-icon>
+											</button>
+										</div>
 									}
 								</td>
 							</ng-container>

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.scss
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.scss
@@ -84,6 +84,10 @@
 	font-size: 1.2em;
 }
 
+.edit-delete-column {
+	display: flex;
+}
+
 .filters {
 	margin-right: 20px;
 	width: 280px;


### PR DESCRIPTION
The edit and delete icons in an expense row will now remain on the same line when the rows shrinks horizontally.