### PR TITLE
feat: Add currency support to emails

### DIFF
--- a/server/db_scripts/edit_expense.sql
+++ b/server/db_scripts/edit_expense.sql
@@ -30,7 +30,8 @@ returns table (
   payer_deleted boolean,
   event_id uuid,
   event_name varchar(255),
-  event_private boolean
+  event_private boolean,
+  event_currency varchar(3)
 ) as
 $$
 begin

--- a/server/db_scripts/get_currencies.sql
+++ b/server/db_scripts/get_currencies.sql
@@ -3,13 +3,14 @@ create or replace function get_currencies(
 )
 returns table (
   code varchar(3),
-  "name" varchar(255)
+  "name" varchar(255),
+  format_locale varchar(10)
 ) as
 $$
 begin
   return query
   select
-    c.code, c."name"
+    c.code, c."name", c.format_locale
   from
     currency c
   order by

--- a/server/db_scripts/get_expenses.sql
+++ b/server/db_scripts/get_expenses.sql
@@ -25,13 +25,14 @@ returns table (
   payer_deleted boolean,
   event_id uuid,
   event_name varchar(255),
-  event_private boolean
+  event_private boolean,
+  event_currency varchar(3)
 ) as
 $$
 begin
 
   if (ip_expense_id is not null) then
-  begin
+  begin -- Get specific expense by ID
     if not exists (select 1 from expense ex where ex.id = ip_expense_id) then
       raise exception 'Expense not found' using errcode = 'P0084';
     end if;
@@ -53,7 +54,7 @@ begin
       ex.id, ex.name, ex.description, ex.amount, ex.currency, ex.expense_date, ex.created,
       c.id as category_id, c.name as category_name, c.icon as category_icon,
       u.id as payer_id, u.first_name as payer_first_name, u.last_name as payer_last_name, u.username as payer_username, u.email as payer_email, u.guest as payer_guest, u.deleted as payer_deleted,
-      ev.id as event_id, ev.name as event_name, ev.private as event_private
+      ev.id as event_id, ev.name as event_name, ev.private as event_private, ev.currency as event_currency
     from
       expense ex
       inner join category c on c.id = ex.category_id
@@ -66,7 +67,7 @@ begin
   end;
 
   elsif (ip_event_id is not null and ip_user_id is null) then
-  begin
+  begin -- Get all expenses for an event
     if not exists (select 1 from "event" e where e.id = ip_event_id) then
       raise exception 'Event not found' using errcode = 'P0006';
     end if;
@@ -86,7 +87,7 @@ begin
       ex.id, ex.name, ex.description, ex.amount, ex.currency, ex.expense_date, ex.created,
       c.id as category_id, c.name as category_name, c.icon as category_icon,
       u.id as payer_id, u.first_name as payer_first_name, u.last_name as payer_last_name, u.username as payer_username, u.email as payer_email, u.guest as payer_guest, u.deleted as payer_deleted,
-      ev.id as event_id, ev.name as event_name, ev.private as event_private
+      ev.id as event_id, ev.name as event_name, ev.private as event_private, ev.currency as event_currency
     from
       expense ex
       inner join category c on c.id = ex.category_id
@@ -99,7 +100,7 @@ begin
   end;
 
   elsif (ip_event_id is null and ip_user_id is not null) then
-  begin
+  begin -- Get all expenses for a user
     if not exists (select 1 from "user" u where u.id = ip_user_id) then
       raise exception 'User not found' using errcode = 'P0008';
     end if;
@@ -109,7 +110,7 @@ begin
       ex.id, ex.name, ex.description, ex.amount, ex.currency, ex.expense_date, ex.created,
       c.id as category_id, c.name as category_name, c.icon as category_icon,
       u.id as payer_id, u.first_name as payer_first_name, u.last_name as payer_last_name, u.username as payer_username, u.email as payer_email, u.guest as payer_guest, u.deleted as payer_deleted,
-      ev.id as event_id, ev.name as event_name, ev.private as event_private
+      ev.id as event_id, ev.name as event_name, ev.private as event_private, ev.currency as event_currency
     from
       expense ex
       inner join category c on c.id = ex.category_id
