### PR TITLE
feat: Ready-to-settle email also for receivers

### DIFF
--- a/app/mikane/src/app/pages/event-settings/event-settings.component.html
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.html
@@ -242,8 +242,8 @@
 <ng-template #notificationsReadyToSettleContent>
 	@if (event?.status.id === EventStatusType.READY_TO_SETTLE) {
 		<div class="event-settings-text">
-			As the event is ready to be settled, you can email all payers to inform them of their expenses, how much they owe, and who to
-			pay.
+			As the event is ready to be settled, you can email all participants to inform them of their expenses — how much they owe or are owed,
+			and who to pay or receive payments from.
 		</div>
 	} @else {
 		<div class="event-settings-text">Only events that are ready to be settled can send this email.</div>

--- a/app/mikane/src/app/pages/event-settings/event-settings.component.ts
+++ b/app/mikane/src/app/pages/event-settings/event-settings.component.ts
@@ -280,7 +280,7 @@ export class EventSettingsComponent implements OnInit, OnDestroy {
 			width: '420px',
 			data: {
 				title: "Send 'ready to settle' email",
-				content: "Are you sure you want to send the 'ready to settle' email? Emails will be sent to all payers in the event.",
+				content: "Are you sure you want to send the 'ready to settle' email? Emails will be sent to all participants in the event.",
 				confirm: 'Yes, I am sure',
 			},
 		});

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -4083,8 +4083,8 @@
         "tags": [
           "Notifications"
         ],
