### PR TITLE
fix: Emails not being sent to all receivers

### DIFF
--- a/server/src/email-services/notifications/readyToSettle.ts
+++ b/server/src/email-services/notifications/readyToSettle.ts
@@ -39,7 +39,7 @@ export const sendReadyToSettleEmails = async (paymentsInput: Payment[], event: E
 
   for (const senderPayment of senderPayments) {
     if (senderPayment.sender.guest) {
-      return;
+      continue;
     }
     if (!senderPayment.sender.email) {
       throw new Error("User " + senderPayment.sender.name + " missing email");

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -33,11 +33,11 @@ export const PUD002: ErrorCode = {
 };
 
 /**
- * PUD-003: Username/email and password does not match (401)
+ * PUD-003: Username/email and password do not match (401)
  */
 export const PUD003: ErrorCode = {
   code: "PUD-003",
-  message: "Username/email and password does not match",
+  message: "Username/email and password do not match",
   status: 401
 };
 


### PR DESCRIPTION
Upon setting an event as 'ready-to-settle', emails will now be sent to all intended recipients.

Fixes #405 