@@ -124,7 +125,7 @@ begin
   end;
 
   elsif (ip_event_id is not null and ip_user_id is not null) then
-  begin
+  begin -- Get all expenses for a specific event and user
     if not exists (select 1 from "event" e where e.id = ip_event_id) then
       raise exception 'Event not found' using errcode = 'P0006';
     end if;
@@ -148,7 +149,7 @@ begin
       ex.id, ex.name, ex.description, ex.amount, ex.currency, ex.expense_date, ex.created,
       c.id as category_id, c.name as category_name, c.icon as category_icon,
       u.id as payer_id, u.first_name as payer_first_name, u.last_name as payer_last_name, u.username as payer_username, u.email as payer_email, u.guest as payer_guest, u.deleted as payer_deleted,
-      ev.id as event_id, ev.name as event_name, ev.private as event_private
+      ev.id as event_id, ev.name as event_name, ev.private as event_private, ev.currency as event_currency
     from
       expense ex
       inner join category c on c.id = ex.category_id

--- a/server/db_scripts/get_users.sql
+++ b/server/db_scripts/get_users.sql
@@ -21,20 +21,22 @@ returns table (
   public_phone boolean,
   event_id uuid,
   is_event_admin boolean,
-  event_joined_time timestamp
+  event_joined_time timestamp,
+  event_currency varchar(3)
 ) as
 $$
 begin
 
   if (ip_event_id is null) then
-  begin
+  begin -- No event ID provided, return all users based on deleted status and excluding specific user if provided
     return query
     select
       u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.created, u.guest, u.guest_created_by, u.super_admin, u.deleted,
       up.public_email, up.public_phone,
       null::uuid as event_id,
       null::boolean as is_event_admin,
-      null::timestamp as event_joined_time
+      null::timestamp as event_joined_time,
+      null::varchar(3) as event_currency
     from
       "user" u
       left join user_preferences up on u.id = up.user_id
@@ -48,7 +50,7 @@ begin
   end;
 
   else
-  begin
+  begin -- Event ID provided, return users associated with the event based on deleted status and excluding specific user if provided
 
     if not exists (select 1 from "event" e where e.id = ip_event_id) then
       raise exception 'Event not found' using errcode = 'P0006';
@@ -68,7 +70,7 @@ begin
     select
       u.id, u.username, u.first_name, u.last_name, u.email, u.phone_number, u.created, u.guest, u.guest_created_by, u.super_admin, u.deleted,
       up.public_email, up.public_phone,
-      e.id as event_id, ue.admin as is_event_admin, ue.joined_time as event_joined_time
+      e.id as event_id, ue.admin as is_event_admin, ue.joined_time as event_joined_time, e.currency as event_currency
     from
       "user" u
       inner join user_event ue on ue.user_id = u.id

--- a/server/db_scripts/new_expense.sql
+++ b/server/db_scripts/new_expense.sql
@@ -29,7 +29,8 @@ returns table (
   payer_deleted boolean,
   event_id uuid,
   event_name varchar(255),
-  event_private boolean
+  event_private boolean,
+  event_currency varchar(3)
 ) as
 $$
 declare

--- a/server/db_scripts/patch_expense.sql
+++ b/server/db_scripts/patch_expense.sql
@@ -33,7 +33,8 @@ returns table (
   payer_deleted boolean,
   event_id uuid,
   event_name varchar(255),
-  event_private boolean
+  event_private boolean,
+  event_currency varchar(3)
 ) as
 $$
 begin

