### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,4 +1,6 @@
 name: "~ Backend tests"
+permissions:
+  contents: read
 on:
     workflow_call:
         inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/pudding-tech/mikane/security/code-scanning/2](https://github.com/pudding-tech/mikane/security/code-scanning/2)

To fix this problem, explicitly set a `permissions` block in the workflow to restrict the GITHUB_TOKEN to only the minimum permissions required. Since this workflow appears to primarily check out code, set up a database, run tests, and upload code coverage, the only required permission is read access to repository contents. No step requires write access (such as pushing a commit or publishing a release). The best place to add the `permissions` block is at the root level of the workflow file (before `jobs:`) so it applies to all jobs. Edit .github/workflows/backend-test.yml to insert the following block after the `name:` line (and before `on:`):

```yaml
permissions:
  contents: read
```

No new methods, imports, or other definitions are required—just this configuration block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
