### PR TITLE
Potential fix for code scanning alert no. 30: Missing CSRF middleware

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^5.1.0",
         "express-session": "^1.18.2",
         "helmet": "^8.1.0",
+        "lusca": "^1.7.0",
         "pg": "^8.16.3",
         "postmark": "^4.0.5",
         "swagger-ui-express": "^5.0.1"
@@ -3884,6 +3885,17 @@
         "node": "14 || >=16.14"
       }
     },
+    "node_modules/lusca": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lusca/-/lusca-1.7.0.tgz",
+      "integrity": "sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==",
+      "dependencies": {
+        "tsscmp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -5524,6 +5536,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/tsx": {
       "version": "4.20.4",
@@ -8688,6 +8709,14 @@
       "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
       "dev": true
     },
+    "lusca": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lusca/-/lusca-1.7.0.tgz",
+      "integrity": "sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==",
+      "requires": {
+        "tsscmp": "^1.0.5"
+      }
+    },
     "magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -9762,6 +9791,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
+    },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "tsx": {
       "version": "4.20.4",

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,8 @@
     "helmet": "^8.1.0",
     "pg": "^8.16.3",
     "postmark": "^4.0.5",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,5 +1,6 @@
 import express, { NextFunction, Request, Response } from "express";
 import session from "express-session";
+import lusca from "lusca";
 import swaggerUi from "swagger-ui-express";
 import cors from "cors";
 import helmet from "helmet";
@@ -104,6 +105,9 @@ app.use(session({
   rolling: true,
   unset: "destroy"
 }));
+
+// CSRF protection
+app.use(lusca.csrf());
 
 app.post("/{*any}", (req, res, next) => {
   if (req.headers["content-type"] !== undefined && !req.is("application/json")) {


### PR DESCRIPTION
Potential fix for [https://github.com/pudding-tech/mikane/security/code-scanning/30](https://github.com/pudding-tech/mikane/security/code-scanning/30)

To mitigate CSRF attacks in this Express.js app, you should add standard server-side CSRF protection middleware. The best way to fix the problem is to include a package like `lusca` or `csurf` immediately after the session middleware and before you define API routes that mutate state. Since the CodeQL recommendation is to use `lusca.csrf`, the fix should involve importing `lusca`, extracting its CSRF middleware, and adding `app.use(lusca.csrf())` after `app.use(session(...))` (i.e., after line 106).

You'll need to:
- Install the `lusca` package as a dependency (if it's not already present).
- Add an import for `lusca`.
- Insert the CSRF middleware after the session middleware, and before any state-changing routes.

No existing functionality needs to be changed except for introducing this security middleware. Note: You may need to accommodate how CSRF tokens are delivered/extracted on the frontend and sent in requests, but that's outside the provided code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