--- a/server/db_scripts/schema/db_schema.sql
+++ b/server/db_scripts/schema/db_schema.sql
@@ -6,6 +6,7 @@ create table event_status_type (
 create table currency (
   code varchar(3) primary key,
   "name" varchar(255) not null,
+  format_locale varchar(10) not null,
   sort_order int not null
 );
 
@@ -142,9 +143,19 @@ create table log_client (
 insert into event_status_type (id, "name")
   values (1, 'Active'), (2, 'Ready to settle'), (3, 'Settled');
 
-insert into currency (code, "name", sort_order)
-  values ('USD', 'US Dollar', 2), ('EUR', 'Euro', 3), ('GBP', 'British Pound', 4), ('CAD', 'Canadian Dollar', 5), ('AUD', 'Australian Dollar', 6),
-    ('NOK', 'Norwegian Krone', 1), ('SEK', 'Swedish Krona', 7), ('DKK', 'Danish Krone', 8), ('JPY', 'Japanese Yen', 9), ('CNY', 'Chinese Yuan', 10),
-    ('KRW', 'South Korean Won', 11), ('CHF', 'Swiss Franc', 12);
+insert into currency (code, "name", format_locale, sort_order)
+  values
+    ('NOK', 'Norwegian Krone', 'nb-NO', 1),
+    ('USD', 'US Dollar', 'en-US', 2),
+    ('EUR', 'Euro', 'de-DE', 3),
+    ('GBP', 'British Pound', 'en-GB', 4),
+    ('CAD', 'Canadian Dollar', 'en-CA', 5),
+    ('AUD', 'Australian Dollar', 'en-AU', 6),
+    ('SEK', 'Swedish Krona', 'sv-SE', 7),
+    ('DKK', 'Danish Krone', 'da-DK', 8),
+    ('JPY', 'Japanese Yen', 'ja-JP', 9),
+    ('CNY', 'Chinese Yuan', 'zh-CN', 10),
+    ('KRW', 'South Korean Won', 'ko-KR', 11),
+    ('CHF', 'Swiss Franc', 'de-CH', 12);
 
 create extension if not exists pgcrypto;

--- a/server/db_scripts/schema/migrations/2.5-2.6_migrations.sql
+++ b/server/db_scripts/schema/migrations/2.5-2.6_migrations.sql
@@ -1,13 +1,24 @@
 create table currency (
   code varchar(3) primary key,
   "name" varchar(255) not null,
+  format_locale varchar(10) not null,
   sort_order int not null
 );
 
-insert into currency (code, "name", sort_order)
-  values ('USD', 'US Dollar', 2), ('EUR', 'Euro', 3), ('GBP', 'British Pound', 4), ('CAD', 'Canadian Dollar', 5), ('AUD', 'Australian Dollar', 6),
-    ('NOK', 'Norwegian Krone', 1), ('SEK', 'Swedish Krona', 7), ('DKK', 'Danish Krone', 8), ('JPY', 'Japanese Yen', 9), ('CNY', 'Chinese Yuan', 10),
-    ('KRW', 'South Korean Won', 11), ('CHF', 'Swiss Franc', 12);
+insert into currency (code, "name", format_locale, sort_order)
+  values
+    ('NOK', 'Norwegian Krone', 'nb-NO', 1),
+    ('USD', 'US Dollar', 'en-US', 2),
+    ('EUR', 'Euro', 'de-DE', 3),
+    ('GBP', 'British Pound', 'en-GB', 4),
+    ('CAD', 'Canadian Dollar', 'en-CA', 5),
+    ('AUD', 'Australian Dollar', 'en-AU', 6),
+    ('SEK', 'Swedish Krona', 'sv-SE', 7),
+    ('DKK', 'Danish Krone', 'da-DK', 8),
+    ('JPY', 'Japanese Yen', 'ja-JP', 9),
+    ('CNY', 'Chinese Yuan', 'zh-CN', 10),
+    ('KRW', 'South Korean Won', 'ko-KR', 11),
+    ('CHF', 'Swiss Franc', 'de-CH', 12);
 
 alter table "event"
   add currency varchar(3) not null default 'NOK' references currency(code) on delete restrict;

--- a/server/src/api.json
+++ b/server/src/api.json
@@ -5463,9 +5463,13 @@
                 "type": "boolean",
                 "example": false
               },
-              "joinedDate": {
+              "joinedTime": {
                 "type": "date-time",
                 "example": "2023-01-20T19:00:00"
+              },
+              "currency": {
+                "type": "string",
+                "example": "EUR"
               }
             }
           }
@@ -5809,6 +5813,14 @@
               "name": {
                 "type": "string",
                 "example": "Example event"
+              },
+              "private": {
+                "type": "boolean",
+                "example": false
+              },
+              "currency": {
+                "type": "string",
+                "example": "EUR"
               }
             }
           },

