### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -1,4 +1,6 @@
 name: "~ Frontend tests"
+permissions:
+    contents: read
 on:
     workflow_call:
         inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/pudding-tech/mikane/security/code-scanning/13](https://github.com/pudding-tech/mikane/security/code-scanning/13)

To fix the issue, we should set a `permissions` block, either at the workflow root or inside the `test` job. Since the workflow appears to have a single job, and does not require write permissions to the repository, we can add the block at the root level so it applies to all jobs (including future ones, unless overridden), with `contents: read` (the minimal recommended value). Place the `permissions` block between the `name` and `on` keys to conform to standard GitHub Actions YAML. No new imports or build steps are required, only the addition of this YAML block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