-        "summary": "Send 'ready-to-settle' email to all payers in an event",
-        "description": "Send a 'ready-to-settle' email to all participants that should send payments in an event",
+        "summary": "Send 'ready-to-settle' email to all participants in an event",
+        "description": "Send a 'ready-to-settle' email to all participants that should send or receive payments in an event",
         "operationId": "postReadyToSettleEmail",
         "security": [
           { "cookieAuth": [] }

--- a/server/src/api/notifications.ts
+++ b/server/src/api/notifications.ts
@@ -47,7 +47,7 @@ router.post("/notifications/:eventId/reminder", authCheck, async (req, res) => {
 });
 
 /*
-* Send 'ready-to-settle' email to all payers in an event
+* Send 'ready-to-settle' email to all participants in an event
 */
 router.post("/notifications/:eventId/settle", authCheck, async (req, res) => {
   if (!env.MIKANE_EMAIL || !env.MIKANE_EMAIL_API_TOKEN) {

--- a/server/src/email-services/notifications/addExpensesReminder.ts
+++ b/server/src/email-services/notifications/addExpensesReminder.ts
@@ -41,7 +41,7 @@ const addExpensesReminderEmailHTML = (user: User, event: Event, cutoffDate?: Dat
 
   return `<html>
             <body>
-              <h1>${event.name} - Reminder to submit your expenses</h1>
+              <h2>${event.name} - Reminder to submit your expenses</h2>
               <div>As a participant in ${event.name}, this is a friendly reminder to log any expenses you haven't yet added.</div>
               ${cutoffText}
               <br>

--- a/server/src/email-services/notifications/readyToSettle.ts
+++ b/server/src/email-services/notifications/readyToSettle.ts
@@ -10,20 +10,31 @@ type SenderPayments = {
     amount: number
   }[]
 };
+type ReceiverPayments = {
+  receiver: User,
+  payments: {
+    sender: User,
+    amount: number
+  }[]
+};
 
 const url = env.ALLOWED_ORIGIN + "/events/";
 
 /**
- * Send emails to all payment senders in an event
+ * Send emails to all payment senders and receivers in an event
  * @param payments List of payments within an event
  * @param event Event to send payment emails for
  */
 export const sendReadyToSettleEmails = async (paymentsInput: Payment[], event: Event) => {
 
-  const subject = `${event.name} is now ready for settlement - Mikane`;
+  const subjectSenders = `${event.name} is now ready for settlement - Mikane`;
+  const subjectReceivers = `${event.name}: You will soon receive payments - Mikane`;
 
   const senderPaymentsMap = new Map<string, SenderPayments>();
+  const receiverPaymentsMap = new Map<string, ReceiverPayments>();
+
   paymentsInput.forEach(payment => {
+    // Sender map
     if (!senderPaymentsMap.has(payment.sender.id)) {
       senderPaymentsMap.set(payment.sender.id, {
         sender: payment.sender,
@@ -34,9 +45,22 @@ export const sendReadyToSettleEmails = async (paymentsInput: Payment[], event: E
       receiver: payment.receiver,
       amount: payment.amount
     });
+
+    // Receiver map
+    if (!receiverPaymentsMap.has(payment.receiver.id)) {
+      receiverPaymentsMap.set(payment.receiver.id, {
+        receiver: payment.receiver,
+        payments: []
+      });
+    }
+    receiverPaymentsMap.get(payment.receiver.id)?.payments.push({
+      sender: payment.sender,
+      amount: payment.amount
+    });
   });
 
   const senderPayments = Array.from(senderPaymentsMap.values());
+  const receiverPayments = Array.from(receiverPaymentsMap.values());
 
   for (const senderPayment of senderPayments) {
     if (senderPayment.sender.guest) {
@@ -46,19 +70,35 @@ export const sendReadyToSettleEmails = async (paymentsInput: Payment[], event: E
       throw new Error("User " + senderPayment.sender.name + " missing email");
     }
 
-    const html = readyToSettleEmailHTML(senderPayment, event);
+    const html = senderEmailHTML(senderPayment, event);
 
-    const sentMessageInfo = await sendEmail(senderPayment.sender.email, subject, html);
+    const sentMessageInfo = await sendEmail(senderPayment.sender.email, subjectSenders, html);
+    if (sentMessageInfo.To) {
+      logger.info(`'Ready to settle' email for event ${event.name} sent to ${sentMessageInfo.To}: ${sentMessageInfo.Message}`);
+    }
+  }
+
+  for (const receiverPayment of receiverPayments) {
+    if (receiverPayment.receiver.guest) {
+      continue;
+    }
+    if (!receiverPayment.receiver.email) {
+      throw new Error("User " + receiverPayment.receiver.name + " missing email");
+    }
+
+    const html = receiverEmailHTML(receiverPayment, event);
+
+    const sentMessageInfo = await sendEmail(receiverPayment.receiver.email, subjectReceivers, html);
     if (sentMessageInfo.To) {
       logger.info(`'Ready to settle' email for event ${event.name} sent to ${sentMessageInfo.To}: ${sentMessageInfo.Message}`);
     }
   }
 };
 
-const readyToSettleEmailHTML = (senderPayment: SenderPayments, event: Event) => {
+const senderEmailHTML = (senderPayment: SenderPayments, event: Event) => {
   return `<html>
             <body>
-              <h1>${event.name} is now ready for settlement</h1>
+              <h2 style="color:#7d0a37;">${event.name} is now ready for settlement</h2>
               <div>As a participant in ${event.name}, you are receiving this notification to inform you that it is time to settle your expenses.</div>
               <br>
               <div>
@@ -78,6 +118,33 @@ const readyToSettleEmailHTML = (senderPayment: SenderPayments, event: Event) => 
               <a href="${url + event.id}/payment" style="display: inline-block; padding: 10px 20px; background-color: #c2185b; color: white; text-decoration: none; border-radius: 4px; font-weight: bold;">See payments</a>
               <br><br>
               <div>Please pay your share as soon as possible. Thank you!</div>
+            </body>
+          </html>`;
+};
+
+const receiverEmailHTML = (receiverPayment: ReceiverPayments, event: Event) => {
+  return `<html>
+            <body>
+              <h2 style="color:#0d4f11;">${event.name}: You will soon receive payments</h2>
+              <div>As a participant in ${event.name}, you are receiving this notification to inform you that the event is now ready for settlement and you will soon receive payments.</div>
+              <br>
+              <div>
+                The following people will pay you:
+                ${receiverPayment.payments.map(payment => {
+                  return `<div style="margin-left: 10px;">
+                            - ${payment.sender.name}
+                            <span style="display: inline-block; background-color: #ff85b65e; padding: 1px 4px; margin-bottom: 2px; border-radius: 4px;">
+                              ${payment.amount} kr
+                            </span>
+                          </div>`;
+                }).join("")}
+                <br>
+                Click the button below to see more details.
+              </div>
+              <br>
+              <a href="${url + event.id}/payment" style="display: inline-block; padding: 10px 20px; background-color: #c2185b; color: white; text-decoration: none; border-radius: 4px; font-weight: bold;">See payments</a>
+              <br><br>
+              <div>If you have any questions, feel free to reach out. Thank you!</div>
             </body>
           </html>`;
 };

--- a/server/src/middlewares/dbLogger.ts
+++ b/server/src/middlewares/dbLogger.ts
@@ -22,8 +22,8 @@ export class DbLogger extends Middleware {
       return;
     }
 
-    // Do not log to DB in dev environment
-    if (env.NODE_ENV === "dev") {
+    // Do not log to DB in local dev environment
+    if (env.NODE_ENV === "dev" && !env.DEPLOYED) {
       return;
     }
 

--- a/server/src/utils/sendEmail.ts
+++ b/server/src/utils/sendEmail.ts
@@ -20,6 +20,10 @@ export const sendEmail = async (recipient: string, subject: string, html: string
 
   const client = new ServerClient(token);
 
+  if (env.NODE_ENV === "dev") {
+    recipient = "test@blackhole.postmarkapp.com";
+  }
+
   return client.sendEmail({
     From: email,
     To: recipient,

--- a/server/tests/notifications.test.ts
+++ b/server/tests/notifications.test.ts
@@ -288,9 +288,12 @@ describe("notifications", async () => {
         .set("Cookie", authToken);
 
       const sentEmails = getSentEmails();
-      const subject = sentEmails[0].Subject;
+      const subject1 = sentEmails[0].Subject;
+      const subject2 = sentEmails[1].Subject;
       const html = sentEmails[0].HtmlBody as string;
-      const sentToEmail = sentEmails[0].To;
+      const sentToEmail1 = sentEmails[0].To;
+      const sentToEmail2 = sentEmails[1].To;
+      const sentToEmail3 = sentEmails[2].To;
 
       const receiver1NameStart = html.indexOf("<div style=\"margin-left: 10px;\">") + "<div style=\"margin-left: 10px;\">".length;
       const receiver1NameEnd = html.indexOf("<", receiver1NameStart);
@@ -309,8 +312,11 @@ describe("notifications", async () => {
       expect(res.status).toEqual(200);
       expect(res.body.message).toEqual("Emails successfully sent");
       
-      expect(subject).toEqual(event.name + " is now ready for settlement - Mikane");
-      expect(sentToEmail).toEqual(user1.email);
+      expect(subject1).toEqual(event.name + " is now ready for settlement - Mikane");
+      expect(subject2).toEqual(event.name + ": You will soon receive payments - Mikane");
+      expect(sentToEmail1).toEqual(user1.email);
+      expect(sentToEmail2).toEqual(user2.email);
+      expect(sentToEmail3).toEqual(user3.email);
       expect(receiver1Name).toEqual(payments[0].receiver.name);
       expect(receiver1Amount).toEqual(payments[0].amount);
       expect(receiver2Name).toEqual(payments[1].receiver.name);


### PR DESCRIPTION
Clicking the "send ready-to-send email" button will now also send a special version of the email to the receivers with information about who will pay them (and how much).

The email subjects, and colors of headers, are adjusted to better differentiate which of the emails one received.

Closes #439 