--- a/server/src/api/notifications.ts
+++ b/server/src/api/notifications.ts
@@ -2,6 +2,7 @@ import express from "express";
 import env from "../env.ts";
 import { getEvent, getEventPayments } from "../db/dbEvents.ts";
 import { getUsers } from "../db/dbUsers.ts";
+import { getCurrencies } from "../db/dbConfig.ts";
 import { authCheck } from "../middlewares/authCheck.ts";
 import { csrfCheck } from "../middlewares/csrf.ts";
 import { singleRequestLimiter } from "../middlewares/singleRequestLimiter.ts";
@@ -12,6 +13,8 @@ import { sendAddExpensesReminderEmails } from "../email-services/notifications/a
 import { sendReadyToSettleEmails } from "../email-services/notifications/readyToSettle.ts";
 import { createDate } from "../utils/dateCreator.ts";
 import * as ec from "../types/errorCodes.ts";
+import logger from "../utils/logger.ts";
+
 const router = express.Router();
 
 /*
@@ -72,7 +75,14 @@ router.post("/notifications/:eventId/settle", singleRequestLimiter, authCheck, c
 
   const payments = await getEventPayments(event.id, activeUserId);
 
-  await sendReadyToSettleEmails(payments, event);
+  const currencies = await getCurrencies();
+  const currency = currencies.find(c => c.code === event.currency);
+  if (!currency) {
+    logger.error(`Currency ${event.currency} not found in database for event ${event.name} (${event.id})`);
+    throw new PudError(ec.PUD151);
+  }
+
+  await sendReadyToSettleEmails(payments, event, currency);
   res.status(200).json({ message: "Emails successfully sent" });
 });
 

--- a/server/src/email-services/notifications/readyToSettle.ts
+++ b/server/src/email-services/notifications/readyToSettle.ts
@@ -1,7 +1,8 @@
 import env from "../../env.ts";
 import logger from "../../utils/logger.ts";
 import { sendEmail } from "../../utils/sendEmail.ts";
-import { Event, Payment, User } from "../../types/types.ts";
+import { formatCurrency } from "../../utils/formatCurrency.ts";
+import { Currency, Event, Payment, User } from "../../types/types.ts";
 
 type SenderPayments = {
   sender: User,
@@ -24,8 +25,9 @@ const url = env.ALLOWED_ORIGIN + "/events/";
  * Send emails to all payment senders and receivers in an event
  * @param payments List of payments within an event
  * @param event Event to send payment emails for
+ * @param currency Currency used in the event, for formatting payment amounts in the email
  */
