### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,4 +1,6 @@
 name: "~ Bump version"
+permissions:
+  contents: write
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/pudding-tech/mikane/security/code-scanning/1](https://github.com/pudding-tech/mikane/security/code-scanning/1)

To fix this issue, add an explicit `permissions` key at the appropriate scope within your workflow YAML. Since only the `bump` job is shown and no other jobs are present, you could insert `permissions:` at the top level (to apply to all jobs, now and in the future), or inside the `bump` job (to scope it just to that job). The minimal required permission for this workflow is `contents: write` because the job makes commits and pushes tags and changes. Add:

```yaml
permissions:
  contents: write
```

at the beginning of the workflow, after the `name:` and before the `on:` block (root level), or as a block within the `bump` job if you intend to restrict it to just that job.

To follow GitHub's recommendations and for future flexibility, adding it at the root of the workflow applies it to all jobs and is the simplest fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
