### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,5 +1,8 @@
 name: Status Checks
 
+permissions:
+    contents: read
+    pull-requests: write
 on:
     pull_request:
         branches: ["develop"]


### PR DESCRIPTION
Potential fix for [https://github.com/pudding-tech/mikane/security/code-scanning/20](https://github.com/pudding-tech/mikane/security/code-scanning/20)

To fix this problem, we should add an explicit `permissions` block either at the workflow root (to apply to all jobs that don't specify their own) or, if needed, at the job level. Given that the jobs are using reusable workflows (via `uses:`), and are unlikely to require write access except possibly for pull requests (for status checks, etc.), the safest, minimal permissions set would be:

```yaml
permissions:
  contents: read
  pull-requests: write
```

This provides read-only access to repository contents and write access only for pull-requests, which is commonly required for status checks, comments, and updates on PRs. The change should be placed directly after the workflow `name:` and before `on:`, or after `on:` if preferred, but before `jobs:`. No other code (or configuration logic) needs to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
