### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Bump and deploy release
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/pudding-tech/mikane/security/code-scanning/23](https://github.com/pudding-tech/mikane/security/code-scanning/23)

To address this issue, an explicit `permissions` block should be added to the workflow to restrict the GitHub Actions GITHUB_TOKEN to the least access required for this workflow. The best practice is to add the block at the workflow root level (just below `name:` and above `on:`) so that all jobs inherit these restrictions unless individually overridden. For most CI/test/build pipelines, the minimum required is `contents: read`, which allows jobs to read repository contents but prevents them from making repository changes (e.g., pushes). If a job or the workflow needs additional permissions (for example, creating pull requests or writing issues), further permissions can be specified, but only as needed. As a minimal fix, add:

```yaml
permissions:
  contents: read
```

above the `on:` block (line 2). No additional code changes or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
