### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -4,6 +4,9 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/pudding-tech/mikane/security/code-scanning/7](https://github.com/pudding-tech/mikane/security/code-scanning/7)

The problem should be fixed by adding an explicit `permissions:` block to the workflow root (recommended) or, if needed, to each job that requires different permissions. As a starting point, we should set the most restrictive permissions possible, e.g., `contents: read` (minimal required for most workflows that need to read repository content but not push changes). If a job (now or in the future) needs to write e.g. release, issue, or pull-request data, those can be broadened. In this case, since the workflow mainly builds and deploys, and there is no sign of write-repository operations, `contents: read` is appropriate.

- Edit the top of `.github/workflows/deploy-tag.yml`, adding a `permissions:` block just after the `name:` (or after `on:`, both are accepted).
- No code changes to jobs/steps are needed unless different jobs require different permissions (in this case, a single root block suffices).
- No imports or external dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
