### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,4 +1,6 @@
 name: Post Merge Snapshot
+permissions:
+  contents: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/pudding-tech/mikane/security/code-scanning/29](https://github.com/pudding-tech/mikane/security/code-scanning/29)

The best way to fix the problem is to add an explicit `permissions` block to the workflow. Since at least some jobs appear to perform actions requiring write permissions to repository contents (e.g., "Push changes to repository"), set the minimal required permission at the workflow root. By default, set `contents: write`, as that's needed for git pushes, and otherwise start with `contents: read` if possible. Any jobs (such as artifact upload or third-party actions) that require broader or narrower permissions can override with their own `permissions` block if needed. Place the permissions block **directly after the `name` (line 1)** and before `on`, to apply to **all jobs** by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
