### PR TITLE
feat: Add expand/collapse buttons to mobile payments page

### DIFF
--- a/app/mikane/src/app/features/mobile/payment-item/payment-item.component.spec.ts
+++ b/app/mikane/src/app/features/mobile/payment-item/payment-item.component.spec.ts
@@ -109,9 +109,9 @@ describe('PaymentItemComponent', () => {
 	});
 
 	it('should set lowerHeight to scrollHeight when self is true', fakeAsync(() => {
-		fixture.componentRef.setInput('self', true);
 		component.lower = { nativeElement: { scrollHeight: 100 } } as ElementRef;
-		component.ngOnInit();
+		fixture.componentRef.setInput('self', true);
+		fixture.componentRef.setInput('expanded', true);
 		fixture.detectChanges();
 		tick();
 

--- a/app/mikane/src/app/features/mobile/payment-item/payment-item.component.ts
+++ b/app/mikane/src/app/features/mobile/payment-item/payment-item.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule, CurrencyPipe, NgOptimizedImage } from '@angular/common';
-import { Component, ElementRef, inject, input, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, inject, input, output, effect, ViewChild } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -26,7 +26,7 @@ import { User } from 'src/app/services/user/user.service';
 		NgOptimizedImage,
 	],
 })
-export class PaymentItemComponent implements OnInit {
+export class PaymentItemComponent {
 	private router = inject(Router);
 
 	@ViewChild('lower') lower: ElementRef;
@@ -39,18 +39,29 @@ export class PaymentItemComponent implements OnInit {
 	}>();
 	self = input.required<boolean>();
 	currentUser = input.required<User>();
+	expanded = input<boolean>(false);
+	dropdownToggled = output<{ senderId: string, expanded: boolean, self: boolean }>();
 
 	dropdownOpen: boolean;
 	lowerHeight: number | string;
+	private initialized = false;
 
-	ngOnInit(): void {
-		this.dropdownOpen = this.self() ? true : false;
-		this.lowerHeight = this.self() ? 'auto' : 0;
-		if (this.lowerHeight === 'auto') {
-			setTimeout(() => {
-				this.lowerHeight = this.lower.nativeElement.scrollHeight;
-			});
-		}
+	constructor() {
+		effect(() => {
+			this.dropdownOpen = this.expanded();
+			this.lowerHeight = this.dropdownOpen ? 'auto' : 0;
+			if (this.lowerHeight === 'auto') {
+				if (!this.initialized) {
+					setTimeout(() => {
+						this.lowerHeight = this.lower.nativeElement.scrollHeight;
+						this.initialized = true;
+					});
+				}
+				else {
+					this.lowerHeight = this.lower.nativeElement.scrollHeight;
+				}
+			}
+		});
 	}
 
 	toggleDropdown = () => {
@@ -61,6 +72,8 @@ export class PaymentItemComponent implements OnInit {
 		} else {
 			this.lowerHeight = 0;
 		}
+
+		this.dropdownToggled.emit({ senderId: this.payment().sender.id, expanded: this.dropdownOpen, self: this.self() });
 	};
 
 	gotoUserProfile(user: User) {

--- a/app/mikane/src/app/pages/payment-structure/payment-structure.component.html
+++ b/app/mikane/src/app/pages/payment-structure/payment-structure.component.html
@@ -2,21 +2,21 @@
 	<div>
 		@if ((breakpointService.isMobile() | async) === false) {
 			<div>
-				@if (senders.length > 0) {
+				@if (senders().length > 0) {
 					<div>
-						<div class="payments-header" [ngClass]="{ 'empty-payments': paymentsSelf.length === 0 }">
+						<div class="payments-header" [ngClass]="{ 'empty-payments': paymentsSelf().length === 0 }">
 							<h3 class="payments-title">Your payments</h3>
-							@if (paymentsSelf.length > 0) {
+							@if (paymentsSelf().length > 0) {
 								<button mat-button color="accent" (click)="toggleExpand(1)" class="collapse-button">
 									<mat-icon>{{ allExpandedSelf ? "visibility_off" : "visibility" }}</mat-icon>
 									{{ allExpandedSelf ? "Collapse all payments" : "Show all payments" }}
 								</button>
 							}
 						</div>
-						@if (paymentsSelf.length > 0) {
+						@if (paymentsSelf().length > 0) {
 							<app-payment-expansion-panel-item
 								#paymentsSelfRef
-								[payments]="paymentsSelf"
+								[payments]="paymentsSelf()"
 								[self]="true"
 								[currentUser]="currentUser"
 								(allPanelsExpanded)="panelToggled(1, $event)"
@@ -24,19 +24,19 @@
 						} @else {
 							<span class="empty-payments-text">You have no payments in this event</span>
 						}
-						<div class="payments-header" [ngClass]="{ 'empty-payments': paymentsOthers.length === 0 }">
+						<div class="payments-header" [ngClass]="{ 'empty-payments': paymentsOthers().length === 0 }">
 							<h3 class="payments-title">Other payments</h3>
-							@if (paymentsOthers.length > 0) {
+							@if (paymentsOthers().length > 0) {
 								<button mat-button color="accent" (click)="toggleExpand(2)" class="collapse-button">
 									<mat-icon>{{ allExpandedOthers ? "visibility_off" : "visibility" }}</mat-icon>
 									{{ allExpandedOthers ? "Collapse all payments" : "Show all payments" }}
 								</button>
 							}
 						</div>
-						@if (paymentsOthers.length > 0) {
+						@if (paymentsOthers().length > 0) {
 							<app-payment-expansion-panel-item
 								#paymentsOthersRef
-								[payments]="paymentsOthers"
+								[payments]="paymentsOthers()"
 								[self]="false"
 								[currentUser]="currentUser"
 								(allPanelsExpanded)="panelToggled(2, $event)"
@@ -56,28 +56,46 @@
 		}
 
 		@else {
-			@if (senders.length > 0) {
+			@if (senders().length > 0) {
 				<div>
-					@if (paymentsSelf.length > 0) {
+					@if (paymentsSelf().length > 0) {
 						<div>
-							@if (paymentsOthers.length > 0) {
+							<div class="payments-header-mobile">
 								<div class="title-mobile">Your payments</div>
-							}
+								<button mat-button color="accent" (click)="toggleExpandMobile(1)" class="collapse-button-mobile">
+									<mat-icon>{{ allExpandedSelf ? "visibility_off" : "visibility" }}</mat-icon>
+								</button>
+							</div>
 							<mat-nav-list class="payments-list-mobile">
-								@for (payment of paymentsSelf; track payment.sender.id) {
-									<app-payment-item [payment]="payment" [self]="true" [currentUser]="currentUser" />
+								@for (payment of paymentsSelf(); track payment.sender.id) {
+									<app-payment-item
+										[payment]="payment"
+										[self]="true"
+										[currentUser]="currentUser"
+										[expanded]="expandedSelf().has(payment.sender.id)"
+										(dropdownToggled)="paymentToggledMobile($event.senderId, $event.expanded, $event.self)"
+									/>
 								}
 							</mat-nav-list>
 						</div>
 					}
-					@if (paymentsOthers.length > 0) {
+					@if (paymentsOthers().length > 0) {
 						<div>
-							@if (paymentsSelf.length > 0) {
+							<div class="payments-header-mobile">
 								<div class="title-mobile">Other payments</div>
-							}
+								<button mat-button color="accent" (click)="toggleExpandMobile(2)" class="collapse-button-mobile">
+									<mat-icon>{{ allExpandedOthers ? "visibility_off" : "visibility" }}</mat-icon>
+								</button>
+							</div>
 							<mat-nav-list class="payments-list-mobile">
-								@for (payment of paymentsOthers; track payment.sender.id) {
-									<app-payment-item [payment]="payment" [self]="false" [currentUser]="currentUser" />
+								@for (payment of paymentsOthers(); track payment.sender.id) {
+									<app-payment-item
+										[payment]="payment"
+										[self]="false"
+										[currentUser]="currentUser"
+										[expanded]="expandedOthers().has(payment.sender.id)"
+										(dropdownToggled)="paymentToggledMobile($event.senderId, $event.expanded, $event.self)"
+									/>
 								}
 							</mat-nav-list>
 						</div>

--- a/app/mikane/src/app/pages/payment-structure/payment-structure.component.scss
+++ b/app/mikane/src/app/pages/payment-structure/payment-structure.component.scss
@@ -31,15 +31,30 @@
 	margin-left: 24px;
 }
 
-.title-mobile {
+.payments-header-mobile {
 	display: flex;
 	align-items: center;
+	justify-content: space-between;
 	height: 40px;
-	padding-left: 16px;
 	background-color: rgba(24, 24, 24, 1);
 	border-top: 1px solid #333333;
 	stroke: #333333;
 	color: #b4b4b4;
+
+	.title-mobile {
+		padding-left: 16px;
+	}
+
+	.collapse-button-mobile {
+		min-width: auto;
+		padding: 0 8px;
+		margin-right: 8px;
+
+		mat-icon {
+			margin-right: 10px;
+			margin-left: 10px;
+		}
+	}
 }
 
 .no-payments {

--- a/app/mikane/src/app/pages/payment-structure/payment-structure.component.spec.ts
+++ b/app/mikane/src/app/pages/payment-structure/payment-structure.component.spec.ts
@@ -144,7 +144,7 @@ describe('PaymentStructureComponent', () => {
 
 		it('should load payments', () => {
 			expect(eventService.loadPayments).toHaveBeenCalledWith('1');
-			expect(component.senders).toEqual([
+			expect(component.senders()).toEqual([
 				{
 					sender: {
 						id: '1',
@@ -222,7 +222,7 @@ describe('PaymentStructureComponent', () => {
 		});
 
 		it('should add payments to paymentsSelf', () => {
-			expect(component.paymentsSelf).toEqual([
+			expect(component.paymentsSelf()).toEqual([
 				{
 					sender: {
 						id: '1',
@@ -283,7 +283,7 @@ describe('PaymentStructureComponent', () => {
 		});
 
 		it('should add payments to paymentsOthers', () => {
-			expect(component.paymentsOthers).toEqual([
+			expect(component.paymentsOthers()).toEqual([
 				{
 					sender: {
 						id: '3',
@@ -379,9 +379,9 @@ describe('PaymentStructureComponent', () => {
 		}));
 
 		it('should not have any payments', () => {
-			expect(component.senders).toEqual([]);
-			expect(component.paymentsSelf).toEqual([]);
-			expect(component.paymentsOthers).toEqual([]);
+			expect(component.senders()).toEqual([]);
+			expect(component.paymentsSelf()).toEqual([]);
+			expect(component.paymentsOthers()).toEqual([]);
 		});
 
 		it('should show payment error message', () => {

--- a/app/mikane/src/app/pages/reset-password/reset-password.component.scss
+++ b/app/mikane/src/app/pages/reset-password/reset-password.component.scss
@@ -67,3 +67,7 @@
 .mat-mdc-card-header {
 	padding: 16px 16px 0;
 }
+
+mat-card-title {
+	padding-left: 0 !important;
+}

--- a/app/mikane/src/app/services/event/event.service.ts
+++ b/app/mikane/src/app/services/event/event.service.ts
@@ -109,6 +109,6 @@ export class EventService {
 	}
 
 	sendReadyToSettleEmails(eventId: string): Observable<void> {
-		return this.httpClient.post<void>(this.env.apiUrl + `/notifications/${eventId}/settle`, {});
+		return this.httpClient.post<void>(this.env.apiUrl + `notifications/${eventId}/settle`, {});
 	}
 }

--- a/app/mikane/src/manifest.webmanifest
+++ b/app/mikane/src/manifest.webmanifest
@@ -5,5 +5,12 @@
   "background_color": "#1d1d1d",
   "display": "standalone",
   "scope": "./",
-  "start_url": "./"
+  "start_url": "./",
+  "icons": [
+    {
+      "src": "/assets/mikane.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,7 +15,6 @@
         "express": "^5.1.0",
         "express-session": "^1.18.2",
         "helmet": "^8.1.0",
-        "nodemailer": "^7.0.5",
         "pg": "^8.16.3",
         "postmark": "^4.0.5",
         "swagger-ui-express": "^5.0.1"
@@ -4100,7 +4099,9 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
       "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "dev": true,
       "license": "MIT-0",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -8818,7 +8819,9 @@
     "nodemailer": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
-      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg=="
+      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "dev": true,
+      "peer": true
     },
     "nodemailer-mock": {
       "version": "2.0.9",

--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,6 @@
     "express": "^5.1.0",
     "express-session": "^1.18.2",
     "helmet": "^8.1.0",
-    "nodemailer": "^7.0.5",
     "pg": "^8.16.3",
     "postmark": "^4.0.5",
     "swagger-ui-express": "^5.0.1"


### PR DESCRIPTION
Changelog:
- Added expand/collapse buttons to mobile payments page, one for own payments and one for others' payments
- Refactored payment structure and item components to use signals and computed properties for better state management
- Fixed bug with sending ready-to-settle API call
- Fixed title styling in reset password page
- Added icons property to webmanifest
- Updated relevant tests

Closes #396 