### PR TITLE
chore: separate building steps to their own jobs when making snapshot

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -47,7 +47,16 @@ jobs:
       - name: Push changes to repository
         run: |
           git push origin develop
-
+  build-frontend:
+    needs: snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
       - name: Install frontend dependencies
         run: |
           cd ./app/mikane/
@@ -60,10 +69,18 @@ jobs:
         id: upload-artifact-frontend
         uses: actions/upload-artifact@v4
         with:
-          if-no-files-found: error
-          name: ${{ steps.bump-snapshot.outputs.artifact-frontend }}
+          name: ${{ needs.snapshot.outputs.frontend-artifact }}
           path: ./app/mikane/dist/mikane/browser/
-
+  build-backend:
+    runs-on: ubuntu-latest
+    needs: snapshot
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
       - name: Install backend dependencies
         run: |
           cd ./server/
@@ -77,7 +94,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ steps.bump-snapshot.outputs.artifact-backend }}
+          name: ${{ needs.snapshot.outputs.backend-artifact }}
           path: ./server/build/
   test-frontend:
     needs: snapshot


### PR DESCRIPTION
Having building in the same job as bumping means the build step can't be
retried if it fails because the bump step triess rerunning as well