### PR TITLE
Potential fix for code scanning alert no. 38: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,8 @@
     "helmet": "^8.1.0",
     "pg": "^8.16.3",
     "postmark": "^4.0.5",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/server/src/api/users.ts
+++ b/server/src/api/users.ts
@@ -1,7 +1,7 @@
 import express from "express";
+import RateLimit from "express-rate-limit";
 import env from "../env.ts";
 import * as db from "../db/dbUsers.ts";
-import * as dbAuth from "../db/dbAuthentication.ts";
 import * as ec from "../types/errorCodes.ts";
 import { authCheck } from "../middlewares/authCheck.ts";
 import { authenticate, createHash } from "../utils/auth.ts";
@@ -16,6 +16,12 @@ import { sendRegisterAccountEmail } from "../email-services/registerAccount.ts";
 import { sendDeleteAccountEmail } from "../email-services/deleteAccount.ts";
 import { Event, Expense, User } from "../types/types.ts";
 import { ErrorExt } from "../types/errorExt.ts";
+// Apply a rate limiter to sensitive endpoints (e.g., account deletion)
+const deleteAccountLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5, // max 5 requests per windowMs per IP
+  message: "Too many account deletion attempts from this IP, please try again later.",
+});
 const router = express.Router();
 
 /* --- */
@@ -433,7 +439,7 @@ router.put("/users/:id/preferences", authCheck, async (req, res) => {
 /*
 * Delete user
 */
-router.delete("/users/:id", authCheck, async (req, res) => {
+router.delete("/users/:id", deleteAccountLimiter, authCheck, async (req, res) => {
   const key: string = req.body.key;
   const userId = req.params.id;
   if (!isUUID(userId)) {


### PR DESCRIPTION
Potential fix for [https://github.com/pudding-tech/mikane/security/code-scanning/38](https://github.com/pudding-tech/mikane/security/code-scanning/38)

To fix the missing rate limiting, we should add a rate-limiting middleware to the route handler for `DELETE /users/:id`. The best way is to use a widely-adopted package such as `express-rate-limit`. We’ll import the rate limiter, define a rate-limiting rule local to this router or specifically for this endpoint (e.g., max N requests per window per IP), and apply the middleware as the first argument to this route handler. All code changes are to be made at the top of server/src/api/users.ts (for the import and rate limiter definition), and on the definition of the `router.delete` endpoint (line 436), by adding the rate limiter as a middleware before `authCheck` and the handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
