### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/call_deploy.yml
+++ b/.github/workflows/call_deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy specific release
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/pudding-tech/mikane/security/code-scanning/14](https://github.com/pudding-tech/mikane/security/code-scanning/14)

To fix this issue, we should add a `permissions:` block at the root of the workflow file (above `jobs:`) to explicitly restrict the permissions granted to the `GITHUB_TOKEN`. As a minimal starting point, set `contents: read`—this ensures the token can only read repository contents, which suffices for most read-only actions (such as checkout). If any workflow jobs require additional write access (e.g. to create pull requests, upload releases, etc.), those can be enumerated and added with finer granularity. Since the provided workflow mainly checks tags and runs build/deploy processes using reused workflows, for now, adding `contents: read` is sufficient and follows the principle of least privilege.

The edit should be made at the start of the file after (or before) the `name:` key and before `jobs:`. No imports or additional method definitions are needed for this YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
