### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -1,4 +1,6 @@
 name: "~ Build backend"
+permissions:
+  contents: read
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/pudding-tech/mikane/security/code-scanning/4](https://github.com/pudding-tech/mikane/security/code-scanning/4)

The best way to fix this problem is to add an explicit `permissions` block to the workflow YAML file. It is typically safest to set this at the workflow root level, so all jobs inherit it, unless a job requires additional permissions. Based on the contents of the jobs (`actions/checkout`, `actions/upload-artifact`), the minimal required permission is usually `contents: read` (which is required to read the repository content). Uploading to the GitHub Actions artifact store does not require additional permissions on the repository unless uploading releases, which is not the case here.

**Specific fix:**  
- Add a root-level `permissions` block after the `name` and before `on:` (or directly after `on:`) in `.github/workflows/backend-build.yml`.
- Set it to `contents: read` (you could refine further if necessary, but this is the minimal common requirement).
- No changes are required at the job level unless a job needs an expanded set.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
