### PR TITLE
fix: Participant spinner now uses correct styling

### DIFF
--- a/app/mikane/src/app/pages/expenditures/expenditures.component.html
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.html
@@ -143,7 +143,7 @@
 							<!-- Row shown when there is no matching data -->
 							<tr class="mat-row" *matNoDataRow>
 								<td class="mat-cell" colspan="8" class="no-expenses">
-									No expenses matching the filter "{{ input?.value }}"
+									No expenses matching the filter
 								</td>
 							</tr>
 						</table>

--- a/app/mikane/src/app/pages/expenditures/expenditures.component.scss
+++ b/app/mikane/src/app/pages/expenditures/expenditures.component.scss
@@ -33,7 +33,6 @@
 
 .clickable {
 	cursor: pointer;
-	transition: filter 0.2s;
 	position: relative;
 
 	&:before {
@@ -44,14 +43,11 @@
 		width: calc(100% + 10px);
 		height: calc(100% + 10px);
 		border-radius: 6px;
-		background-color: rgba(255, 255, 255, 0);
 		transition: background-color 0.3s;
-		z-index: -1;
 	}
 
 	&:hover::before {
 		background-color: rgba(255, 255, 255, 0.2);
-		z-index: 0;
 	}
 }
 

--- a/app/mikane/src/app/pages/participant/participant.component.html
+++ b/app/mikane/src/app/pages/participant/participant.component.html
@@ -83,7 +83,7 @@
 									<!-- Deferred initialization until the panel is open. -->
 									@if (dataSources[i].loading$ | async) {
 										<div class="spinner-container">
-											<mat-spinner class="spinner" />
+											<mat-spinner class="participant-spinner" />
 										</div>
 									}
 									@if (dataSources[i].notEmpty | async) {

--- a/app/mikane/src/app/pages/participant/participant.component.scss
+++ b/app/mikane/src/app/pages/participant/participant.component.scss
@@ -2,7 +2,7 @@
 	margin: 2em 0 2em 2em;
 }
 
-.spinner {
+.participant-spinner {
 	width: 50px !important;
 	height: 20px !important;
 	position: absolute;


### PR DESCRIPTION
Changelog:
- The participant spinner does not conflict with the global spinner class anymore.
- Fixed the filter match input value could end up as an empty string in quotes if there was no text search, but the dropdown filters produced no results.
- Removed some unused style properties.

Closes #479 