### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: "~ Deploy"
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/pudding-tech/mikane/security/code-scanning/5](https://github.com/pudding-tech/mikane/security/code-scanning/5)

The best fix is to explicitly add a `permissions` block specifying the minimal necessary permissions for the workflow. Since the workflow mainly downloads artifacts (which only requires `contents: read` for accessing workflow artifacts) and does not create or modify issues, PRs, or use writable repository APIs, `contents: read` (or even `none` if no GitHub API access is needed) is likely sufficient. The `permissions` block should be placed at the top level of the workflow (before `jobs:`) to apply to all jobs unless more specific job-level permissions are required later. No other functionality needs to change, and no new imports or code changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