-export const sendReadyToSettleEmails = async (paymentsInput: Payment[], event: Event) => {
+export const sendReadyToSettleEmails = async (paymentsInput: Payment[], event: Event, currency: Currency) => {
 
   const subjectSenders = `${event.name} is now ready for settlement - Mikane`;
   const subjectReceivers = `${event.name}: You will soon receive payments - Mikane`;
@@ -70,7 +72,7 @@ export const sendReadyToSettleEmails = async (paymentsInput: Payment[], event: E
       throw new Error("User " + senderPayment.sender.name + " missing email");
     }
 
-    const html = senderEmailHTML(senderPayment, event);
+    const html = senderEmailHTML(senderPayment, event, currency);
 
     const sentMessageInfo = await sendEmail(senderPayment.sender.email, subjectSenders, html);
     if (sentMessageInfo.To) {
@@ -86,7 +88,7 @@ export const sendReadyToSettleEmails = async (paymentsInput: Payment[], event: E
       throw new Error("User " + receiverPayment.receiver.name + " missing email");
     }
 
-    const html = receiverEmailHTML(receiverPayment, event);
+    const html = receiverEmailHTML(receiverPayment, event, currency);
 
     const sentMessageInfo = await sendEmail(receiverPayment.receiver.email, subjectReceivers, html);
     if (sentMessageInfo.To) {
@@ -95,7 +97,7 @@ export const sendReadyToSettleEmails = async (paymentsInput: Payment[], event: E
   }
 };
 
-const senderEmailHTML = (senderPayment: SenderPayments, event: Event) => {
+const senderEmailHTML = (senderPayment: SenderPayments, event: Event, currency: Currency) => {
   return `<html>
             <body>
               <h2 style="color:#7d0a37;">${event.name} is now ready for settlement</h2>
@@ -107,7 +109,7 @@ const senderEmailHTML = (senderPayment: SenderPayments, event: Event) => {
                   return `<div style="margin-left: 10px;">
                             - ${payment.receiver.name}
                             <span style="display: inline-block; background-color: #ff85b65e; padding: 1px 4px; margin-bottom: 2px; border-radius: 4px;">
-                              ${payment.amount} kr
+                              ${formatCurrency(payment.amount, event.currency, currency.formatLocale)}
                             </span>
                           </div>`;
                 }).join("")}
@@ -122,7 +124,7 @@ const senderEmailHTML = (senderPayment: SenderPayments, event: Event) => {
           </html>`;
 };
 
-const receiverEmailHTML = (receiverPayment: ReceiverPayments, event: Event) => {
+const receiverEmailHTML = (receiverPayment: ReceiverPayments, event: Event, currency: Currency) => {
   return `<html>
             <body>
               <h2 style="color:#0d4f11;">${event.name}: You will soon receive payments</h2>
@@ -134,7 +136,7 @@ const receiverEmailHTML = (receiverPayment: ReceiverPayments, event: Event) => {
                   return `<div style="margin-left: 10px;">
                             - ${payment.sender.name}
                             <span style="display: inline-block; background-color: #ff85b65e; padding: 1px 4px; margin-bottom: 2px; border-radius: 4px;">
-                              ${payment.amount} kr
+                              ${formatCurrency(payment.amount, event.currency, currency.formatLocale)}
                             </span>
                           </div>`;
                 }).join("")}

--- a/server/src/parsers/parseConfigs.ts
+++ b/server/src/parsers/parseConfigs.ts
@@ -11,7 +11,8 @@ export const parseCurrencies = (currenciesInput: CurrencyDB[]) => {
   for (const currencyObj of currenciesInput) {
     const currency: Currency = {
       code: currencyObj.code,
-      name: currencyObj.name
+      name: currencyObj.name,
+      formatLocale: currencyObj.format_locale
     };
     currencies.push(currency);
   }

--- a/server/src/parsers/parseExpenses.ts
+++ b/server/src/parsers/parseExpenses.ts
@@ -35,7 +35,8 @@ export const parseExpenses = (expInput: ExpenseDB[], usersInEventInput?: UserNam
       eventInfo: {
         id: expObj.event_id,
         name: expObj.event_name,
-        private: expObj.event_private
+        private: expObj.event_private,
+        currency: expObj.event_currency
       },
       payer: expObj.payer_deleted ? {
         id: expObj.payer_id,

--- a/server/src/parsers/parseUsers.ts
+++ b/server/src/parsers/parseUsers.ts
@@ -46,10 +46,11 @@ export const parseUsers = (usersInput: UserDB[], withEventData: boolean, exclude
       superAdmin: userObj.super_admin,
       publicEmail: userObj.public_email ?? false,
       publicPhone: userObj.public_phone ?? false,
-      eventInfo: withEventData && userObj.event_id && userObj.event_joined_time ? {
+      eventInfo: withEventData && userObj.event_id && userObj.event_joined_time && userObj.event_currency ? {
         id: userObj.event_id,
         isAdmin: userObj.is_event_admin ?? false,
-        joinedTime: userObj.event_joined_time
+        joinedTime: userObj.event_joined_time,
+        currency: userObj.event_currency
       } : undefined
     };
     allUsers.push(user);

--- a/server/src/types/types.ts
+++ b/server/src/types/types.ts
@@ -17,7 +17,8 @@ export type User = {
   eventInfo?: {
     id: string,
     isAdmin: boolean,
-    joinedTime: Date
+    joinedTime: Date,
+    currency: string
   }
 };
 
@@ -86,7 +87,8 @@ export type Expense = {
   eventInfo: {
     id: string,
     name: string,
-    private: boolean
+    private: boolean,
+    currency: string
   },
   payer: User
 };
@@ -127,7 +129,8 @@ export type APIKey = {
 
 export type Currency = {
   code: string,
-  name: string
+  name: string,
+  formatLocale: string
 };
 
 export type DBConfig = {

--- a/server/src/types/typesDB.ts
+++ b/server/src/types/typesDB.ts
@@ -14,7 +14,8 @@ export type UserDB = {
   deleted: boolean,
   event_id?: string,
   is_event_admin?: boolean,
-  event_joined_time?: Date
+  event_joined_time?: Date,
+  event_currency?: string
 };
 
 export type EventDB = {
@@ -73,7 +74,8 @@ export type ExpenseDB = {
   payer_deleted: boolean,
   event_id: string,
   event_name: string,
-  event_private: boolean
+  event_private: boolean,
+  event_currency: string
 };
 
 export type APIKeyDB = {
@@ -87,7 +89,8 @@ export type APIKeyDB = {
 
 export type CurrencyDB = {
   code: string,
-  name: string
+  name: string,
+  format_locale: string
 };
 
 export type UserNamesDB = {

--- a/server/src/utils/formatCurrency.ts
+++ b/server/src/utils/formatCurrency.ts
@@ -1,0 +1,15 @@
+/**
+ * Formats a number as a currency string.
+ * @param amount The amount to format.
+ * @param currency The currency code (e.g., "EUR", "USD").
+ * @param formatLocale The locale to use for formatting (e.g., "en-US", "fr-FR").
+ * @param display How to display the currency (default is "code"). Options are "code", "name", "symbol", or "narrowSymbol".
+ * @returns The formatted currency string.
+ */
+export const formatCurrency = (amount: number, currency: string, formatLocale: string, display: "code" | "name" | "symbol" | "narrowSymbol" = "code") => {
+  return new Intl.NumberFormat(formatLocale, {
+    style: "currency",
+    currency: currency,
+    currencyDisplay: display
+  }).format(amount);
+};

--- a/server/tests/currencies.test.ts
+++ b/server/tests/currencies.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import request from "supertest";
 import app from "../src/server.ts";
-import { Category, Event, User, UserBalance, Payment } from "../src/types/types.ts";
+import { PUD001 } from "../src/types/errorCodes.ts";
+import { Category, Currency, Event, User, UserBalance, Payment } from "../src/types/types.ts";
 import { mockCurrencyExchangeFetch, STATIC_EXCHANGE_RATES } from "./mocks/currencyExchangeMock.ts";
 
 describe("currency exchange", async () => {
@@ -130,6 +131,49 @@ describe("currency exchange", async () => {
   afterAll(() => {
     // Restore the original fetch function after tests
     fetchMock.mockRestore();
+  });
+
+  /* --------------- */
+  /* GET /currencies */
+  /* --------------- */
+  describe("GET /currencies", async () => {
+    test("fail getting currencies when not authenticated", async () => {
+      const res = await request(app)
+        .get("/api/currencies");
+
+      expect(res.status).toEqual(401);
+      expect(res.body.code).toEqual(PUD001.code);
+    });
+
+    test("should get supported currencies with format locale", async () => {
+      const res = await request(app)
+        .get("/api/currencies")
+        .set("Cookie", authToken);
+
+      const currencies: Currency[] = res.body;
+      const nok = currencies.find((currency) => currency.code === "NOK");
+      const usd = currencies.find((currency) => currency.code === "USD");
+      const jpy = currencies.find((currency) => currency.code === "JPY");
+
+      expect(res.status).toEqual(200);
+      expect(currencies.length).toBeGreaterThan(0);
+
+      expect(nok).toEqual({
+        code: "NOK",
+        name: "Norwegian Krone",
+        formatLocale: "nb-NO"
+      });
+      expect(usd).toEqual({
+        code: "USD",
+        name: "US Dollar",
+        formatLocale: "en-US"
+      });
+      expect(jpy).toEqual({
+        code: "JPY",
+        name: "Japanese Yen",
+        formatLocale: "ja-JP"
+      });
+    });
   });
 
   /* ------------------------ */

--- a/server/tests/notifications.test.ts
+++ b/server/tests/notifications.test.ts
@@ -3,8 +3,9 @@ import request from "supertest";
 import app from "../src/server.ts";
 import env from "../src/env.ts";
 import * as ec from "../src/types/errorCodes.ts";
-import { Category, Event, Payment, User } from "../src/types/types.ts";
+import { Category, Currency, Event, Payment, User } from "../src/types/types.ts";
 import { EventStatusType } from "../src/types/enums.ts";
+import { formatCurrency } from "../src/utils/formatCurrency.ts";
 import { getSentEmails, resetSentEmails } from "./mocks/postmarkMock.ts";
 
 describe("notifications", async () => {
@@ -14,6 +15,7 @@ describe("notifications", async () => {
   let user2: User;
   let user3: User;
   let event: Event;
+  let eventCurrency: Currency;
   let category: Category;
 
   /*
@@ -72,10 +74,19 @@ describe("notifications", async () => {
         name: "Example event",
         description: "Example description",
         private: false,
-        currency: "NOK"
+        currency: "JPY"
       });
 
     event = resEvent.body;
+
+    // Get event currency (for formatting amounts in emails)
+    const resCurrencies = await request(app)
+      .get("/api/currencies")
+      .set("Cookie", authToken);
+
+    expect(resCurrencies.status).toEqual(200);
+    eventCurrency = resCurrencies.body.find((currency: Currency) => currency.code === event.currency);
+    expect(eventCurrency.formatLocale).toEqual("ja-JP");
 
     // Add users to event
     await request(app)
@@ -300,16 +311,10 @@ describe("notifications", async () => {
       const receiver1NameStart = html.indexOf("<div style=\"margin-left: 10px;\">") + "<div style=\"margin-left: 10px;\">".length;
       const receiver1NameEnd = html.indexOf("<", receiver1NameStart);
       const receiver1Name = html.substring(receiver1NameStart, receiver1NameEnd).replace("- ", "").trim();
-      const receiver1AmountStart = html.indexOf("border-radius: 4px;\">", receiver1NameEnd) + "border-radius: 4px;\">".length;
-      const receiver1AmountEnd = html.indexOf("kr", receiver1AmountStart);
-      const receiver1Amount = Number(html.substring(receiver1AmountStart, receiver1AmountEnd).trim());
 
-      const receiver2NameStart = html.indexOf("<div style=\"margin-left: 10px;\">", receiver1AmountEnd) + "<div style=\"margin-left: 10px;\">".length;
+      const receiver2NameStart = html.indexOf("<div style=\"margin-left: 10px;\">", receiver1NameEnd) + "<div style=\"margin-left: 10px;\">".length;
       const receiver2NameEnd = html.indexOf("<", receiver2NameStart);
       const receiver2Name = html.substring(receiver2NameStart, receiver2NameEnd).replace("- ", "").trim();
-      const receiver2AmountStart = html.indexOf("border-radius: 4px;\">", receiver2NameEnd) + "border-radius: 4px;\">".length;
-      const receiver2AmountEnd = html.indexOf("kr", receiver2AmountStart);
-      const receiver2Amount = Number(html.substring(receiver2AmountStart, receiver2AmountEnd).trim());
 
       expect(res.status).toEqual(200);
       expect(res.body.message).toEqual("Emails successfully sent");
@@ -320,9 +325,10 @@ describe("notifications", async () => {
       expect(sentToEmail2).toEqual(user2.email);
       expect(sentToEmail3).toEqual(user3.email);
       expect(receiver1Name).toEqual(payments[0].receiver.name);
-      expect(receiver1Amount).toEqual(payments[0].amount);
+      expect(html).toContain(formatCurrency(payments[0].amount, event.currency, eventCurrency.formatLocale));
       expect(receiver2Name).toEqual(payments[1].receiver.name);
-      expect(receiver2Amount).toEqual(payments[1].amount);
+      expect(html).toContain(formatCurrency(payments[1].amount, event.currency, eventCurrency.formatLocale));
+      expect(html).not.toContain(" kr");
     });
   });
 });


### PR DESCRIPTION
Changelog:
- Implement support for currencies in emails, displayed as per the event's set currency.
- Add currency to eventInfo in User and Expense objects.
- Change currency datamodel to contain locale, for correct formatting purposes.
- Update documentation and tests.

Closes #501 