### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,4 +1,6 @@
 name: "~ Build frontend"
+permissions:
+  contents: read
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/pudding-tech/mikane/security/code-scanning/16](https://github.com/pudding-tech/mikane/security/code-scanning/16)

The fix is to explicitly set a `permissions:` block in the workflow YAML file to restrict the GITHUB_TOKEN's access according to the principle of least privilege. The best place for this is at the top/root of the workflow so it covers all jobs, but it can also be placed per-job if different jobs require different privileges. In this case, since the workflow only needs actions such as checking out code and uploading artifacts—which require at most read access to the repository contents—it is prudent to set `permissions: contents: read` at the top. Should any job need to write to `pull-requests` or other scopes, this can be added on a job-by-job basis. For now, adding the following at the top (after `name:` and before `on:`) is safest and most maintainable:
```yaml
permissions:
  contents: read
```

**Region to change:** Insert after the first line, before `on:` in `.github/workflows/frontend-build.yml`.

No additional methods, imports, or changes are needed elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
