### PR TITLE
fix: Use query parameter in get event by name endpoint

### DIFF
--- a/server/src/api.json
+++ b/server/src/api.json
@@ -2825,22 +2825,18 @@
           { "csrfToken": [] },
           { "apiKeyAuth": [] }
         ],
-        "requestBody": {
-          "description": "Event name",
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "example": "Example Event"
-                  }
-                }
-              }
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Event name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "Example event"
             }
           }
-        },
+        ],
         "responses": {
           "200": {
             "description": "Success - 'userInfo' property is only present when a logged in user makes the request",

--- a/server/src/api/events.ts
+++ b/server/src/api/events.ts
@@ -44,7 +44,7 @@ router.get("/events/:id", useRateLimit(), authCheck, csrfCheck, async (req, res)
 * Get specific event by name
 */
 router.get("/eventbyname", useRateLimit(), authKeyCheck, async (req, res) => {
-  const eventName = req.body.name;
+  const eventName = req.query.name as string;
   const activeUserId = req.session.userId;
   const authIsApiKey = req.authIsApiKey;
 

--- a/server/tests/events.test.ts
+++ b/server/tests/events.test.ts
@@ -154,10 +154,8 @@ describe("events", async () => {
     test("should get event by name", async () => {
       const res = await request(app)
         .get("/api/eventbyname")
-        .set("Cookie", authToken)
-        .send({
-          name: "Example event"
-        });
+        .query("name=" + "Example event")
+        .set("Cookie", authToken);
 
       expect(res.status).toEqual(200);
       expect(res.body.name).toEqual("Example event");
@@ -166,10 +164,8 @@ describe("events", async () => {
     test("fail get event by non-exisisting name", async () => {
       const res = await request(app)
         .get("/api/eventbyname")
-        .set("Cookie", authToken)
-        .send({
-          name: "No named event"
-        });
+        .query("name=" + "No named event")
+        .set("Cookie", authToken);
 
       expect(res.status).toEqual(404);
       expect(res.body.code).toEqual(ec.PUD006.code);
@@ -178,10 +174,8 @@ describe("events", async () => {
     test("should get event by name also when using API key as auth", async () => {
       const res = await request(app)
         .get("/api/eventbyname")
-        .set("Authorization", "886a2ef41eedfa5bb9978268965a645e")
-        .send({
-          name: "Example event"
-        });
+        .query("name=" + "Example event")
+        .set("Authorization", "886a2ef41eedfa5bb9978268965a645e");
 
       expect(res.status).toEqual(200);
       expect(res.body.name).toEqual("Example event");
@@ -190,10 +184,8 @@ describe("events", async () => {
     test("fail get event by name when using wrong API key as auth", async () => {
       const res = await request(app)
         .get("/api/eventbyname")
-        .set("Authorization", "886a2ef41eedfa5bb9978268965a6450")
-        .send({
-          name: "Example event"
-        });
+        .query("name=" + "Example event")
+        .set("Authorization", "886a2ef41eedfa5bb9978268965a6450");
 
       expect(res.status).toEqual(401);
       expect(res.body.code).toEqual(ec.PUD066.code);


### PR DESCRIPTION
Changelog:
- Change event retrieval by name to use query parameter instead of request body
- Update tests and documentation accordingly