### PR TITLE
feat: Implement backend rate-limiting

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -2,11 +2,16 @@ NODE_ENV= # Optional - defaults to dev
 PORT= # Optional - defaults to 3002
 ALLOWED_ORIGIN= # Optional - defaults to http://localhost:4200
 LOG_LEVEL= # Optional - defaults to log
-COOKIE_NAME= # Optional - defaults to mikane.sid
-COOKIE_DOMAIN= # Optional - defaults to domain server is running on
 DEPLOYED= # Optional - defaults to false
 SESSION_SECRET= # Optional/Required - defaults to abcdef (must be set in production)
+TRUSTED_PROXIES= # Optional - number of trusted proxies, defaults to 0
 SKIP_CSRF_CHECK= # Optional - defaults to false
+COOKIE_NAME= # Optional - defaults to mikane.sid
+COOKIE_DOMAIN= # Optional - defaults to domain server is running on
+RATE_LIMIT_WINDOW_SEC= # Optional - defaults to 300 (5 minutes)
+RATE_LIMIT_MAX_REQUESTS= # Optional - defaults to 200
+RATE_LIMIT_STRICT_WINDOW_SEC= # Optional - defaults to 60 (1 minute)
+RATE_LIMIT_STRICT_MAX_REQUESTS= # Optional - defaults to 10
 
 DB_HOST= # Required - database hostname or IP address
 DB_PORT= # Optional - port the database is running on, defaults to 5432
@@ -14,5 +19,5 @@ DB_DATABASE= # Optional - database name, defaults to master
 DB_USER= # Required - DB user username
 DB_PASSWORD= # Required - DB user password
 
-MIKANE_EMAIL= # Optional - but required for email services
-MIKANE_EMAIL_API_TOKEN= # Optional - but required for email services
+MIKANE_EMAIL= # Optional, but required for email services
+MIKANE_EMAIL_API_TOKEN= # Optional, but required for email services

--- a/server/.env.example
+++ b/server/.env.example
@@ -12,6 +12,7 @@ RATE_LIMIT_WINDOW_SEC= # Optional - defaults to 300 (5 minutes)
 RATE_LIMIT_MAX_REQUESTS= # Optional - defaults to 200
 RATE_LIMIT_STRICT_WINDOW_SEC= # Optional - defaults to 60 (1 minute)
 RATE_LIMIT_STRICT_MAX_REQUESTS= # Optional - defaults to 10
+RATE_LIMIT_SINGLE_WINDOW_SEC= # Optional - defaults to 300 (5 minutes)
 
 DB_HOST= # Required - database hostname or IP address
 DB_PORT= # Optional - port the database is running on, defaults to 5432

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,7 @@
         "csrf-sync": "^4.2.1",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.0.1",
         "express-session": "^1.18.2",
         "helmet": "^8.1.0",
         "pg": "^8.16.3",
@@ -2998,6 +2999,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express-session": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
@@ -3628,6 +3647,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -8045,6 +8073,14 @@
         "vary": "^1.1.2"
       }
     },
+    "express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "requires": {
+        "ip-address": "10.0.1"
+      }
+    },
     "express-session": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
@@ -8476,6 +8512,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="
     },
     "ipaddr.js": {
       "version": "1.9.1",

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "csrf-sync": "^4.2.1",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.0.1",
     "express-session": "^1.18.2",
     "helmet": "^8.1.0",
     "pg": "^8.16.3",

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -5031,7 +5031,7 @@
         ],
         "parameters": [
           {
-            "name": "id",
+            "name": "eventId",
             "in": "path",
             "description": "Event ID",
             "required": true,
@@ -5128,7 +5128,7 @@
         ],
         "parameters": [
           {
-            "name": "id",
+            "name": "eventId",
             "in": "path",
             "description": "Event ID",
             "required": true,

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -58,6 +58,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -126,6 +136,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -161,6 +181,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NoAuthResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -218,6 +248,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -257,6 +297,16 @@
           },
           "400": {
             "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -329,6 +379,16 @@
           },
           "409": {
             "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -415,6 +475,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -468,6 +538,16 @@
           },
           "409": {
             "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -546,6 +626,16 @@
           },
           "404": {
             "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -649,6 +739,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -734,6 +834,16 @@
           },
           "404": {
             "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -829,6 +939,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -903,6 +1023,16 @@
           },
           "404": {
             "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -1001,6 +1131,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -1072,6 +1212,16 @@
           },
           "404": {
             "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -1151,6 +1301,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -1223,6 +1383,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -1258,6 +1428,16 @@
           },
           "403": {
             "description": "Forbidden - invalid CSRF token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -1307,6 +1487,16 @@
           },
           "403": {
             "description": "Forbidden - invalid CSRF token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -1371,6 +1561,16 @@
           },
           "403": {
             "description": "Forbidden - invalid CSRF token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -1466,6 +1666,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -1542,6 +1752,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -1584,6 +1804,16 @@
           },
           "403": {
             "description": "Forbidden - invalid CSRF token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -1689,6 +1919,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -1760,6 +2000,16 @@
           },
           "404": {
             "description": "Event not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -1881,6 +2131,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -1950,6 +2210,16 @@
           },
           "404": {
             "description": "Event not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -2038,6 +2308,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -2103,6 +2383,16 @@
           },
           "404": {
             "description": "Event not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -2208,6 +2498,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -2287,6 +2587,16 @@
           },
           "404": {
             "description": "Event/user not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -2392,6 +2702,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -2478,6 +2798,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -2534,6 +2864,16 @@
           },
           "404": {
             "description": "Event not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -2615,6 +2955,16 @@
           },
           "404": {
             "description": "Event not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -2714,6 +3064,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -2785,6 +3145,16 @@
           },
           "404": {
             "description": "Category not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -2888,6 +3258,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -2957,6 +3337,16 @@
           },
           "404": {
             "description": "Category not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -3051,6 +3441,16 @@
           },
           "404": {
             "description": "Category not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -3172,6 +3572,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -3275,6 +3685,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -3361,6 +3781,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -3435,6 +3865,16 @@
           },
           "404": {
             "description": "Event not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -3543,6 +3983,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -3614,6 +4064,16 @@
           },
           "404": {
             "description": "Expense not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -3733,6 +4193,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -3829,6 +4299,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -3905,6 +4385,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -3935,6 +4425,16 @@
           },
           "400": {
             "description": "Invalid key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -4004,6 +4504,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -4048,6 +4558,16 @@
           },
           "403": {
             "description": "Forbidden - invalid CSRF token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -4126,6 +4646,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -4197,6 +4727,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -4261,6 +4801,16 @@
           },
           "409": {
             "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -4346,6 +4896,16 @@
           },
           "409": {
             "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -4443,6 +5003,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -4530,6 +5100,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -4594,6 +5174,16 @@
           },
           "404": {
             "description": "Event not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -4670,6 +5260,16 @@
           },
           "403": {
             "description": "Forbidden - invalid CSRF token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
             "content": {
               "application/json": {
                 "schema": {

--- a/server/src/api/authentication.ts
+++ b/server/src/api/authentication.ts
@@ -6,6 +6,7 @@ import * as dbAuth from "../db/dbAuthentication.ts";
 import * as ec from "../types/errorCodes.ts";
 import { generateCsrfToken } from "../middlewares/csrf.ts";
 import { useRateLimit } from "../middlewares/rateLimiter.ts";
+import { singleRequestLimiter } from "../middlewares/singleRequestLimiter.ts";
 import { authenticate, createHash, generateApiKey } from "../utils/auth.ts";
 import { generateKey } from "../utils/generateKey.ts";
 import { User } from "../types/types.ts";
@@ -14,13 +15,6 @@ import { isValidPassword } from "../utils/validators/passwordValidator.ts";
 import { sendPasswordResetEmail } from "../email-services/passwordReset.ts";
 import { ErrorExt } from "../types/errorExt.ts";
 const router = express.Router();
-
-router.get("/ip", useRateLimit("strict"), (req, res) => {
-  res.status(200).json({
-    ip: req.ip,
-    xForwardedFor: req.headers["x-forwarded-for"] ?? null
-  });
-});
 
 /* --- */
 /* GET */
@@ -148,7 +142,7 @@ router.post("/generatekey", useRateLimit("strict"), masterKeyCheck, async (req, 
 /*
 * Request a password reset
 */
-router.post("/requestpasswordreset", useRateLimit("strict"), async (req, res) => {
+router.post("/requestpasswordreset", singleRequestLimiter, async (req, res) => {
   if (!env.MIKANE_EMAIL || !env.MIKANE_EMAIL_API_TOKEN) {
     throw new ErrorExt(ec.PUD073);
   }

--- a/server/src/api/authentication.ts
+++ b/server/src/api/authentication.ts
@@ -5,6 +5,7 @@ import * as dbUsers from "../db/dbUsers.ts";
 import * as dbAuth from "../db/dbAuthentication.ts";
 import * as ec from "../types/errorCodes.ts";
 import { generateCsrfToken } from "../middlewares/csrf.ts";
+import { useRateLimit } from "../middlewares/rateLimiter.ts";
 import { authenticate, createHash, generateApiKey } from "../utils/auth.ts";
 import { generateKey } from "../utils/generateKey.ts";
 import { User } from "../types/types.ts";
@@ -14,6 +15,13 @@ import { sendPasswordResetEmail } from "../email-services/passwordReset.ts";
 import { ErrorExt } from "../types/errorExt.ts";
 const router = express.Router();
 
+router.get("/ip", useRateLimit("strict"), (req, res) => {
+  res.status(200).json({
+    ip: req.ip,
+    xForwardedFor: req.headers["x-forwarded-for"] ?? null
+  });
+});
+
 /* --- */
 /* GET */
 /* --- */
@@ -21,7 +29,7 @@ const router = express.Router();
 /*
 * Check if user is signed in
 */
-router.get("/login", (req, res) => {
+router.get("/login", useRateLimit("strict"), (req, res) => {
   if (!req.session.authenticated) {
     throw new ErrorExt(ec.PUD000);
   }
@@ -38,7 +46,7 @@ router.get("/login", (req, res) => {
 /*
 * Verify that a password reset key is valid
 */
-router.get("/verifykey/passwordreset/:key", async (req, res) => {
+router.get("/verifykey/passwordreset/:key", useRateLimit("strict"), async (req, res) => {
   const key = req.params.key;
   const valid = await dbAuth.verifyPasswordResetKey(key);
   if (!valid) {
@@ -54,7 +62,7 @@ router.get("/verifykey/passwordreset/:key", async (req, res) => {
 /*
 * User sign in
 */
-router.post("/login", async (req, res) => {
+router.post("/login", useRateLimit("strict"), async (req, res) => {
   const { usernameEmail, password } = req.body;
   if (!usernameEmail || !password) {
     throw new ErrorExt(ec.PUD002);
@@ -107,7 +115,7 @@ router.post("/login", async (req, res) => {
 /*
 * User sign out of session
 */
-router.post("/logout", (req, res) => {
+router.post("/logout", useRateLimit("strict"), (req, res) => {
   if (!req.session.authenticated) {
     throw new ErrorExt(ec.PUD001);
   }
@@ -125,7 +133,7 @@ router.post("/logout", (req, res) => {
 /*
 * Generate API key
 */
-router.post("/generatekey", masterKeyCheck, async (req, res) => {
+router.post("/generatekey", useRateLimit("strict"), masterKeyCheck, async (req, res) => {
   const name = req.body.name as string;
   if (!name) {
     throw new ErrorExt(ec.PUD068);
@@ -140,7 +148,7 @@ router.post("/generatekey", masterKeyCheck, async (req, res) => {
 /*
 * Request a password reset
 */
-router.post("/requestpasswordreset", async (req, res) => {
+router.post("/requestpasswordreset", useRateLimit("strict"), async (req, res) => {
   if (!env.MIKANE_EMAIL || !env.MIKANE_EMAIL_API_TOKEN) {
     throw new ErrorExt(ec.PUD073);
   }
@@ -170,7 +178,7 @@ router.post("/requestpasswordreset", async (req, res) => {
 /*
 * Reset a password
 */
-router.post("/resetpassword", async (req, res) => {
+router.post("/resetpassword", useRateLimit("strict"), async (req, res) => {
   const key: string = req.body.key;
   const valid = await dbAuth.verifyPasswordResetKey(key);
   if (!valid) {

--- a/server/src/api/categories.ts
+++ b/server/src/api/categories.ts
@@ -2,6 +2,7 @@ import express from "express";
 import * as db from "../db/dbCategories.ts";
 import { authCheck } from "../middlewares/authCheck.ts";
 import { csrfCheck } from "../middlewares/csrf.ts";
+import { useRateLimit } from "../middlewares/rateLimiter.ts";
 import { isUUID } from "../utils/validators/uuidValidator.ts";
 import { Category } from "../types/types.ts";
 import { CategoryIcon } from "../types/enums.ts";
@@ -16,7 +17,7 @@ const router = express.Router();
 /*
 * Get a list of all categories for a given event
 */
-router.get("/categories", authCheck, csrfCheck, async (req, res) => {
+router.get("/categories", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const eventId = req.query.eventId as string;
   const activeUserId = req.session.userId;
 
@@ -34,7 +35,7 @@ router.get("/categories", authCheck, csrfCheck, async (req, res) => {
 /*
 * Get a specific category
 */
-router.get("/categories/:id", authCheck, csrfCheck, async (req, res) => {
+router.get("/categories/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const id = req.params.id;
   const activeUserId = req.session.userId;
 
@@ -59,7 +60,7 @@ router.get("/categories/:id", authCheck, csrfCheck, async (req, res) => {
 /*
 * Create a new category
 */
-router.post("/categories", authCheck, csrfCheck, async (req, res) => {
+router.post("/categories", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const name: string = req.body.name;
   if (!name || !req.body.eventId || req.body.weighted === undefined) {
     throw new ErrorExt(ec.PUD046);
@@ -88,7 +89,7 @@ router.post("/categories", authCheck, csrfCheck, async (req, res) => {
 /*
 * Add a user to a category
 */
-router.post("/categories/:id/user/:userId", authCheck, csrfCheck, async (req, res) => {
+router.post("/categories/:id/user/:userId", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const catId = req.params.id;
   const userId = req.params.userId;
   const weight = req.body.weight ? Number(req.body.weight) : undefined;
@@ -119,7 +120,7 @@ router.post("/categories/:id/user/:userId", authCheck, csrfCheck, async (req, re
 /*
 * Edit a category
 */
-router.put("/categories/:id", authCheck, csrfCheck, async (req, res) => {
+router.put("/categories/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const catId = req.params.id;
   if (!isUUID(catId)) {
     throw new ErrorExt(ec.PUD045);
@@ -157,7 +158,7 @@ router.put("/categories/:id", authCheck, csrfCheck, async (req, res) => {
 /*
 * Change weight status for a category (weighted or non-weighted)
 */
-router.put("/categories/:id/weighted", authCheck, csrfCheck, async (req, res) => {
+router.put("/categories/:id/weighted", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const catId = req.params.id;
   if (!isUUID(catId)) {
     throw new ErrorExt(ec.PUD045);
@@ -178,7 +179,7 @@ router.put("/categories/:id/weighted", authCheck, csrfCheck, async (req, res) =>
 /*
 * Edit a user's weight for a category
 */
-router.put("/categories/:id/user/:userId", authCheck, csrfCheck, async (req, res) => {
+router.put("/categories/:id/user/:userId", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const catId = req.params.id;
   const userId = req.params.userId;
   const weight = req.body.weight ? Number(req.body.weight) : undefined;
@@ -209,7 +210,7 @@ router.put("/categories/:id/user/:userId", authCheck, csrfCheck, async (req, res
 /*
 * Delete a category
 */
-router.delete("/categories/:id", authCheck, csrfCheck, async (req, res) => {
+router.delete("/categories/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const catId = req.params.id;
   if (!isUUID(catId)) {
     throw new ErrorExt(ec.PUD045);
@@ -227,7 +228,7 @@ router.delete("/categories/:id", authCheck, csrfCheck, async (req, res) => {
 /*
 * Remove a user from a category
 */
-router.delete("/categories/:id/user/:userId", authCheck, csrfCheck, async (req, res) => {
+router.delete("/categories/:id/user/:userId", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const catId = req.params.id;
   const userId = req.params.userId;
   if (!isUUID(catId) || !isUUID(userId)) {

--- a/server/src/api/events.ts
+++ b/server/src/api/events.ts
@@ -2,6 +2,7 @@ import express from "express";
 import * as db from "../db/dbEvents.ts";
 import { authCheck, authKeyCheck } from "../middlewares/authCheck.ts";
 import { csrfCheck } from "../middlewares/csrf.ts";
+import { useRateLimit } from "../middlewares/rateLimiter.ts";
 import { removeUserInfoFromPayments, removeUserInfoFromUserBalances } from "../parsers/parseUserInfo.ts";
 import { isUUID } from "../utils/validators/uuidValidator.ts";
 import { Event, Payment, UserBalance } from "../types/types.ts";
@@ -16,7 +17,7 @@ const router = express.Router();
 /*
 * Get a list of all events
 */
-router.get("/events", authCheck, csrfCheck, async (req, res) => {
+router.get("/events", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const activeUserId = req.session.userId;
   const events: Event[] = await db.getEvents(activeUserId);
   res.status(200).send(events);
@@ -25,7 +26,7 @@ router.get("/events", authCheck, csrfCheck, async (req, res) => {
 /*
 * Get specific event
 */
-router.get("/events/:id", authCheck, csrfCheck, async (req, res) => {
+router.get("/events/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const eventId = req.params.id;
   const activeUserId = req.session.userId;
   if (!isUUID(eventId)) {
@@ -42,7 +43,7 @@ router.get("/events/:id", authCheck, csrfCheck, async (req, res) => {
 /*
 * Get specific event by name
 */
-router.get("/eventbyname", authKeyCheck, async (req, res) => {
+router.get("/eventbyname", useRateLimit(), authKeyCheck, async (req, res) => {
   const eventName = req.body.name;
   const activeUserId = req.session.userId;
   const authIsApiKey = req.authIsApiKey;
@@ -57,7 +58,7 @@ router.get("/eventbyname", authKeyCheck, async (req, res) => {
 /*
 * Get a list of all users' balance information for an event
 */
-router.get("/events/:id/balances", authCheck, csrfCheck, async (req, res) => {
+router.get("/events/:id/balances", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const eventId = req.params.id;
   const activeUserId = req.session.userId;
   if (!isUUID(eventId)) {
@@ -84,7 +85,7 @@ router.get("/events/:id/balances", authCheck, csrfCheck, async (req, res) => {
 /*
 * Get a list of all payments for a given event
 */
-router.get("/events/:id/payments", authKeyCheck, async (req, res) => {
+router.get("/events/:id/payments", useRateLimit(), authKeyCheck, async (req, res) => {
   const eventId = req.params.id;
   const activeUserId = req.session.userId;
   if (!isUUID(eventId)) {
@@ -115,7 +116,7 @@ router.get("/events/:id/payments", authKeyCheck, async (req, res) => {
 /*
 * Create new event
 */
-router.post("/events", authCheck, csrfCheck, async (req, res) => {
+router.post("/events", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const name: string = req.body.name;
   if (!name || (req.body.private === null || req.body.private === undefined)) {
     throw new ErrorExt(ec.PUD014);
@@ -136,7 +137,7 @@ router.post("/events", authCheck, csrfCheck, async (req, res) => {
 /*
 * Add a user to an event
 */
-router.post("/events/:id/user/:userId", authCheck, csrfCheck, async (req, res) => {
+router.post("/events/:id/user/:userId", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const eventId = req.params.id;
   const userId = req.params.userId;
   if (!isUUID(eventId) || !isUUID(userId)) {
@@ -155,7 +156,7 @@ router.post("/events/:id/user/:userId", authCheck, csrfCheck, async (req, res) =
 /*
 * Set a user as admin for an event
 */
-router.post("/events/:id/admin/:userId", authCheck, csrfCheck, async (req, res) => {
+router.post("/events/:id/admin/:userId", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const eventId = req.params.id;
   const userId = req.params.userId;
   if (!isUUID(eventId) || !isUUID(userId)) {
@@ -177,7 +178,7 @@ router.post("/events/:id/admin/:userId", authCheck, csrfCheck, async (req, res) 
 /*
 * Edit event
 */
-router.put("/events/:id", authCheck, csrfCheck, async (req, res) => {
+router.put("/events/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const eventId = req.params.id;
   if (!isUUID(eventId)) {
     throw new ErrorExt(ec.PUD013);
@@ -204,7 +205,7 @@ router.put("/events/:id", authCheck, csrfCheck, async (req, res) => {
 /*
 * Delete event
 */
-router.delete("/events/:id", authCheck, csrfCheck, async (req, res) => {
+router.delete("/events/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const eventId = req.params.id;
   if (!isUUID(eventId)) {
     throw new ErrorExt(ec.PUD013);
@@ -221,7 +222,7 @@ router.delete("/events/:id", authCheck, csrfCheck, async (req, res) => {
 /*
 * Remove a user from an event
 */
-router.delete("/events/:id/user/:userId", authCheck, csrfCheck, async (req, res) => {
+router.delete("/events/:id/user/:userId", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const eventId = req.params.id;
   const userId = req.params.userId;
   if (!isUUID(eventId) || !isUUID(userId)) {
@@ -240,7 +241,7 @@ router.delete("/events/:id/user/:userId", authCheck, csrfCheck, async (req, res)
 /*
 * Remove a user as event admin
 */
-router.delete("/events/:id/admin/:userId", authCheck, csrfCheck, async (req, res) => {
+router.delete("/events/:id/admin/:userId", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const eventId = req.params.id;
   const userId = req.params.userId;
   if (!isUUID(eventId) || !isUUID(userId)) {

--- a/server/src/api/expenses.ts
+++ b/server/src/api/expenses.ts
@@ -2,6 +2,7 @@ import express from "express";
 import * as db from "../db/dbExpenses.ts";
 import { authCheck } from "../middlewares/authCheck.ts";
 import { csrfCheck } from "../middlewares/csrf.ts";
+import { useRateLimit } from "../middlewares/rateLimiter.ts";
 import { createDate } from "../utils/dateCreator.ts";
 import { isUUID } from "../utils/validators/uuidValidator.ts";
 import { Expense } from "../types/types.ts";
@@ -16,7 +17,7 @@ const router = express.Router();
 /*
 * Get a list of all expenses for a given event
 */
-router.get("/expenses", authCheck, csrfCheck, async (req, res) => {
+router.get("/expenses", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const eventId = req.query.eventId as string;
   if (!isUUID(eventId)) {
     throw new ErrorExt(ec.PUD013);
@@ -34,7 +35,7 @@ router.get("/expenses", authCheck, csrfCheck, async (req, res) => {
 /*
 * Get a specific expense
 */
-router.get("/expenses/:id", authCheck, csrfCheck, async (req, res) => {
+router.get("/expenses/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const expenseId = req.params.id;
   if (!isUUID(expenseId)) {
     throw new ErrorExt(ec.PUD056);
@@ -59,7 +60,7 @@ router.get("/expenses/:id", authCheck, csrfCheck, async (req, res) => {
 /*
 * Create a new expense
 */
-router.post("/expenses", authCheck, csrfCheck, async (req, res) => {
+router.post("/expenses", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   if (!req.body.name || [null, undefined].includes(req.body.amount) || !req.body.categoryId || !req.body.payerId) {
     throw new ErrorExt(ec.PUD057);
   }
@@ -103,7 +104,7 @@ router.post("/expenses", authCheck, csrfCheck, async (req, res) => {
 /*
 * Edit (replace) expense
 */
-router.put("/expenses/:id", authCheck, csrfCheck, async (req, res) => {
+router.put("/expenses/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const expenseId = req.params.id;
   if (!isUUID(expenseId)) {
     throw new ErrorExt(ec.PUD056);
@@ -159,7 +160,7 @@ router.put("/expenses/:id", authCheck, csrfCheck, async (req, res) => {
 /*
 * Edit (patch) expense
 */
-router.patch("/expenses/:id", authCheck, csrfCheck, async (req, res) => {
+router.patch("/expenses/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const expenseId = req.params.id;
   if (!isUUID(expenseId)) {
     throw new ErrorExt(ec.PUD056);
@@ -219,7 +220,7 @@ router.patch("/expenses/:id", authCheck, csrfCheck, async (req, res) => {
 /*
 * Delete an expense
 */
-router.delete("/expenses/:id", authCheck, csrfCheck, async (req, res) => {
+router.delete("/expenses/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const expenseId = req.params.id;
   if (!isUUID(expenseId)) {
     throw new ErrorExt(ec.PUD056);

--- a/server/src/api/guestUsers.ts
+++ b/server/src/api/guestUsers.ts
@@ -4,6 +4,7 @@ import * as ec from "../types/errorCodes.ts";
 import { randomUUID } from "crypto";
 import { authCheck } from "../middlewares/authCheck.ts";
 import { csrfCheck } from "../middlewares/csrf.ts";
+import { useRateLimit } from "../middlewares/rateLimiter.ts";
 import { Guest } from "../types/types.ts";
 import { ErrorExt } from "../types/errorExt.ts";
 import { isUUID } from "../utils/validators/uuidValidator.ts";
@@ -16,7 +17,7 @@ const router = express.Router();
 /*
 * Get a list of all guest users
 */
-router.get("/guests", authCheck, csrfCheck, async (_req, res) => {
+router.get("/guests", useRateLimit(), authCheck, csrfCheck, async (_req, res) => {
   const guestUsers: Guest[] = await db.getGuestUsers();
   res.status(200).send(guestUsers);
 });
@@ -28,7 +29,7 @@ router.get("/guests", authCheck, csrfCheck, async (_req, res) => {
 /*
 * Create new guest user
 */
-router.post("/guests", authCheck, csrfCheck, async (req, res) => {
+router.post("/guests", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const firstName: string = req.body.firstName;
   const lastName: string = req.body.lastName;
   const id = randomUUID();
@@ -53,7 +54,7 @@ router.post("/guests", authCheck, csrfCheck, async (req, res) => {
 /*
 * Edit guest user
 */
-router.put("/guests/:id", authCheck, csrfCheck, async (req, res) => {
+router.put("/guests/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const guestId = req.params.id;
   if (!isUUID(guestId)) {
     throw new ErrorExt(ec.PUD016);
@@ -92,7 +93,7 @@ router.put("/guests/:id", authCheck, csrfCheck, async (req, res) => {
 /*
 * Delete guest user
 */
-router.delete("/guests/:id", authCheck, csrfCheck, async (req, res) => {
+router.delete("/guests/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const guestId = req.params.id;
   if (!isUUID(guestId)) {
     throw new ErrorExt(ec.PUD016);

--- a/server/src/api/log.ts
+++ b/server/src/api/log.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { authCheck } from "../middlewares/authCheck.ts";
 import { csrfCheck } from "../middlewares/csrf.ts";
+import { useRateLimit } from "../middlewares/rateLimiter.ts";
 import { logClientToDatabase } from "../db/dbLog.ts";
 import { createDate } from "../utils/dateCreator.ts";
 import { ALLOWED_LOG_LEVELS, type LogLevelType } from "../env.ts";
@@ -11,7 +12,7 @@ const router = express.Router();
 /*
 * Save client log message in database
 */
-router.post("/log", authCheck, csrfCheck, async (req, res) => {
+router.post("/log", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const msg: string = req.body.message;
   const level: LogLevelType | undefined = req.body.level;
   const timestamp = req.body.timestamp ? createDate(req.body.timestamp) : new Date();

--- a/server/src/api/notifications.ts
+++ b/server/src/api/notifications.ts
@@ -4,6 +4,7 @@ import { getEvent, getEventPayments } from "../db/dbEvents.ts";
 import { getUsers } from "../db/dbUsers.ts";
 import { authCheck } from "../middlewares/authCheck.ts";
 import { csrfCheck } from "../middlewares/csrf.ts";
+import { useRateLimit } from "../middlewares/rateLimiter.ts";
 import { isUUID } from "../utils/validators/uuidValidator.ts";
 import { EventStatusType } from "../types/enums.ts";
 import { ErrorExt } from "../types/errorExt.ts";
@@ -16,7 +17,7 @@ const router = express.Router();
 /*
 * Send 'add expenses reminder' email to all participants in an event
 */
-router.post("/notifications/:eventId/reminder", authCheck, csrfCheck, async (req, res) => {
+router.post("/notifications/:eventId/reminder", useRateLimit("strict"), authCheck, csrfCheck, async (req, res) => {
   if (!env.MIKANE_EMAIL || !env.MIKANE_EMAIL_API_TOKEN) {
     throw new ErrorExt(ec.PUD073);
   }
@@ -50,7 +51,7 @@ router.post("/notifications/:eventId/reminder", authCheck, csrfCheck, async (req
 /*
 * Send 'ready-to-settle' email to all participants in an event
 */
-router.post("/notifications/:eventId/settle", authCheck, csrfCheck, async (req, res) => {
+router.post("/notifications/:eventId/settle", useRateLimit("strict"), authCheck, csrfCheck, async (req, res) => {
   if (!env.MIKANE_EMAIL || !env.MIKANE_EMAIL_API_TOKEN) {
     throw new ErrorExt(ec.PUD073);
   }

--- a/server/src/api/notifications.ts
+++ b/server/src/api/notifications.ts
@@ -4,7 +4,7 @@ import { getEvent, getEventPayments } from "../db/dbEvents.ts";
 import { getUsers } from "../db/dbUsers.ts";
 import { authCheck } from "../middlewares/authCheck.ts";
 import { csrfCheck } from "../middlewares/csrf.ts";
-import { useRateLimit } from "../middlewares/rateLimiter.ts";
+import { singleRequestLimiter } from "../middlewares/singleRequestLimiter.ts";
 import { isUUID } from "../utils/validators/uuidValidator.ts";
 import { EventStatusType } from "../types/enums.ts";
 import { ErrorExt } from "../types/errorExt.ts";
@@ -17,7 +17,7 @@ const router = express.Router();
 /*
 * Send 'add expenses reminder' email to all participants in an event
 */
-router.post("/notifications/:eventId/reminder", useRateLimit("strict"), authCheck, csrfCheck, async (req, res) => {
+router.post("/notifications/:eventId/reminder", singleRequestLimiter, authCheck, csrfCheck, async (req, res) => {
   if (!env.MIKANE_EMAIL || !env.MIKANE_EMAIL_API_TOKEN) {
     throw new ErrorExt(ec.PUD073);
   }
@@ -51,7 +51,7 @@ router.post("/notifications/:eventId/reminder", useRateLimit("strict"), authChec
 /*
 * Send 'ready-to-settle' email to all participants in an event
 */
-router.post("/notifications/:eventId/settle", useRateLimit("strict"), authCheck, csrfCheck, async (req, res) => {
+router.post("/notifications/:eventId/settle", singleRequestLimiter, authCheck, csrfCheck, async (req, res) => {
   if (!env.MIKANE_EMAIL || !env.MIKANE_EMAIL_API_TOKEN) {
     throw new ErrorExt(ec.PUD073);
   }

--- a/server/src/api/users.ts
+++ b/server/src/api/users.ts
@@ -5,6 +5,7 @@ import * as dbAuth from "../db/dbAuthentication.ts";
 import * as ec from "../types/errorCodes.ts";
 import { authCheck } from "../middlewares/authCheck.ts";
 import { csrfCheck } from "../middlewares/csrf.ts";
+import { useRateLimit } from "../middlewares/rateLimiter.ts";
 import { authenticate, createHash } from "../utils/auth.ts";
 import { generateKey } from "../utils/generateKey.ts";
 import { isUUID } from "../utils/validators/uuidValidator.ts";
@@ -26,7 +27,7 @@ const router = express.Router();
 /*
 * Get a list of all users in a given event
 */
-router.get("/users", authCheck, csrfCheck, async (req, res) => {
+router.get("/users", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const filter: { eventId?: string, excludeGuests?: boolean, excludeUserId?: string } = {
     eventId: req.query.eventId as string,
     excludeGuests: req.query.excludeGuests === "true"
@@ -57,7 +58,7 @@ router.get("/users", authCheck, csrfCheck, async (req, res) => {
 /*
 * Get a specific user
 */
-router.get("/users/:id", authCheck, csrfCheck, async (req, res) => {
+router.get("/users/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const userId = req.params.id;
   const activeUserId = req.session.userId;
   if (!isUUID(userId)) {
@@ -81,7 +82,7 @@ router.get("/users/:id", authCheck, csrfCheck, async (req, res) => {
 /*
 * Get a specific user by username (also accepts ID)
 */
-router.get("/users/username/:usernameOrUserId", authCheck, csrfCheck, async (req, res) => {
+router.get("/users/username/:usernameOrUserId", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const usernameOrUserId = req.params.usernameOrUserId;
   const activeUserId = req.session.userId;
   if (!activeUserId) {
@@ -109,7 +110,7 @@ router.get("/users/username/:usernameOrUserId", authCheck, csrfCheck, async (req
 /*
 * Get a list of a user's events
 */
-router.get("/users/:id/events", authCheck, csrfCheck, async (req, res) => {
+router.get("/users/:id/events", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const userId = req.params.id;
   if (!isUUID(userId)) {
     throw new ErrorExt(ec.PUD016);
@@ -132,7 +133,7 @@ router.get("/users/:id/events", authCheck, csrfCheck, async (req, res) => {
 /*
 * Get a list of a user's expenses, optionally in an event
 */
-router.get("/users/:id/expenses", authCheck, csrfCheck, async (req, res) => {
+router.get("/users/:id/expenses", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const userId = req.params.id;
   if (!isUUID(userId)) {
     throw new ErrorExt(ec.PUD016);
@@ -160,7 +161,7 @@ router.get("/users/:id/expenses", authCheck, csrfCheck, async (req, res) => {
 /*
 * Verify that a register account key is valid
 */
-router.get("/verifykey/register/:key", async (req, res) => {
+router.get("/verifykey/register/:key", useRateLimit("strict"), async (req, res) => {
   const key = req.params.key;
   const { email, guestUser, firstName, lastName } = await db.verifyRegisterAccountKey(key);
   if (!email) {
@@ -172,7 +173,7 @@ router.get("/verifykey/register/:key", async (req, res) => {
 /*
 * Verify that a delete account key is valid
 */
-router.get("/verifykey/deleteaccount/:key", authCheck, csrfCheck, async (req, res) => {
+router.get("/verifykey/deleteaccount/:key", useRateLimit("strict"), authCheck, csrfCheck, async (req, res) => {
   const key = req.params.key;
   const valid = await db.verifyDeleteAccountKey(key);
   if (!valid) {
@@ -188,7 +189,7 @@ router.get("/verifykey/deleteaccount/:key", authCheck, csrfCheck, async (req, re
 /*
 * Register a new user
 */
-router.post("/users", async (req, res) => {
+router.post("/users", useRateLimit("strict"), async (req, res) => {
   const key: string = req.body.key;
   const keyInfo = await db.verifyRegisterAccountKey(key);
 
@@ -245,7 +246,7 @@ router.post("/users", async (req, res) => {
 /*
 * Change signed in user's password
 */
-router.post("/users/changepassword", authCheck, csrfCheck, async (req, res) => {
+router.post("/users/changepassword", useRateLimit("strict"), authCheck, csrfCheck, async (req, res) => {
   // Get signed in user's hashed password
   const userId = req.session.userId;
   const userPW = await dbAuth.getUserHash(undefined, userId);
@@ -282,7 +283,7 @@ router.post("/users/changepassword", authCheck, csrfCheck, async (req, res) => {
 /*
 * Invite a new user via email
 */
-router.post("/users/invite", authCheck, csrfCheck, async (req, res) => {
+router.post("/users/invite", useRateLimit("strict"), authCheck, csrfCheck, async (req, res) => {
   if (!env.MIKANE_EMAIL || !env.MIKANE_EMAIL_API_TOKEN) {
     throw new ErrorExt(ec.PUD073);
   }
@@ -317,7 +318,7 @@ router.post("/users/invite", authCheck, csrfCheck, async (req, res) => {
 /*
 * Request an account deletion confirmation email
 */
-router.post("/users/requestdeleteaccount", authCheck, csrfCheck, async (req, res) => {
+router.post("/users/requestdeleteaccount", useRateLimit("strict"), authCheck, csrfCheck, async (req, res) => {
   if (!env.MIKANE_EMAIL || !env.MIKANE_EMAIL_API_TOKEN) {
     throw new ErrorExt(ec.PUD073);
   }
@@ -340,7 +341,7 @@ router.post("/users/requestdeleteaccount", authCheck, csrfCheck, async (req, res
 /*
 * Edit user
 */
-router.put("/users/:id", authCheck, csrfCheck, async (req, res) => {
+router.put("/users/:id", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const userId = req.params.id;
   if (!isUUID(userId)) {
     throw new ErrorExt(ec.PUD016);
@@ -393,7 +394,7 @@ router.put("/users/:id", authCheck, csrfCheck, async (req, res) => {
 /*
 * Edit user preferences
 */
-router.put("/users/:id/preferences", authCheck, csrfCheck, async (req, res) => {
+router.put("/users/:id/preferences", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const userId = req.params.id;
   if (!isUUID(userId)) {
     throw new ErrorExt(ec.PUD016);
@@ -434,14 +435,12 @@ router.put("/users/:id/preferences", authCheck, csrfCheck, async (req, res) => {
 /*
 * Delete user
 */
-router.delete("/users/:id", authCheck, csrfCheck, async (req, res) => {
+router.delete("/users/:id", useRateLimit("strict"), authCheck, csrfCheck, async (req, res) => {
   const key: string = req.body.key;
   const userId = req.params.id;
   if (!isUUID(userId)) {
     throw new ErrorExt(ec.PUD016);
   }
-
-  
 
   const valid = await db.verifyDeleteAccountKey(key);
   if (!valid) {

--- a/server/src/api/users.ts
+++ b/server/src/api/users.ts
@@ -6,6 +6,7 @@ import * as ec from "../types/errorCodes.ts";
 import { authCheck } from "../middlewares/authCheck.ts";
 import { csrfCheck } from "../middlewares/csrf.ts";
 import { useRateLimit } from "../middlewares/rateLimiter.ts";
+import { singleRequestLimiter } from "../middlewares/singleRequestLimiter.ts";
 import { authenticate, createHash } from "../utils/auth.ts";
 import { generateKey } from "../utils/generateKey.ts";
 import { isUUID } from "../utils/validators/uuidValidator.ts";
@@ -318,7 +319,7 @@ router.post("/users/invite", useRateLimit("strict"), authCheck, csrfCheck, async
 /*
 * Request an account deletion confirmation email
 */
-router.post("/users/requestdeleteaccount", useRateLimit("strict"), authCheck, csrfCheck, async (req, res) => {
+router.post("/users/requestdeleteaccount", singleRequestLimiter, authCheck, csrfCheck, async (req, res) => {
   if (!env.MIKANE_EMAIL || !env.MIKANE_EMAIL_API_TOKEN) {
     throw new ErrorExt(ec.PUD073);
   }

--- a/server/src/api/validation.ts
+++ b/server/src/api/validation.ts
@@ -3,6 +3,7 @@ import * as ec from "../types/errorCodes.ts";
 import * as db from "../db/dbValidation.ts";
 import { authCheck } from "../middlewares/authCheck.ts";
 import { csrfCheck } from "../middlewares/csrf.ts";
+import { useRateLimit } from "../middlewares/rateLimiter.ts";
 import { isEmail } from "../utils/validators/emailValidator.ts";
 import { isUUID } from "../utils/validators/uuidValidator.ts";
 import { ErrorExt } from "../types/errorExt.ts";
@@ -13,7 +14,7 @@ const router = express.Router();
 /*
 * User: Username validation
 */
-router.post("/validation/user/username", async (req, res) => {
+router.post("/validation/user/username", useRateLimit(), async (req, res) => {
   const username: string = req.body.username;
   const userId: string | undefined = req.body.userId;
   if (!username) {
@@ -39,7 +40,7 @@ router.post("/validation/user/username", async (req, res) => {
 /*
 * User: Email validation
 */
-router.post("/validation/user/email", async (req, res) => {
+router.post("/validation/user/email", useRateLimit(), async (req, res) => {
   const email: string = req.body.email;
   const userId: string | undefined = req.body.userId;
   if (!email) {
@@ -62,7 +63,7 @@ router.post("/validation/user/email", async (req, res) => {
 /*
 * User: Phone number validation
 */
-router.post("/validation/user/phone", async (req, res) => {
+router.post("/validation/user/phone", useRateLimit(), async (req, res) => {
   const phoneNumber: string = req.body.phone;
   const userId: string | undefined = req.body.userId;
   if (!phoneNumber) {
@@ -85,7 +86,7 @@ router.post("/validation/user/phone", async (req, res) => {
 /*
 * Event: Name validation
 */
-router.post("/validation/event/name", authCheck, csrfCheck, async (req, res) => {
+router.post("/validation/event/name", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const name: string = req.body.name;
   const eventId: string | undefined = req.body.eventId;
   if (!name) {
@@ -108,7 +109,7 @@ router.post("/validation/event/name", authCheck, csrfCheck, async (req, res) => 
 /*
 * Category: Name validation
 */
-router.post("/validation/category/name", authCheck, csrfCheck, async (req, res) => {
+router.post("/validation/category/name", useRateLimit(), authCheck, csrfCheck, async (req, res) => {
   const name: string = req.body.name;
   const eventId: string = req.body.eventId;
   const categoryId: string | undefined = req.body.categoryId;

--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -24,6 +24,7 @@ interface EnvVariables {
   RATE_LIMIT_MAX_REQUESTS?: number;
   RATE_LIMIT_STRICT_WINDOW_SEC?: number;
   RATE_LIMIT_STRICT_MAX_REQUESTS?: number;
+  RATE_LIMIT_SINGLE_WINDOW_SEC?: number;
 
   DB_HOST: string;
   DB_PORT: number;
@@ -127,6 +128,13 @@ const createEnvVariables = (env: NodeJS.ProcessEnv): EnvVariables => {
     }
   }
 
+  if (env.RATE_LIMIT_SINGLE_WINDOW_SEC !== undefined) {
+    const rateLimitWindow = Number(env.RATE_LIMIT_SINGLE_WINDOW_SEC);
+    if (isNaN(rateLimitWindow) || rateLimitWindow <= 0) {
+      throw new Error(`Environment variable RATE_LIMIT_SINGLE_WINDOW_SEC (${env.RATE_LIMIT_SINGLE_WINDOW_SEC}) must be a valid positive number`);
+    }
+  }
+
   if (env.MIKANE_EMAIL && !isEmail(env.MIKANE_EMAIL)) {
     throw new Error(`Environment variable MIKANE_EMAIL (${env.MIKANE_EMAIL}) is not a valid email`);
   }
@@ -151,6 +159,7 @@ const createEnvVariables = (env: NodeJS.ProcessEnv): EnvVariables => {
     RATE_LIMIT_MAX_REQUESTS: env.RATE_LIMIT_MAX_REQUESTS ? Number(env.RATE_LIMIT_MAX_REQUESTS) : undefined,
     RATE_LIMIT_STRICT_WINDOW_SEC: env.RATE_LIMIT_STRICT_WINDOW_SEC ? Number(env.RATE_LIMIT_STRICT_WINDOW_SEC) : undefined,
     RATE_LIMIT_STRICT_MAX_REQUESTS: env.RATE_LIMIT_STRICT_MAX_REQUESTS ? Number(env.RATE_LIMIT_STRICT_MAX_REQUESTS) : undefined,
+    RATE_LIMIT_SINGLE_WINDOW_SEC: env.RATE_LIMIT_SINGLE_WINDOW_SEC ? Number(env.RATE_LIMIT_SINGLE_WINDOW_SEC) : undefined,
 
     DB_HOST: env.DB_HOST as string,
     DB_PORT: Number(env.DB_PORT) || 5432,

--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -16,9 +16,14 @@ interface EnvVariables {
   ALLOWED_ORIGIN: string;
   SESSION_SECRET: string;
   LOG_LEVEL: LogLevelType;
+  TRUSTED_PROXIES: number;
+  SKIP_CSRF_CHECK: boolean;
   COOKIE_NAME?: string;
   COOKIE_DOMAIN?: string;
-  SKIP_CSRF_CHECK: boolean;
+  RATE_LIMIT_WINDOW_SEC?: number;
+  RATE_LIMIT_MAX_REQUESTS?: number;
+  RATE_LIMIT_STRICT_WINDOW_SEC?: number;
+  RATE_LIMIT_STRICT_MAX_REQUESTS?: number;
 
   DB_HOST: string;
   DB_PORT: number;
@@ -55,7 +60,7 @@ const isLogLevelType = (logLevel: any): logLevel is LogLevelType => {
   return false;
 };
 
-const validateEnvVariables = (env: NodeJS.ProcessEnv): EnvVariables => {
+const createEnvVariables = (env: NodeJS.ProcessEnv): EnvVariables => {
 
   const missing: string[] = [];
 
@@ -73,6 +78,55 @@ const validateEnvVariables = (env: NodeJS.ProcessEnv): EnvVariables => {
     throw new Error("SESSION_SECRET environement variable needs to be set when running in production");
   }
 
+  if (env.PORT !== undefined) {
+    const port = Number(env.PORT);
+    if (isNaN(port) || port <= 0) {
+      throw new Error(`Environment variable PORT (${env.PORT}) must be a valid non-negative number`);
+    }
+  }
+
+  if (env.DB_PORT !== undefined) {
+    const dbPort = Number(env.DB_PORT);
+    if (isNaN(dbPort) || dbPort <= 0) {
+      throw new Error(`Environment variable DB_PORT (${env.DB_PORT}) must be a valid non-negative number`);
+    }
+  }
+
+  if (env.TRUSTED_PROXIES !== undefined) {
+    const trustedProxies = Number(env.TRUSTED_PROXIES);
+    if (isNaN(trustedProxies) || trustedProxies < 0) {
+      throw new Error(`Environment variable TRUSTED_PROXIES (${env.TRUSTED_PROXIES}) must be a valid non-negative number`);
+    }
+  }
+
+  if (env.RATE_LIMIT_WINDOW_SEC !== undefined) {
+    const rateLimitWindow = Number(env.RATE_LIMIT_WINDOW_SEC);
+    if (isNaN(rateLimitWindow) || rateLimitWindow <= 0) {
+      throw new Error(`Environment variable RATE_LIMIT_WINDOW_SEC (${env.RATE_LIMIT_WINDOW_SEC}) must be a valid positive number`);
+    }
+  }
+
+  if (env.RATE_LIMIT_MAX_REQUESTS !== undefined) {
+    const rateLimitMax = Number(env.RATE_LIMIT_MAX_REQUESTS);
+    if (isNaN(rateLimitMax) || rateLimitMax <= 0) {
+      throw new Error(`Environment variable RATE_LIMIT_MAX_REQUESTS (${env.RATE_LIMIT_MAX_REQUESTS}) must be a valid positive number`);
+    }
+  }
+
+  if (env.RATE_LIMIT_STRICT_WINDOW_SEC !== undefined) {
+    const rateLimitWindow = Number(env.RATE_LIMIT_STRICT_WINDOW_SEC);
+    if (isNaN(rateLimitWindow) || rateLimitWindow <= 0) {
+      throw new Error(`Environment variable RATE_LIMIT_STRICT_WINDOW_SEC (${env.RATE_LIMIT_STRICT_WINDOW_SEC}) must be a valid positive number`);
+    }
+  }
+
+  if (env.RATE_LIMIT_STRICT_MAX_REQUESTS !== undefined) {
+    const rateLimitMax = Number(env.RATE_LIMIT_STRICT_MAX_REQUESTS);
+    if (isNaN(rateLimitMax) || rateLimitMax <= 0) {
+      throw new Error(`Environment variable RATE_LIMIT_STRICT_MAX_REQUESTS (${env.RATE_LIMIT_STRICT_MAX_REQUESTS}) must be a valid positive number`);
+    }
+  }
+
   if (env.MIKANE_EMAIL && !isEmail(env.MIKANE_EMAIL)) {
     throw new Error(`Environment variable MIKANE_EMAIL (${env.MIKANE_EMAIL}) is not a valid email`);
   }
@@ -85,16 +139,21 @@ const validateEnvVariables = (env: NodeJS.ProcessEnv): EnvVariables => {
     NODE_ENV: isEnvType(env.NODE_ENV) ? env.NODE_ENV : "dev",
     IN_PROD: env.NODE_ENV === "production",
     DEPLOYED: env.DEPLOYED === "true",
-    PORT: parseInt(env.PORT ?? "") || 3002,
+    PORT: Number(env.PORT) || 3002,
     ALLOWED_ORIGIN: env.ALLOWED_ORIGIN || "http://localhost:4200",
     SESSION_SECRET: env.SESSION_SECRET || "abcdef",
     LOG_LEVEL: isLogLevelType(env.LOG_LEVEL) ? (env.LOG_LEVEL) : "log",
+    TRUSTED_PROXIES: Number(env.TRUSTED_PROXIES) || 0,
+    SKIP_CSRF_CHECK: env.SKIP_CSRF_CHECK === "true",
     COOKIE_NAME: env.COOKIE_NAME,
     COOKIE_DOMAIN: env.COOKIE_DOMAIN,
-    SKIP_CSRF_CHECK: env.SKIP_CSRF_CHECK === "true",
+    RATE_LIMIT_WINDOW_SEC: env.RATE_LIMIT_WINDOW_SEC ? Number(env.RATE_LIMIT_WINDOW_SEC) : undefined,
+    RATE_LIMIT_MAX_REQUESTS: env.RATE_LIMIT_MAX_REQUESTS ? Number(env.RATE_LIMIT_MAX_REQUESTS) : undefined,
+    RATE_LIMIT_STRICT_WINDOW_SEC: env.RATE_LIMIT_STRICT_WINDOW_SEC ? Number(env.RATE_LIMIT_STRICT_WINDOW_SEC) : undefined,
+    RATE_LIMIT_STRICT_MAX_REQUESTS: env.RATE_LIMIT_STRICT_MAX_REQUESTS ? Number(env.RATE_LIMIT_STRICT_MAX_REQUESTS) : undefined,
 
     DB_HOST: env.DB_HOST as string,
-    DB_PORT: parseInt(env.DB_PORT ?? "") || 5432,
+    DB_PORT: Number(env.DB_PORT) || 5432,
     DB_DATABASE: env.DB_DATABASE || "master",
     DB_USER: env.DB_USER as string,
     DB_PASSWORD: env.DB_PASSWORD as string,
@@ -106,7 +165,7 @@ const validateEnvVariables = (env: NodeJS.ProcessEnv): EnvVariables => {
 
 let envVariables: EnvVariables;
 try {
-  envVariables = validateEnvVariables(process.env);
+  envVariables = createEnvVariables(process.env);
 }
 catch (err) {
   console.error(err);

--- a/server/src/errorHandler.ts
+++ b/server/src/errorHandler.ts
@@ -13,7 +13,7 @@ export const errorHandler = (err: ErrorExt | Error, _req: Request, res: Response
   }
   else if (err instanceof ErrorExt) {
     if (err.log) {
-      logger.error(err.error || err);
+      logger.error(err.error ?? err);
     }
     res.status(err.status).json({
       code: err.code,

--- a/server/src/middlewares/rateLimiter.ts
+++ b/server/src/middlewares/rateLimiter.ts
@@ -4,9 +4,14 @@ import { rateLimit } from "express-rate-limit";
 import { PUD149 } from "../types/errorCodes.ts";
 import env from "../env.ts";
 
+export const RATE_LIMIT_WINDOW_SEC = env.RATE_LIMIT_WINDOW_SEC ? env.RATE_LIMIT_WINDOW_SEC : 300;
+export const RATE_LIMIT_MAX_REQUESTS = env.RATE_LIMIT_MAX_REQUESTS ?? 200;
+export const RATE_LIMIT_STRICT_WINDOW_SEC = env.RATE_LIMIT_STRICT_WINDOW_SEC ? env.RATE_LIMIT_STRICT_WINDOW_SEC : 60;
+export const RATE_LIMIT_STRICT_MAX_REQUESTS = env.RATE_LIMIT_STRICT_MAX_REQUESTS ?? 10;
+
 const rateLimiter = rateLimit({
-  windowMs: env.RATE_LIMIT_WINDOW_SEC ? env.RATE_LIMIT_WINDOW_SEC * 1000 : 300000,
-  limit: env.RATE_LIMIT_MAX_REQUESTS ?? 200,
+  windowMs: RATE_LIMIT_WINDOW_SEC * 1000,
+  limit: RATE_LIMIT_MAX_REQUESTS,
   standardHeaders: "draft-8",
   legacyHeaders: false,
   handler: (_req, res, _next) => {
@@ -15,8 +20,8 @@ const rateLimiter = rateLimit({
 });
 
 const rateLimiterStrict = rateLimit({
-  windowMs: env.RATE_LIMIT_STRICT_WINDOW_SEC ? env.RATE_LIMIT_STRICT_WINDOW_SEC * 1000 : 60000,
-  limit: env.RATE_LIMIT_STRICT_MAX_REQUESTS ?? 10,
+  windowMs: RATE_LIMIT_STRICT_WINDOW_SEC * 1000,
+  limit: RATE_LIMIT_STRICT_MAX_REQUESTS,
   standardHeaders: "draft-8",
   legacyHeaders: false,
   handler: (_req, res, _next) => {

--- a/server/src/middlewares/rateLimiter.ts
+++ b/server/src/middlewares/rateLimiter.ts
@@ -1,0 +1,31 @@
+
+import { NextFunction, Request, RequestHandler, Response } from "express";
+import { rateLimit } from "express-rate-limit";
+import { PUD149 } from "../types/errorCodes.ts";
+import env from "../env.ts";
+
+const rateLimiter = rateLimit({
+  windowMs: env.RATE_LIMIT_WINDOW_SEC ? env.RATE_LIMIT_WINDOW_SEC * 1000 : 300000,
+  limit: env.RATE_LIMIT_MAX_REQUESTS ?? 200,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  handler: (_req, res, _next) => {
+    res.status(PUD149.status).json({ code: PUD149.code, message: PUD149.message });
+  }
+});
+
+const rateLimiterStrict = rateLimit({
+  windowMs: env.RATE_LIMIT_STRICT_WINDOW_SEC ? env.RATE_LIMIT_STRICT_WINDOW_SEC * 1000 : 60000,
+  limit: env.RATE_LIMIT_STRICT_MAX_REQUESTS ?? 10,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  handler: (_req, res, _next) => {
+    res.status(PUD149.status).json({ code: PUD149.code, message: PUD149.message });
+  }
+});
+
+export const useRateLimit = (type: "standard" | "strict" = "standard"): RequestHandler => {
+  return env.NODE_ENV !== "test"
+    ? (type === "strict" ? rateLimiterStrict : rateLimiter)
+    : (_req: Request, _res: Response, next: NextFunction) => next();
+};

--- a/server/src/middlewares/singleRequestLimiter.ts
+++ b/server/src/middlewares/singleRequestLimiter.ts
@@ -1,0 +1,51 @@
+import { NextFunction, Request, Response } from "express";
+import { PUD150 } from "../types/errorCodes.ts";
+import env from "../env.ts";
+
+export const RATE_LIMIT_SINGLE_WINDOW_SEC = env.RATE_LIMIT_SINGLE_WINDOW_SEC ? env.RATE_LIMIT_SINGLE_WINDOW_SEC : 300;
+const windowMs = RATE_LIMIT_SINGLE_WINDOW_SEC * 1000;
+
+const requestStore: Record<string, Record<string, number>> = {};
+
+export const singleRequestLimiter = (req: Request, res: Response, next: NextFunction) => {
+  if (env.NODE_ENV === "test") {
+    return next();
+  }
+
+  cleanupExpired();
+
+  const ip = req.ip ?? "unknown";
+  const endpoint = req.originalUrl;
+  const now = Date.now();
+
+  if (!requestStore[ip]) {
+    requestStore[ip] = {};
+  }
+
+  const lastTime = requestStore[ip][endpoint];
+
+  if (lastTime && (now - lastTime) < windowMs) {
+    const secondsLeft = Math.ceil((windowMs - (now - lastTime)) / 1000);
+
+    res.setHeader("Retry-After", secondsLeft);
+    res.status(PUD150.status).json({ code: PUD150.code, message: PUD150.message });
+    return;
+  }
+
+  requestStore[ip][endpoint] = now;
+  next();
+};
+
+const cleanupExpired = () => {
+  const now = Date.now();
+  for (const ip in requestStore) {
+    for (const endpoint in requestStore[ip]) {
+      if ((now - requestStore[ip][endpoint]) > windowMs) {
+        delete requestStore[ip][endpoint];
+      }
+    }
+    if (Object.keys(requestStore[ip]).length === 0) {
+      delete requestStore[ip];
+    }
+  }
+};

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -52,8 +52,8 @@ app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
   }
 });
 
-// Trust proxy
-app.enable("trust proxy");
+// Trust proxies (number of proxies set through env variable)
+app.set("trust proxy", env.TRUSTED_PROXIES);
 
 // Helmet protection
 app.use(helmet());

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -1404,3 +1404,12 @@ export const PUD148: ErrorCode = {
   message: "Invalid CSRF token",
   status: 403
 };
+
+/**
+ * PUD-149: You have exceeded the allowed number of requests, please try again later (429)
+ */
+export const PUD149: ErrorCode = {
+  code: "PUD-149",
+  message: "You have exceeded the allowed number of requests, please try again later",
+  status: 429
+};

--- a/server/src/types/errorCodes.ts
+++ b/server/src/types/errorCodes.ts
@@ -1,4 +1,5 @@
 import { ALLOWED_LOG_LEVELS } from "../env.ts";
+import { RATE_LIMIT_SINGLE_WINDOW_SEC } from "../middlewares/singleRequestLimiter.ts";
 
 export type ErrorCode = {
   code: string,
@@ -1411,5 +1412,14 @@ export const PUD148: ErrorCode = {
 export const PUD149: ErrorCode = {
   code: "PUD-149",
   message: "You have exceeded the allowed number of requests, please try again later",
+  status: 429
+};
+
+/**
+ * PUD-150: You can only call this endpoint once every X seconds, please wait before trying again (429)
+ */
+export const PUD150: ErrorCode = {
+  code: "PUD-150",
+  message: `You can only call this endpoint once every ${RATE_LIMIT_SINGLE_WINDOW_SEC} seconds, please wait before trying again`,
   status: 429
 };

--- a/server/src/types/express.d.ts
+++ b/server/src/types/express.d.ts
@@ -1,7 +1,9 @@
 import "express";
+import type { RateLimitInfo } from "express-rate-limit";
 
 declare module "express-serve-static-core" {
   export interface Request {
     authIsApiKey?: boolean;
+    rateLimit?: RateLimitInfo;
   }
 }


### PR DESCRIPTION
Changelog:
- Implemented backend rate-limiting, using the `express-rate-limit` package. The rate limiting comes in 2 versions:
  - Standard: Can be controlled with environment variables `RATE_LIMIT_WINDOW_SEC` and `RATE_LIMIT_MAX_REQUESTS`.
  - Strict (for sensitive endpoints): Can be controlled with environment variables `RATE_LIMIT_STRICT_WINDOW_SEC` and `RATE_LIMIT_STRICT_MAX_REQUESTS`.
- Implemented a "single request" limiter for endpoints sending emails:
  - This limiter is special in that it limits per endpoint, instead of a shared pool as the other rate limiters.
  - Can be controlled with environment variable `RATE_LIMIT_SINGLE_WINDOW_SEC`. Limit will always be 1.
- For all limiters, the number of seconds before another request is accepted will be sent in the response header `Retry-After`.
- Backend will now not automatically trust all proxy IPs in the `X-Forwarded-For` header - instead use the environment variable `TRUST_PROXIES` to set the number of proxies to trust.
- Improved validation of envionment variables.

Closes #462 